### PR TITLE
Change define! macro again

### DIFF
--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -22,12 +22,8 @@ pub use mbedtls_sys::mpi_sint;
 define!(
     #[c_ty(mpi)]
     struct Mpi;
-    fn init() {
-        mpi_init
-    }
-    fn drop() {
-        mpi_free
-    }
+    const init: fn() -> Self = mpi_init;
+    const drop: fn(&mut Self) = mpi_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/cipher/raw/mod.rs
+++ b/mbedtls/src/cipher/raw/mod.rs
@@ -157,12 +157,8 @@ define!(
     #[c_ty(cipher_context_t)]
     #[repr(C)]
     struct Cipher;
-    fn init() {
-        cipher_init
-    }
-    fn drop() {
-        cipher_free
-    }
+    const init: fn() -> Self = cipher_init;
+    const drop: fn(&mut Self) = cipher_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -18,12 +18,8 @@ use pk::EcGroupId;
 define!(
     #[c_ty(ecp_group)]
     struct EcGroup;
-    fn init() {
-        ecp_group_init
-    }
-    fn drop() {
-        ecp_group_free
-    }
+    const init: fn() -> Self = ecp_group_init;
+    const drop: fn(&mut Self) = ecp_group_free;
     impl<'a> Into<ptr> {}
 );
 
@@ -74,12 +70,8 @@ impl EcGroup {
 define!(
     #[c_ty(ecp_point)]
     struct EcPoint;
-    fn init() {
-        ecp_point_init
-    }
-    fn drop() {
-        ecp_point_free
-    }
+    const init: fn() -> Self = ecp_point_init;
+    const drop: fn(&mut Self) = ecp_point_free;
     impl<'a> Into<ptr> {}
 );
 
@@ -240,10 +232,10 @@ impl EcPoint {
 #[cfg(test)]
 mod tests {
 
-    use pk::EcGroupId;
+    use bignum::Mpi;
     use ecp::EcGroup;
     use ecp::EcPoint;
-    use bignum::Mpi;
+    use pk::EcGroupId;
 
     #[test]
     fn test_ec_group() {

--- a/mbedtls/src/hash/mod.rs
+++ b/mbedtls/src/hash/mod.rs
@@ -64,12 +64,8 @@ impl Into<*const md_info_t> for MdInfo {
 define!(
     #[c_ty(md_context_t)]
     struct Md;
-    fn init() {
-        md_init
-    }
-    fn drop() {
-        md_free
-    }
+    const init: fn() -> Self = md_init;
+    const drop: fn(&mut Self) = md_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/pk/dhparam.rs
+++ b/mbedtls/src/pk/dhparam.rs
@@ -13,12 +13,8 @@ define!(
     #[c_ty(dhm_context)]
     #[repr(C)]
     struct Dhm;
-    fn init() {
-        dhm_init
-    }
-    fn drop() {
-        dhm_free
-    }
+    const init: fn() -> Self = dhm_init;
+    const drop: fn(&mut Self) = dhm_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/pk/ec.rs
+++ b/mbedtls/src/pk/ec.rs
@@ -60,12 +60,8 @@ define!(
     #[c_ty(ecp_keypair)]
     #[repr(C)]
     struct EcpKeypair;
-    fn init() {
-        ecp_keypair_init
-    }
-    fn drop() {
-        ecp_keypair_free
-    }
+    const init: fn() -> Self = ecp_keypair_init;
+    const drop: fn(&mut Self) = ecp_keypair_free;
     impl<'a> Into<ptr> {}
     impl<'a> UnsafeFrom<ptr> {}
 );
@@ -74,12 +70,8 @@ define!(
     #[c_ty(ecdh_context)]
     #[repr(C)]
     struct Ecdh;
-    fn init() {
-        ecdh_init
-    }
-    fn drop() {
-        ecdh_free
-    }
+    const init: fn() -> Self = ecdh_init;
+    const drop: fn(&mut Self) = ecdh_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -72,12 +72,8 @@ define!(
     #[c_ty(pk_context)]
     #[repr(C)]
     struct Pk;
-    fn init() {
-        pk_init
-    }
-    fn drop() {
-        pk_free
-    }
+    const init: fn() -> Self = pk_init;
+    const drop: fn(&mut Self) = pk_free;
     impl<'a> Into<ptr> {}
     impl<'a> UnsafeFrom<ptr> {}
 );

--- a/mbedtls/src/rng/hmac_drbg.rs
+++ b/mbedtls/src/rng/hmac_drbg.rs
@@ -20,12 +20,8 @@ use error::IntoResult;
 define!(
     #[c_ty(hmac_drbg_context)]
     struct HmacDrbg<'entropy>;
-    fn init() {
-        hmac_drbg_init
-    }
-    fn drop() {
-        hmac_drbg_free
-    }
+    const init: fn() -> Self = hmac_drbg_init;
+    const drop: fn(&mut Self) = hmac_drbg_free;
 );
 
 #[cfg(feature = "threading")]

--- a/mbedtls/src/rng/os_entropy.rs
+++ b/mbedtls/src/rng/os_entropy.rs
@@ -17,12 +17,8 @@ callback!(EntropySourceCallback(data: *mut c_uchar, size: size_t, out: *mut size
 define!(
     #[c_ty(entropy_context)]
     struct OsEntropy<'source>;
-    pub fn new() {
-        entropy_init
-    }
-    fn drop() {
-        entropy_free
-    }
+    pub const new: fn() -> Self = entropy_init;
+    const drop: fn(&mut Self) = entropy_free;
 );
 
 #[cfg(feature = "threading")]

--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -70,12 +70,8 @@ callback!(DbgCallback:Sync(level: c_int, file: *const c_char, line: c_int, messa
 define!(
     #[c_ty(ssl_config)]
     struct Config<'c>;
-    fn init() {
-        ssl_config_init
-    }
-    fn drop() {
-        ssl_config_free
-    }
+    const init: fn() -> Self = ssl_config_init;
+    const drop: fn(&mut Self) = ssl_config_free;
     impl<'q> Into<ptr> {}
     impl<'q> UnsafeFrom<ptr> {}
 );

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -76,12 +76,8 @@ impl<IO: Read + Write> IoCallback for IO {
 define!(
     #[c_ty(ssl_context)]
     struct Context<'config>;
-    fn init() {
-        ssl_init
-    }
-    fn drop() {
-        ssl_free
-    }
+    const init: fn() -> Self = ssl_init;
+    const drop: fn(&mut Self) = ssl_free;
     impl<'a> Into<ptr> {}
     impl<'a> UnsafeFrom<ptr> {}
 );

--- a/mbedtls/src/ssl/ticket.rs
+++ b/mbedtls/src/ssl/ticket.rs
@@ -34,12 +34,8 @@ pub trait TicketCallback {
 define!(
     #[c_ty(ssl_ticket_context)]
     struct TicketContext<'rng>;
-    fn init() {
-        ssl_ticket_init
-    }
-    fn drop() {
-        ssl_ticket_free
-    }
+    const init: fn() -> Self = ssl_ticket_init;
+    const drop: fn(&mut Self) = ssl_ticket_free;
 );
 
 impl<'rng> TicketContext<'rng> {

--- a/mbedtls/src/wrapper_macros.rs
+++ b/mbedtls/src/wrapper_macros.rs
@@ -97,11 +97,11 @@ macro_rules! define_struct {
         );
     };
 
-    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> fn init() { $ctor:ident } $($defs:tt)* } => {
+    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> const init: fn() -> Self = $ctor:ident; $($defs:tt)* } => {
         define_struct!(init $name () init $ctor $(lifetime $l)* );
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };
-    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> pub fn new() { $ctor:ident } $($defs:tt)* } => {
+    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> pub const new: fn() -> Self = $ctor:ident; $($defs:tt)* } => {
         define_struct!(init $name (pub) new $ctor $(lifetime $l)* );
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };
@@ -124,7 +124,7 @@ macro_rules! define_struct {
         );
     };
 
-    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> fn drop() { $dtor:ident } $($defs:tt)* } => {
+    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> const drop: fn(&mut Self) = $dtor:ident; $($defs:tt)* } => {
         define_struct!(drop $name dtor $dtor $(lifetime $l)* );
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -23,12 +23,8 @@ use private::UnsafeFrom;
 define!(
     #[c_ty(x509_crt)]
     struct Certificate;
-    fn init() {
-        x509_crt_init
-    }
-    fn drop() {
-        x509_crt_free
-    }
+    const init: fn() -> Self = x509_crt_init;
+    const drop: fn(&mut Self) = x509_crt_free;
 );
 
 impl Certificate {
@@ -406,12 +402,8 @@ impl<'c, 'r> From<&'c mut List<'r>> for &'c mut LinkedCertificate {
 define!(
     #[c_ty(x509write_cert)]
     struct Builder<'a>;
-    pub fn new() {
-        x509write_crt_init
-    }
-    fn drop() {
-        x509write_crt_free
-    }
+    pub const new: fn() -> Self = x509write_crt_init;
+    const drop: fn(&mut Self) = x509write_crt_free;
 );
 
 impl<'a> Builder<'a> {

--- a/mbedtls/src/x509/crl.rs
+++ b/mbedtls/src/x509/crl.rs
@@ -16,12 +16,8 @@ define!(
     #[c_ty(x509_crl)]
     /// Certificate Revocation List
     struct Crl;
-    pub fn new() {
-        x509_crl_init
-    }
-    fn drop() {
-        x509_crl_free
-    }
+    pub const new: fn() -> Self = x509_crl_init;
+    const drop: fn(&mut Self) = x509_crl_free;
     impl<'a> Into<ptr> {}
 );
 

--- a/mbedtls/src/x509/csr.rs
+++ b/mbedtls/src/x509/csr.rs
@@ -19,12 +19,8 @@ define!(
     #[c_ty(x509_csr)]
     /// Certificate Signing Request
     struct Csr;
-    fn init() {
-        x509_csr_init
-    }
-    fn drop() {
-        x509_csr_free
-    }
+    const init: fn() -> Self = x509_csr_init;
+    const drop: fn(&mut Self) = x509_csr_free;
 );
 
 impl Csr {
@@ -76,12 +72,8 @@ impl fmt::Debug for Csr {
 define!(
     #[c_ty(x509write_csr)]
     struct Builder<'a>;
-    pub fn new() {
-        x509write_csr_init
-    }
-    fn drop() {
-        x509write_csr_free
-    }
+    pub const new: fn() -> Self = x509write_csr_init;
+    const drop: fn(&mut Self) = x509write_csr_free;
 );
 
 impl<'a> Builder<'a> {


### PR DESCRIPTION
We used to have assignment in the macro but I couldn't come up with a syntax that would fly with rustfmt when making the change a few days ago. I thought of one now.

Not sure if this is better or not. The advantage is it puts everything on a single line.