### PR TITLE
Expand operations for Mpi

### DIFF
--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -78,6 +78,10 @@ name = "mbedtls_self_tests"
 path = "tests/mbedtls_self_tests.rs"
 
 [[test]]
+name = "bignum"
+path = "tests/bignum.rs"
+
+[[test]]
 name = "rsa"
 path = "tests/rsa.rs"
 

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -165,7 +165,8 @@ impl Mpi {
 
         let s = String::from_utf8(buf).expect("from_utf8 can't fail on radix-N data");
 
-        Ok(s.trim_end_matches(char::from(0)).to_owned())
+        #[allow(deprecated)]
+        Ok(s.trim_right_matches(char::from(0)).to_owned())
     }
 
     /// Serialize the MPI as big endian binary data

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -6,8 +6,15 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use error::IntoResult;
+use error::{Error, IntoResult};
 use mbedtls_sys::*;
+
+use core::cmp::Ordering;
+use core::fmt::{Binary, Debug, Display, Formatter, Octal, Result as FmtResult, UpperHex};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
+use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
+
+pub use mbedtls_sys::mpi_sint;
 
 define!(struct Mpi(mpi) {
 	fn init=mpi_init;
@@ -15,7 +22,73 @@ define!(struct Mpi(mpi) {
 	impl<'a> Into<*>;
 });
 
+fn fmt_mpi(n: &Mpi, radix: i32) -> String {
+    n.to_string_radix(radix)
+        .unwrap_or("(failed to format multi-precision integer)".to_owned())
+}
+
+impl Display for Mpi {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", fmt_mpi(self, 10))
+    }
+}
+
+impl Debug for Mpi {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", fmt_mpi(self, 16))
+    }
+}
+
+impl UpperHex for Mpi {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", fmt_mpi(self, 16))
+    }
+}
+
+impl Octal for Mpi {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", fmt_mpi(self, 8))
+    }
+}
+
+impl Binary for Mpi {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", fmt_mpi(self, 2))
+    }
+}
+
+impl ::core::str::FromStr for Mpi {
+    type Err = ::Error;
+
+    fn from_str(s: &str) -> ::Result<Mpi> {
+        let is_hex = s.starts_with("0x");
+        let radix = if is_hex { 16 } else { 10 };
+        let skip = if is_hex { 2 } else { 0 };
+        let chars = ::std::ffi::CString::new(&s[skip..]).map_err(|_| Error::Utf8Error(None))?;
+
+        let mut ret = Self::init();
+
+        unsafe { mpi_read_string(&mut ret.inner, radix, chars.as_ptr()) }.into_result()?;
+
+        Ok(ret)
+    }
+}
+
 impl Mpi {
+    pub(crate) fn handle(&self) -> &::mbedtls_sys::mpi {
+        &self.inner
+    }
+
+    pub(crate) fn handle_mut(&mut self) -> &mut ::mbedtls_sys::mpi {
+        &mut self.inner
+    }
+
+    pub(crate) fn copy(value: &mpi) -> ::Result<Mpi> {
+        let mut ret = Self::init();
+        unsafe { mpi_copy(&mut ret.inner, value) }.into_result()?;
+        Ok(ret)
+    }
+
     pub fn new(value: mpi_sint) -> ::Result<Mpi> {
         let mut ret = Self::init();
         try!(unsafe { mpi_lset(&mut ret.inner, value).into_result() });
@@ -28,8 +101,504 @@ impl Mpi {
         try!(unsafe { mpi_read_binary(&mut ret.inner, num.as_ptr(), num.len()).into_result() });
         Ok(ret)
     }
+
+    pub fn get_bit(&self, bit: usize) -> bool {
+        // does not fail
+        if unsafe { mpi_get_bit(&self.inner, bit) } == 1 {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn set_bit(&mut self, bit: usize, val: bool) -> ::Result<()> {
+        unsafe {
+            mpi_set_bit(&mut self.inner, bit, val as u8).into_result()?;
+        }
+        Ok(())
+    }
+
+    fn get_limb(&self, n: usize) -> mpi_uint {
+        if n < self.inner.n {
+            unsafe { *self.inner.p.offset(n as isize) }
+        } else {
+            // zero pad
+            0
+        }
+    }
+
+    pub fn as_u32(&self) -> ::Result<u32> {
+        if self.bit_length()? > 32 {
+            // Not exactly correct but close enough
+            return Err(Error::MpiBufferTooSmall);
+        }
+
+        Ok(self.get_limb(0) as u32)
+    }
+
+    pub fn to_string_radix(&self, radix: i32) -> ::Result<String> {
+        let mut olen = 0;
+        let r =
+            unsafe { mpi_write_string(&self.inner, radix, ::core::ptr::null_mut(), 0, &mut olen) };
+
+        if r != ERR_MPI_BUFFER_TOO_SMALL {
+            return Err(Error::from_mbedtls_code(r));
+        }
+
+        let mut buf = vec![0u8; olen];
+        unsafe {
+            mpi_write_string(
+                &self.inner,
+                radix,
+                buf.as_mut_ptr() as *mut i8,
+                buf.len(),
+                &mut olen,
+            )
+        }
+        .into_result()?;
+
+        let s = String::from_utf8(buf).expect("from_utf8 can't fail on radix-N data");
+
+        Ok(s.trim_end_matches(char::from(0)).to_owned())
+    }
+
+    /// Serialize the MPI as big endian binary data
+    pub fn to_binary(&self) -> ::Result<Vec<u8>> {
+        let len = self.byte_length()?;
+        let mut ret = vec![0; len];
+        unsafe { mpi_write_binary(&self.inner, ret.as_mut_ptr(), ret.len()).into_result() }?;
+        Ok(ret)
+    }
+
+    /// Serialize the MPI as big endian binary data, padding to at least min_len bytes
+    pub fn to_padded_binary(&self, min_len: usize) -> ::Result<Vec<u8>> {
+        let len = self.byte_length()?;
+        let larger_len = if len < min_len { min_len } else { len };
+        let mut ret = vec![0; larger_len];
+        let pad_len = ret.len() - len;
+        unsafe {
+            mpi_write_binary(&self.inner, ret.as_mut_ptr().offset(pad_len as isize), len)
+                .into_result()
+        }?;
+        Ok(ret)
+    }
+
+    /// Return size of this MPI in bits
+    pub fn bit_length(&self) -> ::Result<usize> {
+        let l = unsafe { mpi_bitlen(&self.inner) };
+        Ok(l)
+    }
+
+    /// Return size of this MPI in bytes (rounded up)
+    pub fn byte_length(&self) -> ::Result<usize> {
+        let l = unsafe { mpi_size(&self.inner) };
+        Ok(l)
+    }
+
+    pub fn divrem(&self, other: &Mpi) -> ::Result<(Mpi, Mpi)> {
+        let mut q = Self::init();
+        let mut r = Self::init();
+        unsafe { mpi_div_mpi(&mut q.inner, &mut r.inner, &self.inner, &other.inner) }
+            .into_result()?;
+        Ok((q, r))
+    }
+
+    /// Reduce self modulo other
+    pub fn modulo(&self, other: &Mpi) -> ::Result<Mpi> {
+        let mut ret = Self::init();
+        unsafe { mpi_mod_mpi(&mut ret.inner, &self.inner, &other.inner) }.into_result()?;
+        Ok(ret)
+    }
+
+    pub fn divrem_int(&self, other: mpi_sint) -> ::Result<(Mpi, Mpi)> {
+        let mut q = Self::init();
+        let mut r = Self::init();
+        unsafe { mpi_div_int(&mut q.inner, &mut r.inner, &self.inner, other) }.into_result()?;
+        Ok((q, r))
+    }
+
+    pub fn modinv(&self, modulus: &Mpi) -> ::Result<Mpi> {
+        let mut r = Self::init();
+        unsafe { mpi_inv_mod(&mut r.inner, &self.inner, &modulus.inner) }.into_result()?;
+        Ok(r)
+    }
+
+    /// Return (self^exponent) % n
+    pub fn mod_exp(&self, exponent: &Mpi, modulus: &Mpi) -> ::Result<Mpi> {
+        let mut r = Self::init();
+        unsafe {
+            mpi_exp_mod(
+                &mut r.inner,
+                &self.inner,
+                &exponent.inner,
+                &modulus.inner,
+                ::core::ptr::null_mut(),
+            )
+        }
+        .into_result()?;
+
+        Ok(r)
+    }
+}
+
+impl Ord for Mpi {
+    fn cmp(&self, other: &Mpi) -> Ordering {
+        let r = unsafe { mpi_cmp_mpi(&self.inner, &other.inner) };
+        match r {
+            -1 => Ordering::Less,
+            0 => Ordering::Equal,
+            1 => Ordering::Greater,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl PartialOrd for Mpi {
+    fn partial_cmp(&self, other: &Mpi) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Mpi {
+    fn eq(&self, other: &Mpi) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for Mpi {}
+
+macro_rules! impl_arithmetic_op {
+    ($op_trait:ident, $op_assign_trait:ident, $trait_func:ident, $trait_assign_func:ident, $func:expr, $int_func:expr) => {
+        impl<'a, 'b> $op_trait<&'a Mpi> for &'b Mpi {
+            type Output = ::Result<Mpi>;
+
+            fn $trait_func(self, other: &Mpi) -> ::Result<Mpi> {
+                let mut ret = Mpi::init();
+                unsafe { $func(&mut ret.inner, &self.inner, &other.inner) }.into_result()?;
+                Ok(ret)
+            }
+        }
+
+        impl<'a> $op_trait<mpi_sint> for &'a Mpi {
+            type Output = ::Result<Mpi>;
+
+            fn $trait_func(self, other: mpi_sint) -> ::Result<Mpi> {
+                let mut ret = Mpi::init();
+                unsafe { $int_func(&mut ret.inner, &self.inner, other as _) }.into_result()?;
+                Ok(ret)
+            }
+        }
+
+        impl<'a> $op_assign_trait<&'a Mpi> for Mpi {
+            fn $trait_assign_func(&mut self, other: &Mpi) {
+                unsafe { $func(self.handle_mut(), self.handle(), other.handle()) }
+                    .into_result()
+                    .expect("suceeded");
+            }
+        }
+
+        impl $op_assign_trait<Mpi> for Mpi {
+            fn $trait_assign_func(&mut self, other: Mpi) {
+                unsafe { $func(self.handle_mut(), self.handle(), other.handle()) }
+                    .into_result()
+                    .expect("suceeded");
+            }
+        }
+
+        impl $op_assign_trait<mpi_sint> for Mpi {
+            fn $trait_assign_func(&mut self, other: mpi_sint) {
+                unsafe { $int_func(self.handle_mut(), self.handle(), other as _) }
+                    .into_result()
+                    .expect("mpi_add_int worked");
+            }
+        }
+    };
+}
+
+impl_arithmetic_op!(Add, AddAssign, add, add_assign, mpi_add_mpi, mpi_add_int);
+impl_arithmetic_op!(Sub, SubAssign, sub, sub_assign, mpi_sub_mpi, mpi_sub_int);
+impl_arithmetic_op!(Mul, MulAssign, mul, mul_assign, mpi_mul_mpi, mpi_mul_int);
+
+impl<'a, 'b> Div<&'b Mpi> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn div(self, other: &Mpi) -> ::Result<Mpi> {
+        let mut q = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                &mut q.inner,
+                ::core::ptr::null_mut(),
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()?;
+        Ok(q)
+    }
+}
+
+impl<'a> Div<Mpi> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn div(self, other: Mpi) -> ::Result<Mpi> {
+        let mut q = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                &mut q.inner,
+                ::core::ptr::null_mut(),
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()?;
+        Ok(q)
+    }
+}
+
+impl<'a> Div<mpi_sint> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn div(self, other: mpi_sint) -> ::Result<Mpi> {
+        let mut q = Mpi::init();
+        unsafe { mpi_div_int(&mut q.inner, ::core::ptr::null_mut(), &self.inner, other) }
+            .into_result()?;
+        Ok(q)
+    }
+}
+
+/// Note this will panic if other == 0
+impl<'a> DivAssign<&'a Mpi> for Mpi {
+    fn div_assign(&mut self, other: &Mpi) {
+        // mpi_div_mpi produces incorrect output when arguments alias, so avoid doing that
+        let mut q = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                &mut q.inner,
+                ::core::ptr::null_mut(),
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()
+        .expect("mpi_div_mpi success");
+        *self = q;
+    }
+}
+
+/// Note this will panic if other == 0
+impl DivAssign<Mpi> for Mpi {
+    fn div_assign(&mut self, other: Mpi) {
+        // mpi_div_mpi produces incorrect output when arguments alias, so avoid doing that
+        let mut q = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                &mut q.inner,
+                ::core::ptr::null_mut(),
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()
+        .expect("mpi_div_mpi success");
+        *self = q;
+    }
+}
+
+/// Note this will panic if other == 0
+impl DivAssign<mpi_sint> for Mpi {
+    fn div_assign(&mut self, other: mpi_sint) {
+        unsafe {
+            mpi_div_int(
+                self.handle() as *const ::mbedtls_sys::mpi as _,
+                ::core::ptr::null_mut(),
+                &self.inner,
+                other,
+            )
+        }
+        .into_result()
+        .expect("mpi_div_int success");
+    }
+}
+
+impl<'a, 'b> Rem<&'b Mpi> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn rem(self, other: &Mpi) -> ::Result<Mpi> {
+        let mut r = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                ::core::ptr::null_mut(),
+                &mut r.inner,
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()?;
+        Ok(r)
+    }
+}
+
+impl<'a> Rem<Mpi> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn rem(self, other: Mpi) -> ::Result<Mpi> {
+        let mut r = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                ::core::ptr::null_mut(),
+                &mut r.inner,
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()?;
+        Ok(r)
+    }
+}
+
+impl Rem<mpi_sint> for Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn rem(self, other: mpi_sint) -> ::Result<Mpi> {
+        let mut r = Mpi::init();
+        unsafe { mpi_div_int(::core::ptr::null_mut(), &mut r.inner, &self.inner, other) }
+            .into_result()?;
+        Ok(r)
+    }
+}
+
+impl<'a> Rem<mpi_sint> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn rem(self, other: mpi_sint) -> ::Result<Mpi> {
+        let mut r = Mpi::init();
+        unsafe { mpi_div_int(::core::ptr::null_mut(), &mut r.inner, &self.inner, other) }
+            .into_result()?;
+        Ok(r)
+    }
+}
+
+/// Note this will panic if other == 0
+impl<'a> RemAssign<&'a Mpi> for Mpi {
+    fn rem_assign(&mut self, other: &Mpi) {
+        // mpi_div_mpi produces incorrect output when arguments alias, so avoid doing that
+        let mut r = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                ::core::ptr::null_mut(),
+                &mut r.inner,
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()
+        .expect("mpi_div_mpi success");
+        *self = r;
+    }
+}
+
+/// Note this will panic if other == 0
+impl RemAssign<Mpi> for Mpi {
+    fn rem_assign(&mut self, other: Mpi) {
+        // mpi_div_mpi produces incorrect output when arguments alias, so avoid doing that
+        let mut r = Mpi::init();
+        unsafe {
+            mpi_div_mpi(
+                ::core::ptr::null_mut(),
+                &mut r.inner,
+                &self.inner,
+                other.handle(),
+            )
+        }
+        .into_result()
+        .expect("mpi_div_mpi success");
+        *self = r;
+    }
+}
+
+/// Note this will panic if other == 0
+impl RemAssign<mpi_sint> for Mpi {
+    fn rem_assign(&mut self, other: mpi_sint) {
+        unsafe {
+            mpi_div_int(
+                ::core::ptr::null_mut(),
+                self.handle() as *const ::mbedtls_sys::mpi as _,
+                &self.inner,
+                other,
+            )
+        }
+        .into_result()
+        .expect("mpi_div_int success");
+    }
+}
+
+impl<'a> Shl<usize> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn shl(self, shift: usize) -> ::Result<Mpi> {
+        let mut r = Mpi::copy(self.handle())?;
+        unsafe { mpi_shift_l(&mut r.inner, shift) }.into_result()?;
+        Ok(r)
+    }
+}
+
+impl Shl<usize> for Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn shl(self, shift: usize) -> ::Result<Mpi> {
+        let mut r = Mpi::copy(self.handle())?;
+        unsafe { mpi_shift_l(&mut r.inner, shift) }.into_result()?;
+        Ok(r)
+    }
+}
+
+impl ShlAssign<usize> for Mpi {
+    fn shl_assign(&mut self, shift: usize) {
+        unsafe { mpi_shift_l(self.handle() as *const ::mbedtls_sys::mpi as _, shift) }
+            .into_result()
+            .expect("mpi_shift_l success");
+    }
+}
+
+impl<'a> Shr<usize> for &'a Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn shr(self, shift: usize) -> ::Result<Mpi> {
+        let mut r = Mpi::copy(self.handle())?;
+        unsafe { mpi_shift_r(&mut r.inner, shift) }.into_result()?;
+        Ok(r)
+    }
+}
+
+impl Shr<usize> for Mpi {
+    type Output = ::Result<Mpi>;
+
+    fn shr(self, shift: usize) -> ::Result<Mpi> {
+        let mut r = Mpi::copy(self.handle())?;
+        unsafe { mpi_shift_r(&mut r.inner, shift) }.into_result()?;
+        Ok(r)
+    }
+}
+
+impl ShrAssign<usize> for Mpi {
+    fn shr_assign(&mut self, shift: usize) {
+        unsafe { mpi_shift_r(self.handle() as *const ::mbedtls_sys::mpi as _, shift) }
+            .into_result()
+            .expect("mpi_shift_l success");
+    }
 }
 
 // TODO
-// lots...
-//
+// mbedtls_mpi_swap
+// mbedtls_mpi_safe_cond_assign
+// mbedtls_mpi_safe_cond_swap
+// mbedtls_mpi_lset
+// mbedtls_mpi_lsb
+// mbedtls_mpi_write_string
+// mbedtls_mpi_cmp_abs
+// mbedtls_mpi_cmp_int
+// mbedtls_mpi_add_abs
+// mbedtls_mpi_sub_abs
+// mbedtls_mpi_mod_int
+// mbedtls_mpi_gcd
+// mbedtls_mpi_is_prime

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -181,7 +181,8 @@ impl Mpi {
     pub fn to_padded_binary(&self, min_len: usize) -> ::Result<Vec<u8>> {
         let len = self.byte_length()?;
         let larger_len = if len < min_len { min_len } else { len };
-        let mut ret = vec![0; larger_len];
+        let mut ret = Vec::new();
+        ret.resize(larger_len, 0u8);
         let pad_len = ret.len() - len;
         unsafe {
             mpi_write_binary(&self.inner, ret.as_mut_ptr().offset(pad_len as isize), len)

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -9,6 +9,9 @@
 use error::{Error, IntoResult};
 use mbedtls_sys::*;
 
+#[cfg(not(feature = "std"))]
+use alloc_prelude::*;
+
 use core::cmp::Ordering;
 use core::fmt::{Binary, Debug, Display, Formatter, Octal, Result as FmtResult, UpperHex};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -60,6 +60,7 @@ impl Binary for Mpi {
     }
 }
 
+#[cfg(feature = "std")]
 impl ::core::str::FromStr for Mpi {
     type Err = ::Error;
 
@@ -148,7 +149,9 @@ impl Mpi {
             return Err(Error::from_mbedtls_code(r));
         }
 
-        let mut buf = vec![0u8; olen];
+        let mut buf = Vec::new();
+        buf.resize(olen, 0u8);
+
         unsafe {
             mpi_write_string(
                 &self.inner,
@@ -168,7 +171,8 @@ impl Mpi {
     /// Serialize the MPI as big endian binary data
     pub fn to_binary(&self) -> ::Result<Vec<u8>> {
         let len = self.byte_length()?;
-        let mut ret = vec![0; len];
+        let mut ret = Vec::new();
+        ret.resize(len, 0u8);
         unsafe { mpi_write_binary(&self.inner, ret.as_mut_ptr(), ret.len()).into_result() }?;
         Ok(ret)
     }

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -35,7 +35,6 @@ mod wrapper_macros;
 // ==============
 //      API
 // ==============
-#[allow(dead_code)] // to be exported once the API is more complete
 pub mod bignum;
 mod error;
 pub use error::{Error, Result};

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -36,7 +36,7 @@ mod wrapper_macros;
 //      API
 // ==============
 #[allow(dead_code)] // to be exported once the API is more complete
-mod bignum;
+pub mod bignum;
 mod error;
 pub use error::{Error, Result};
 pub mod cipher;

--- a/mbedtls/tests/bignum.rs
+++ b/mbedtls/tests/bignum.rs
@@ -1,0 +1,259 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or
+ * https://www.gnu.org/licenses/gpl-2.0.html> or the Apache License, Version
+ * 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, at your
+ * option. This file may not be copied, modified, or distributed except
+ * according to those terms. */
+
+extern crate mbedtls;
+
+use mbedtls::bignum::Mpi;
+use std::str::FromStr;
+
+#[test]
+fn bignum() {
+    let six = Mpi::new(6).unwrap();
+
+    assert_eq!(six.byte_length().unwrap(), 1);
+    assert_eq!(six.bit_length().unwrap(), 3);
+
+    let six_bytes = six.to_binary().unwrap();
+    assert_eq!(six_bytes.len(), 1);
+    assert_eq!(six_bytes[0], 6);
+
+    let five = Mpi::new(5).unwrap();
+    assert_eq!(six.cmp(&five), ::std::cmp::Ordering::Greater);
+    assert_eq!(five.cmp(&five), ::std::cmp::Ordering::Equal);
+    assert_eq!(five.cmp(&six), ::std::cmp::Ordering::Less);
+
+    let bigger = Mpi::new(0x2a2f5dce).unwrap();
+
+    assert_eq!(bigger.byte_length().unwrap(), 4);
+    assert_eq!(bigger.bit_length().unwrap(), 30);
+
+    let b_bytes = bigger.to_binary().unwrap();
+    assert_eq!(b_bytes.len(), 4);
+    assert_eq!(b_bytes[0], 0x2a);
+    assert_eq!(b_bytes[1], 0x2f);
+    assert_eq!(b_bytes[2], 0x5d);
+    assert_eq!(b_bytes[3], 0xce);
+
+    assert!(bigger.eq(&Mpi::from_binary(&b_bytes).unwrap()));
+
+    let p256_16 =
+        Mpi::from_str("0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff")
+            .unwrap();
+    let p256_10 = Mpi::from_str(
+        "115792089210356248762697446949407573530086143415290314195533631308867097853951",
+    )
+    .unwrap();
+
+    assert!(p256_16.eq(&p256_10));
+
+    assert_eq!(
+        format!("{}", p256_10),
+        "115792089210356248762697446949407573530086143415290314195533631308867097853951"
+    );
+    assert_eq!(
+        format!("{:X}", p256_10),
+        "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF"
+    );
+    assert_eq!(
+        format!("{:o}", p256_10),
+        "17777777777400000000010000000000000000000000000000000077777777777777777777777777777777"
+    );
+    assert_eq!(format!("{:b}", p256_10), "1111111111111111111111111111111100000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
+}
+
+#[test]
+fn bignum_shifts() {
+    let x = Mpi::new(3).unwrap();
+
+    let y = (&x << 30).unwrap();
+
+    assert_eq!(format!("{}", y), "3221225472");
+
+    let y = (&y >> 30).unwrap();
+
+    assert_eq!(format!("{}", y), "3");
+
+    let y = (&y >> 2).unwrap();
+
+    assert_eq!(format!("{}", y), "0");
+
+    let mut z = Mpi::new(1).unwrap();
+
+    z <<= 5;
+    assert_eq!(format!("{}", z), "32");
+    z <<= 15;
+    assert_eq!(format!("{}", z), "1048576");
+
+    z >>= 10;
+    assert_eq!(format!("{}", z), "1024");
+}
+
+#[test]
+fn bignum_op_assign() {
+    let mut x = Mpi::new(4).unwrap();
+
+    x += 9;
+
+    assert_eq!(format!("{}", x), "13");
+
+    x += Mpi::new(13).unwrap();
+
+    assert_eq!(format!("{}", x), "26");
+
+    let y = Mpi::new(10).unwrap();
+    x += &y;
+
+    assert_eq!(format!("{}", x), "36");
+
+    x -= 3;
+    assert_eq!(format!("{}", x), "33");
+
+    x -= Mpi::new(5).unwrap();
+    assert_eq!(format!("{}", x), "28");
+
+    x -= &y;
+    assert_eq!(format!("{}", x), "18");
+
+    x *= &y;
+    assert_eq!(format!("{}", x), "180");
+
+    x *= 2;
+    assert_eq!(format!("{}", x), "360");
+
+    x *= Mpi::new(-2).unwrap();
+    assert_eq!(format!("{}", x), "-720");
+
+    x /= Mpi::new(-3).unwrap();
+    assert_eq!(format!("{}", x), "240");
+
+    x /= 2;
+    assert_eq!(format!("{}", x), "120");
+
+    x /= &y;
+    assert_eq!(format!("{}", x), "12");
+
+    x %= 100;
+    assert_eq!(format!("{}", x), "12");
+
+    x %= Mpi::new(5).unwrap();
+    assert_eq!(format!("{}", x), "2");
+
+    assert_eq!(format!("{}", y), "10"); // verify y not moved
+}
+
+#[test]
+fn bignum_cmp() {
+    let big = Mpi::new(2147483647).unwrap();
+    let small = Mpi::new(2).unwrap();
+
+    assert!(big > small);
+    assert!(small < big);
+    assert!(big >= small);
+    assert!(small <= big);
+    assert!(small >= small);
+    assert!(big <= big);
+    assert!(small == small);
+    assert!(small != big);
+}
+
+#[test]
+fn bigint_ops() {
+    let x = Mpi::new(100).unwrap();
+    let y = Mpi::new(20900).unwrap();
+
+    assert_eq!(x.as_u32().unwrap(), 100);
+
+    let z = (&x + &y).unwrap();
+    assert_eq!(z.as_u32().unwrap(), 21000);
+
+    let z = (&z * &y).unwrap();
+    assert_eq!(z, Mpi::from_str("438900000").unwrap());
+
+    let z = (&z - &x).unwrap();
+    assert_eq!(z, Mpi::from_str("0x1A2914BC").unwrap());
+
+    let r = (&z % 127).unwrap();
+    assert_eq!(r.as_u32().unwrap(), 92);
+
+    let r = (&z % &Mpi::from_str("127").unwrap()).unwrap();
+    assert_eq!(r.as_u32().unwrap(), 92);
+
+    let q = (&z / 53).unwrap();
+    assert_eq!(q.as_u32().unwrap(), 8281130);
+
+    let q = (&z / &Mpi::from_str("53").unwrap()).unwrap();
+    assert_eq!(q.as_u32().unwrap(), 8281130);
+
+    let nan = &z / 0;
+    assert!(nan.is_err());
+}
+
+const BASE58_ALPHABET: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+fn base58_encode(bits: &[u8]) -> mbedtls::Result<String> {
+    let zero = Mpi::new(0)?;
+    let mut n = Mpi::from_binary(bits)?;
+    let radix: i64 = 58;
+
+    let mut s = Vec::new();
+
+    while n > zero {
+        let (q, r) = n.divrem_int(radix)?;
+        n = q;
+        s.push(BASE58_ALPHABET[r.as_u32()? as usize]);
+    }
+
+    s.reverse();
+    Ok(String::from_utf8(s).unwrap())
+}
+
+fn base58_decode(b58: &str) -> mbedtls::Result<Vec<u8>> {
+    let radix: i64 = 58;
+
+    let mut n = Mpi::new(0)?;
+
+    fn base58_val(b: u8) -> mbedtls::Result<usize> {
+        for (i, c) in BASE58_ALPHABET.iter().enumerate() {
+            if *c == b {
+                return Ok(i);
+            }
+        }
+        Err(mbedtls::Error::Base64InvalidCharacter)
+    }
+
+    for c in b58.bytes() {
+        let v = base58_val(c)? as i64;
+        n = (&n * radix)?;
+        n = (&n + v)?;
+    }
+
+    n.to_binary()
+}
+
+#[test]
+fn test_base58_encode() {
+    fn test_base58_rt(input: &[u8], expected: &str) {
+        assert_eq!(base58_encode(input).unwrap(), expected);
+        assert_eq!(base58_decode(expected).unwrap(), input);
+    }
+
+    test_base58_rt(b"", "");
+    test_base58_rt(&[32], "Z");
+    test_base58_rt(&[45], "n");
+    test_base58_rt(&[48], "q");
+    test_base58_rt(&[49], "r");
+    test_base58_rt(&[57], "z");
+    test_base58_rt(&[45, 49], "4SU");
+    test_base58_rt(&[49, 49], "4k8");
+    test_base58_rt(b"abc", "ZiCa");
+    test_base58_rt(b"1234598760", "3mJr7AoUXx2Wqd");
+    test_base58_rt(
+        b"abcdefghijklmnopqrstuvwxyz",
+        "3yxU3u1igY8WkgtjK92fbJQCd4BZiiT1v25f",
+    );
+}

--- a/mbedtls/tests/bignum.rs
+++ b/mbedtls/tests/bignum.rs
@@ -9,7 +9,36 @@
 extern crate mbedtls;
 
 use mbedtls::bignum::Mpi;
-use std::str::FromStr;
+
+#[cfg(feature = "std")]
+#[test]
+fn bignum_from_str() {
+    use std::str::FromStr;
+
+    let p256_16 =
+        Mpi::from_str("0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff")
+            .unwrap();
+    let p256_10 = Mpi::from_str(
+        "115792089210356248762697446949407573530086143415290314195533631308867097853951",
+    )
+    .unwrap();
+
+    assert!(p256_16.eq(&p256_10));
+
+    assert_eq!(
+        format!("{}", p256_10),
+        "115792089210356248762697446949407573530086143415290314195533631308867097853951"
+    );
+    assert_eq!(
+        format!("{:X}", p256_10),
+        "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF"
+    );
+    assert_eq!(
+        format!("{:o}", p256_10),
+        "17777777777400000000010000000000000000000000000000000077777777777777777777777777777777"
+    );
+    assert_eq!(format!("{:b}", p256_10), "1111111111111111111111111111111100000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
+}
 
 #[test]
 fn bignum() {
@@ -41,29 +70,6 @@ fn bignum() {
 
     assert!(bigger.eq(&Mpi::from_binary(&b_bytes).unwrap()));
 
-    let p256_16 =
-        Mpi::from_str("0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff")
-            .unwrap();
-    let p256_10 = Mpi::from_str(
-        "115792089210356248762697446949407573530086143415290314195533631308867097853951",
-    )
-    .unwrap();
-
-    assert!(p256_16.eq(&p256_10));
-
-    assert_eq!(
-        format!("{}", p256_10),
-        "115792089210356248762697446949407573530086143415290314195533631308867097853951"
-    );
-    assert_eq!(
-        format!("{:X}", p256_10),
-        "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF"
-    );
-    assert_eq!(
-        format!("{:o}", p256_10),
-        "17777777777400000000010000000000000000000000000000000077777777777777777777777777777777"
-    );
-    assert_eq!(format!("{:b}", p256_10), "1111111111111111111111111111111100000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111");
 }
 
 #[test]
@@ -172,21 +178,21 @@ fn bigint_ops() {
     assert_eq!(z.as_u32().unwrap(), 21000);
 
     let z = (&z * &y).unwrap();
-    assert_eq!(z, Mpi::from_str("438900000").unwrap());
+    assert_eq!(z, Mpi::new(438900000).unwrap());
 
     let z = (&z - &x).unwrap();
-    assert_eq!(z, Mpi::from_str("0x1A2914BC").unwrap());
+    assert_eq!(z, Mpi::new(0x1A2914BC).unwrap());
 
     let r = (&z % 127).unwrap();
     assert_eq!(r.as_u32().unwrap(), 92);
 
-    let r = (&z % &Mpi::from_str("127").unwrap()).unwrap();
+    let r = (&z % &Mpi::new(127).unwrap()).unwrap();
     assert_eq!(r.as_u32().unwrap(), 92);
 
     let q = (&z / 53).unwrap();
     assert_eq!(q.as_u32().unwrap(), 8281130);
 
-    let q = (&z / &Mpi::from_str("53").unwrap()).unwrap();
+    let q = (&z / &Mpi::new(53).unwrap()).unwrap();
     assert_eq!(q.as_u32().unwrap(), 8281130);
 
     let nan = &z / 0;


### PR DESCRIPTION
Taken from internal version, `rustfmt`ed, and some adjustments for different feature flags.