### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_io 0.1.20190701 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "mbedtls-sys-auto 2.16.0",
+ "mbedtls-sys-auto 2.18.0",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-libc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.18.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0/GPL-2.0+"
+#edition = "2018"
 description = """
 Rust bindings for MbedTLS.
 

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -11,7 +11,7 @@ use bindgen;
 use std::fs::File;
 use std::io::{stderr, Write};
 
-use headers;
+use crate::headers;
 
 #[derive(Debug)]
 struct StderrLogger;
@@ -31,7 +31,7 @@ impl super::BuildConfig {
         File::create(&header)
             .and_then(|mut f| {
                 Ok(for h in headers::enabled_ordered() {
-                    try!(writeln!(f, "#include <mbedtls/{}>", h));
+                    writeln!(f, "#include <mbedtls/{}>", h)?;
                 })
             }).expect("bindgen-input.h I/O error");
 
@@ -73,8 +73,8 @@ impl super::BuildConfig {
         let bindings_rs = self.out_dir.join("bindings.rs");
         File::create(&bindings_rs)
             .and_then(|mut f| {
-                try!(bindings.write(Box::new(&mut f)));
-                f.write_all(b"use ::types::*;\n") // for FILE, time_t, etc.
+                bindings.write(Box::new(&mut f))?;
+                f.write_all(b"use crate::types::*;\n") // for FILE, time_t, etc.
             }).expect("bindings.rs I/O error");
 
         let mod_bindings = self.out_dir.join("mod-bindings.rs");

--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -55,15 +55,15 @@ impl BuildConfig {
 
         File::create(&self.config_h)
             .and_then(|mut f| {
-                try!(f.write_all(config::PREFIX.as_bytes()));
+                f.write_all(config::PREFIX.as_bytes())?;
                 for (name, def) in defines {
-                    try!(f.write_all(def.define(name).as_bytes()));
+                    f.write_all(def.define(name).as_bytes())?;
                 }
                 if have_feature("custom_printf") {
-                    try!(writeln!(f, "int mbedtls_printf(const char *format, ...);"));
+                    writeln!(f, "int mbedtls_printf(const char *format, ...);")?;
                 }
                 if have_feature("custom_threading") {
-                    try!(writeln!(f, "typedef void* mbedtls_threading_mutex_t;"));
+                    writeln!(f, "typedef void* mbedtls_threading_mutex_t;")?;
                 }
                 f.write_all(config::SUFFIX.as_bytes())
             })

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -8,7 +8,7 @@
 
 use cmake;
 
-use have_feature;
+use crate::have_feature;
 
 impl super::BuildConfig {
     pub fn cmake(&self) {

--- a/mbedtls-sys/build/headers.rs
+++ b/mbedtls-sys/build/headers.rs
@@ -6,6 +6,8 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+use crate::have_feature;
+
 /* This list has been generated from a include/mbedtls/ directory as follows:
  *
  * 1. Find all occurences of #include "", but skip MBEDTLS macros and *_alt.h
@@ -102,9 +104,9 @@ pub const ORDERED: &'static [(Option<&'static str>, &'static str)] = &[
     (None,                 "aesni.h"),
 ];
 
-pub fn enabled_ordered() -> Box<Iterator<Item = &'static str>> {
+pub fn enabled_ordered() -> Box<dyn Iterator<Item = &'static str>> {
     Box::new(ORDERED.iter().filter_map(|&(feat, h)| {
-        if feat.map(::have_feature).unwrap_or(true) {
+        if feat.map(have_feature).unwrap_or(true) {
             Some(h)
         } else {
             None

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -3,6 +3,7 @@ name = "mbedtls"
 version = "0.4.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
+edition = "2018"
 license = "Apache-2.0/GPL-2.0+"
 description = """
 Idiomatic Rust wrapper for MbedTLS, allowing you to use MbedTLS with only safe

--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -24,15 +24,15 @@ use support::keys;
 
 fn result_main(addr: &str) -> TlsResult<()> {
     let mut entropy = entropy_new();
-    let mut rng = try!(CtrDrbg::new(&mut entropy, None));
-    let mut cert = try!(Certificate::from_pem(keys::PEM_CERT));
+    let mut rng = CtrDrbg::new(&mut entropy, None)?;
+    let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
     config.set_rng(Some(&mut rng));
     config.set_ca_list(Some(&mut *cert), None);
-    let mut ctx = try!(Context::new(&config));
+    let mut ctx = Context::new(&config)?;
 
     let mut conn = TcpStream::connect(addr).unwrap();
-    let mut session = try!(ctx.establish(&mut conn, None));
+    let mut session = ctx.establish(&mut conn, None)?;
 
     let mut line = String::new();
     stdin().read_line(&mut line).unwrap();

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -6,7 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use error::{Error, IntoResult};
+use crate::error::{Error, IntoResult, Result};
 use mbedtls_sys::*;
 
 #[cfg(not(feature = "std"))]
@@ -64,9 +64,9 @@ impl Binary for Mpi {
 
 #[cfg(feature = "std")]
 impl ::core::str::FromStr for Mpi {
-    type Err = ::Error;
+    type Err = Error;
 
-    fn from_str(s: &str) -> ::Result<Mpi> {
+    fn from_str(s: &str) -> Result<Mpi> {
         let is_hex = s.starts_with("0x");
         let radix = if is_hex { 16 } else { 10 };
         let skip = if is_hex { 2 } else { 0 };
@@ -87,22 +87,22 @@ impl Clone for Mpi {
 }
 
 impl Mpi {
-    pub(crate) fn copy(value: &mpi) -> ::Result<Mpi> {
+    pub(crate) fn copy(value: &mpi) -> Result<Mpi> {
         let mut ret = Self::init();
         unsafe { mpi_copy(&mut ret.inner, value) }.into_result()?;
         Ok(ret)
     }
 
-    pub fn new(value: mpi_sint) -> ::Result<Mpi> {
+    pub fn new(value: mpi_sint) -> Result<Mpi> {
         let mut ret = Self::init();
-        try!(unsafe { mpi_lset(&mut ret.inner, value).into_result() });
+        unsafe { mpi_lset(&mut ret.inner, value) }.into_result()?;
         Ok(ret)
     }
 
     /// Initialize an MPI number from big endian binary data
-    pub fn from_binary(num: &[u8]) -> ::Result<Mpi> {
+    pub fn from_binary(num: &[u8]) -> Result<Mpi> {
         let mut ret = Self::init();
-        try!(unsafe { mpi_read_binary(&mut ret.inner, num.as_ptr(), num.len()).into_result() });
+        unsafe { mpi_read_binary(&mut ret.inner, num.as_ptr(), num.len()) }.into_result()?;
         Ok(ret)
     }
 
@@ -115,7 +115,7 @@ impl Mpi {
         }
     }
 
-    pub fn set_bit(&mut self, bit: usize, val: bool) -> ::Result<()> {
+    pub fn set_bit(&mut self, bit: usize, val: bool) -> Result<()> {
         unsafe {
             mpi_set_bit(&mut self.inner, bit, val as u8).into_result()?;
         }
@@ -131,7 +131,7 @@ impl Mpi {
         }
     }
 
-    pub fn as_u32(&self) -> ::Result<u32> {
+    pub fn as_u32(&self) -> Result<u32> {
         if self.bit_length()? > 32 {
             // Not exactly correct but close enough
             return Err(Error::MpiBufferTooSmall);
@@ -140,7 +140,7 @@ impl Mpi {
         Ok(self.get_limb(0) as u32)
     }
 
-    pub fn to_string_radix(&self, radix: i32) -> ::Result<String> {
+    pub fn to_string_radix(&self, radix: i32) -> Result<String> {
         let mut olen = 0;
         let r =
             unsafe { mpi_write_string(&self.inner, radix, ::core::ptr::null_mut(), 0, &mut olen) };
@@ -171,7 +171,7 @@ impl Mpi {
     }
 
     /// Serialize the MPI as big endian binary data
-    pub fn to_binary(&self) -> ::Result<Vec<u8>> {
+    pub fn to_binary(&self) -> Result<Vec<u8>> {
         let len = self.byte_length()?;
         let mut ret = vec![0u8; len];
         unsafe { mpi_write_binary(&self.inner, ret.as_mut_ptr(), ret.len()).into_result() }?;
@@ -179,7 +179,7 @@ impl Mpi {
     }
 
     /// Serialize the MPI as big endian binary data, padding to at least min_len bytes
-    pub fn to_binary_padded(&self, min_len: usize) -> ::Result<Vec<u8>> {
+    pub fn to_binary_padded(&self, min_len: usize) -> Result<Vec<u8>> {
         let len = self.byte_length()?;
         let larger_len = if len < min_len { min_len } else { len };
         let mut ret = vec![0u8; larger_len];
@@ -192,18 +192,18 @@ impl Mpi {
     }
 
     /// Return size of this MPI in bits
-    pub fn bit_length(&self) -> ::Result<usize> {
+    pub fn bit_length(&self) -> Result<usize> {
         let l = unsafe { mpi_bitlen(&self.inner) };
         Ok(l)
     }
 
     /// Return size of this MPI in bytes (rounded up)
-    pub fn byte_length(&self) -> ::Result<usize> {
+    pub fn byte_length(&self) -> Result<usize> {
         let l = unsafe { mpi_size(&self.inner) };
         Ok(l)
     }
 
-    pub fn divrem(&self, other: &Mpi) -> ::Result<(Mpi, Mpi)> {
+    pub fn divrem(&self, other: &Mpi) -> Result<(Mpi, Mpi)> {
         let mut q = Self::init();
         let mut r = Self::init();
         unsafe { mpi_div_mpi(&mut q.inner, &mut r.inner, &self.inner, &other.inner) }
@@ -212,20 +212,20 @@ impl Mpi {
     }
 
     /// Reduce self modulo other
-    pub fn modulo(&self, other: &Mpi) -> ::Result<Mpi> {
+    pub fn modulo(&self, other: &Mpi) -> Result<Mpi> {
         let mut ret = Self::init();
         unsafe { mpi_mod_mpi(&mut ret.inner, &self.inner, &other.inner) }.into_result()?;
         Ok(ret)
     }
 
-    pub fn divrem_int(&self, other: mpi_sint) -> ::Result<(Mpi, Mpi)> {
+    pub fn divrem_int(&self, other: mpi_sint) -> Result<(Mpi, Mpi)> {
         let mut q = Self::init();
         let mut r = Self::init();
         unsafe { mpi_div_int(&mut q.inner, &mut r.inner, &self.inner, other) }.into_result()?;
         Ok((q, r))
     }
 
-    pub fn modinv(&self, modulus: &Mpi) -> ::Result<Mpi> {
+    pub fn modinv(&self, modulus: &Mpi) -> Result<Mpi> {
         let mut r = Self::init();
         unsafe { mpi_inv_mod(&mut r.inner, &self.inner, &modulus.inner) }.into_result()?;
         Ok(r)
@@ -235,11 +235,11 @@ impl Mpi {
     ///
     /// The modulus must be prime; computing a square root modulo
     /// a composite number is equivalent to factoring the composite.
-    pub fn mod_sqrt(&self, p: &Mpi) -> ::Result<Mpi> {
+    pub fn mod_sqrt(&self, p: &Mpi) -> Result<Mpi> {
         let zero = Mpi::new(0)?;
 
         if self < &zero || self >= p {
-            return Err(::Error::MpiBadInputData);
+            return Err(Error::MpiBadInputData);
         }
         if self == &zero {
             return Ok(zero);
@@ -247,12 +247,12 @@ impl Mpi {
 
         // This ignores p=2 (for which this algorithm is valid), as not cryptographically interesting.
         if p.get_bit(0) == false || p <= &zero {
-            return Err(::Error::MpiBadInputData);
+            return Err(Error::MpiBadInputData);
         }
 
         if self.jacobi(p)? != 1 {
             // a is not a quadratic residue mod p
-            return Err(::Error::MpiBadInputData);
+            return Err(Error::MpiBadInputData);
         }
 
         if (p % 4)?.as_u32()? == 3 {
@@ -299,7 +299,7 @@ impl Mpi {
                 bo = bo.mod_exp(&two, p)?;
                 m += 1;
                 if m >= r {
-                    return Err(::Error::MpiBadInputData);
+                    return Err(Error::MpiBadInputData);
                 }
             }
 
@@ -327,12 +327,12 @@ impl Mpi {
     }
 
     /// Calculates Jacobi symbol (self|N)
-    pub fn jacobi(&self, n: &Mpi) -> ::Result<i32> {
+    pub fn jacobi(&self, n: &Mpi) -> Result<i32> {
         let zero = Mpi::new(0)?;
         let one = Mpi::new(1)?;
 
         if self < &zero || n < &zero || n.get_bit(0) == false {
-            return Err(::Error::MpiBadInputData);
+            return Err(Error::MpiBadInputData);
         }
 
         let mut x = self.modulo(n)?;
@@ -374,7 +374,7 @@ impl Mpi {
     }
 
     /// Return (self^exponent) % n
-    pub fn mod_exp(&self, exponent: &Mpi, modulus: &Mpi) -> ::Result<Mpi> {
+    pub fn mod_exp(&self, exponent: &Mpi, modulus: &Mpi) -> Result<Mpi> {
         let mut r = Self::init();
         unsafe {
             mpi_exp_mod(
@@ -420,9 +420,9 @@ impl Eq for Mpi {}
 macro_rules! impl_arithmetic_op {
     ($op_trait:ident, $op_assign_trait:ident, $trait_func:ident, $trait_assign_func:ident, $func:expr, $int_func:expr) => {
         impl<'a, 'b> $op_trait<&'a Mpi> for &'b Mpi {
-            type Output = ::Result<Mpi>;
+            type Output = Result<Mpi>;
 
-            fn $trait_func(self, other: &Mpi) -> ::Result<Mpi> {
+            fn $trait_func(self, other: &Mpi) -> Result<Mpi> {
                 let mut ret = Mpi::init();
                 unsafe { $func(&mut ret.inner, &self.inner, &other.inner) }.into_result()?;
                 Ok(ret)
@@ -430,9 +430,9 @@ macro_rules! impl_arithmetic_op {
         }
 
         impl<'a> $op_trait<mpi_sint> for &'a Mpi {
-            type Output = ::Result<Mpi>;
+            type Output = Result<Mpi>;
 
-            fn $trait_func(self, other: mpi_sint) -> ::Result<Mpi> {
+            fn $trait_func(self, other: mpi_sint) -> Result<Mpi> {
                 let mut ret = Mpi::init();
                 unsafe { $int_func(&mut ret.inner, &self.inner, other as _) }.into_result()?;
                 Ok(ret)
@@ -470,9 +470,9 @@ impl_arithmetic_op!(Sub, SubAssign, sub, sub_assign, mpi_sub_mpi, mpi_sub_int);
 impl_arithmetic_op!(Mul, MulAssign, mul, mul_assign, mpi_mul_mpi, mpi_mul_int);
 
 impl<'a, 'b> Div<&'b Mpi> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn div(self, other: &Mpi) -> ::Result<Mpi> {
+    fn div(self, other: &Mpi) -> Result<Mpi> {
         let mut q = Mpi::init();
         unsafe {
             mpi_div_mpi(
@@ -488,9 +488,9 @@ impl<'a, 'b> Div<&'b Mpi> for &'a Mpi {
 }
 
 impl<'a> Div<Mpi> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn div(self, other: Mpi) -> ::Result<Mpi> {
+    fn div(self, other: Mpi) -> Result<Mpi> {
         let mut q = Mpi::init();
         unsafe {
             mpi_div_mpi(
@@ -506,9 +506,9 @@ impl<'a> Div<Mpi> for &'a Mpi {
 }
 
 impl<'a> Div<mpi_sint> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn div(self, other: mpi_sint) -> ::Result<Mpi> {
+    fn div(self, other: mpi_sint) -> Result<Mpi> {
         let mut q = Mpi::init();
         unsafe { mpi_div_int(&mut q.inner, ::core::ptr::null_mut(), &self.inner, other) }
             .into_result()?;
@@ -571,9 +571,9 @@ impl DivAssign<mpi_sint> for Mpi {
 }
 
 impl<'a, 'b> Rem<&'b Mpi> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn rem(self, other: &Mpi) -> ::Result<Mpi> {
+    fn rem(self, other: &Mpi) -> Result<Mpi> {
         let mut r = Mpi::init();
         unsafe {
             mpi_div_mpi(
@@ -589,9 +589,9 @@ impl<'a, 'b> Rem<&'b Mpi> for &'a Mpi {
 }
 
 impl<'a> Rem<Mpi> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn rem(self, other: Mpi) -> ::Result<Mpi> {
+    fn rem(self, other: Mpi) -> Result<Mpi> {
         let mut r = Mpi::init();
         unsafe {
             mpi_div_mpi(
@@ -607,9 +607,9 @@ impl<'a> Rem<Mpi> for &'a Mpi {
 }
 
 impl Rem<mpi_sint> for Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn rem(self, other: mpi_sint) -> ::Result<Mpi> {
+    fn rem(self, other: mpi_sint) -> Result<Mpi> {
         let mut r = Mpi::init();
         unsafe { mpi_div_int(::core::ptr::null_mut(), &mut r.inner, &self.inner, other) }
             .into_result()?;
@@ -618,9 +618,9 @@ impl Rem<mpi_sint> for Mpi {
 }
 
 impl<'a> Rem<mpi_sint> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn rem(self, other: mpi_sint) -> ::Result<Mpi> {
+    fn rem(self, other: mpi_sint) -> Result<Mpi> {
         let mut r = Mpi::init();
         unsafe { mpi_div_int(::core::ptr::null_mut(), &mut r.inner, &self.inner, other) }
             .into_result()?;
@@ -683,9 +683,9 @@ impl RemAssign<mpi_sint> for Mpi {
 }
 
 impl<'a> Shl<usize> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn shl(self, shift: usize) -> ::Result<Mpi> {
+    fn shl(self, shift: usize) -> Result<Mpi> {
         let mut r = Mpi::copy(self.handle())?;
         unsafe { mpi_shift_l(&mut r.inner, shift) }.into_result()?;
         Ok(r)
@@ -693,9 +693,9 @@ impl<'a> Shl<usize> for &'a Mpi {
 }
 
 impl Shl<usize> for Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn shl(self, shift: usize) -> ::Result<Mpi> {
+    fn shl(self, shift: usize) -> Result<Mpi> {
         let mut r = Mpi::copy(self.handle())?;
         unsafe { mpi_shift_l(&mut r.inner, shift) }.into_result()?;
         Ok(r)
@@ -711,9 +711,9 @@ impl ShlAssign<usize> for Mpi {
 }
 
 impl<'a> Shr<usize> for &'a Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn shr(self, shift: usize) -> ::Result<Mpi> {
+    fn shr(self, shift: usize) -> Result<Mpi> {
         let mut r = Mpi::copy(self.handle())?;
         unsafe { mpi_shift_r(&mut r.inner, shift) }.into_result()?;
         Ok(r)
@@ -721,9 +721,9 @@ impl<'a> Shr<usize> for &'a Mpi {
 }
 
 impl Shr<usize> for Mpi {
-    type Output = ::Result<Mpi>;
+    type Output = Result<Mpi>;
 
-    fn shr(self, shift: usize) -> ::Result<Mpi> {
+    fn shr(self, shift: usize) -> Result<Mpi> {
         let mut r = Mpi::copy(self.handle())?;
         unsafe { mpi_shift_r(&mut r.inner, shift) }.into_result()?;
         Ok(r)

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, IntoResult, Result};
 use mbedtls_sys::*;
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use core::cmp::Ordering;
 use core::fmt::{Binary, Debug, Display, Formatter, Octal, Result as FmtResult, UpperHex};

--- a/mbedtls/src/cipher/raw/serde.rs
+++ b/mbedtls/src/cipher/raw/serde.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 use crate::cipher::*;
 use core::fmt;
 use core::marker::PhantomData;

--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, IntoResult, Result};
 use mbedtls_sys::*;
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use crate::bignum::Mpi;
 use crate::pk::EcGroupId;

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -50,7 +50,7 @@ extern crate block_modes;
 // ==============
 pub mod bignum;
 mod error;
-pub use error::{Error, Result};
+pub use crate::error::{Error, Result};
 pub mod cipher;
 pub mod ecp;
 pub mod hash;

--- a/mbedtls/src/pk/dhparam.rs
+++ b/mbedtls/src/pk/dhparam.rs
@@ -6,7 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use error::IntoResult;
+use crate::error::{IntoResult, Result};
 use mbedtls_sys::*;
 
 define!(
@@ -22,9 +22,9 @@ impl Dhm {
     /// Takes both DER and PEM forms of FFDH parameters in `DHParams` format.
     ///
     /// When calling on PEM-encoded data, `params` must be NULL-terminated
-    pub(crate) fn from_params(params: &[u8]) -> ::Result<Dhm> {
+    pub(crate) fn from_params(params: &[u8]) -> Result<Dhm> {
         let mut ret = Self::init();
-        unsafe { try!(dhm_parse_dhm(&mut ret.inner, params.as_ptr(), params.len()).into_result()) };
+        unsafe { dhm_parse_dhm(&mut ret.inner, params.as_ptr(), params.len()) }.into_result()?;
         Ok(ret)
     }
 }

--- a/mbedtls/src/pk/ec.rs
+++ b/mbedtls/src/pk/ec.rs
@@ -9,7 +9,7 @@
 use mbedtls_sys::ECDSA_MAX_LEN as MBEDTLS_ECDSA_MAX_LEN;
 use mbedtls_sys::*;
 
-use error::IntoResult;
+use crate::error::{Error, IntoResult, Result};
 
 define!(
     #[c_ty(ecp_group_id)]
@@ -78,9 +78,9 @@ define!(
 );
 
 impl Ecdh {
-    pub fn from_keys(private: &EcpKeypair, public: &EcpKeypair) -> ::Result<Ecdh> {
+    pub fn from_keys(private: &EcpKeypair, public: &EcpKeypair) -> Result<Ecdh> {
         if public.inner.grp.id == ECP_DP_NONE || public.inner.grp.id != private.inner.grp.id {
-            return Err(::Error::EcpBadInputData);
+            return Err(Error::EcpBadInputData);
         }
 
         let mut ret = Self::init();
@@ -92,11 +92,11 @@ impl Ecdh {
         Ok(ret)
     }
 
-    pub fn calc_secret<F: ::rng::Random>(
+    pub fn calc_secret<F: crate::rng::Random>(
         &mut self,
         shared: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
+    ) -> Result<usize> {
         let mut olen = 0;
         unsafe {
             ecdh_calc_secret(
@@ -115,7 +115,7 @@ impl Ecdh {
 
 #[cfg(test)]
 mod tests {
-    use pk::Pk;
+    use crate::pk::Pk;
 
     #[test]
     fn p192_dh() {
@@ -142,7 +142,7 @@ hXzA375dfGH6yIsRgRveMo6KDRK/AanSBLUj
         let k_pb = Pk::from_public_key(PUBLIC_P192).unwrap();
         let mut out = [0; 192 / 8];
         let len = k_pr
-            .agree(&k_pb, &mut out, &mut ::test_support::rand::test_rng())
+            .agree(&k_pb, &mut out, &mut crate::test_support::rand::test_rng())
             .unwrap();
         assert_eq!(len, DH_P192.len());
         assert_eq!(out, DH_P192);

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -14,8 +14,10 @@ use mbedtls_sys::types::raw_types::c_void;
 
 use core::ptr;
 use core::convert::TryInto;
-use error::IntoResult;
-use private::UnsafeFrom;
+use crate::error::{Error, IntoResult, Result};
+use crate::private::UnsafeFrom;
+use crate::rng::Random;
+use crate::hash::Type as MdType;
 
 use byteorder::{BigEndian, ByteOrder};
 
@@ -24,14 +26,14 @@ mod ec;
 mod rfc6979;
 
 use self::rfc6979::Rfc6979Rng;
-use bignum::Mpi;
-use ecp::EcPoint;
+use crate::bignum::Mpi;
+use crate::ecp::EcPoint;
 
 #[doc(inline)]
 pub use self::ec::{EcGroupId, ECDSA_MAX_LEN};
 
 #[doc(inline)]
-pub use ecp::EcGroup;
+pub use crate::ecp::EcGroup;
 
 // SHA-256("Fortanix")[:4]
 const CUSTOM_PK_TYPE: pk_type_t = 0x8b205408 as pk_type_t;
@@ -73,7 +75,7 @@ pub enum RsaPadding {
     /// Use OAEP for encryption, or PSS for signing.
     Pkcs1V21 {
         /// The Mask Generating Function (MGF) to use.
-        mgf: ::hash::Type,
+        mgf: MdType,
     },
 }
 
@@ -141,7 +143,7 @@ impl Pk {
     /// Takes both DER and PEM forms of PKCS#1 or PKCS#8 encoded keys.
     ///
     /// When calling on PEM-encoded data, `key` must be NULL-terminated
-    pub fn from_private_key(key: &[u8], password: Option<&[u8]>) -> ::Result<Pk> {
+    pub fn from_private_key(key: &[u8], password: Option<&[u8]>) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             pk_parse_key(
@@ -159,13 +161,13 @@ impl Pk {
     /// Takes both DER and PEM encoded SubjectPublicKeyInfo keys.
     ///
     /// When calling on PEM-encoded data, `key` must be NULL-terminated
-    pub fn from_public_key(key: &[u8]) -> ::Result<Pk> {
+    pub fn from_public_key(key: &[u8]) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe { pk_parse_public_key(&mut ret.inner, key.as_ptr(), key.len()).into_result()? };
         Ok(ret)
     }
 
-    pub fn generate_rsa<F: ::rng::Random>(rng: &mut F, bits: u32, exponent: u32) -> ::Result<Pk> {
+    pub fn generate_rsa<F: Random>(rng: &mut F, bits: u32, exponent: u32) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             pk_setup(&mut ret.inner, pk_info_from_type(Type::Rsa.into())).into_result()?;
@@ -181,7 +183,7 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn generate_ec<F: ::rng::Random, C: TryInto<EcGroup, Error = impl Into<::Error>>>(rng: &mut F, curve: C) -> ::Result<Pk> {
+    pub fn generate_ec<F: Random, C: TryInto<EcGroup, Error = impl Into<Error>>>(rng: &mut F, curve: C) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             let curve : EcGroup = curve.try_into().map_err(|e| e.into())?;
@@ -200,7 +202,7 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn private_from_ec_components(mut curve: EcGroup, private_key: Mpi) -> ::Result<Pk> {
+    pub fn private_from_ec_components(mut curve: EcGroup, private_key: Mpi) -> Result<Pk> {
         let mut ret = Self::init();
         let curve_generator = curve.generator()?;
         let public_point = curve_generator.mul(&mut curve, &private_key)?;
@@ -214,7 +216,7 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn public_from_ec_components(curve: EcGroup, public_point: EcPoint) -> ::Result<Pk> {
+    pub fn public_from_ec_components(curve: EcGroup, public_point: EcPoint) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             pk_setup(&mut ret.inner, pk_info_from_type(Type::Eckey.into())).into_result()?;
@@ -225,7 +227,7 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn public_custom_algo(algo_id: &[u64], pk: &[u8]) -> ::Result<Pk> {
+    pub fn public_custom_algo(algo_id: &[u64], pk: &[u8]) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             pk_setup(&mut ret.inner, &CUSTOM_PK_INFO).into_result()?;
@@ -236,7 +238,7 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn private_custom_algo(algo_id: &[u64], pk: &[u8], sk: &[u8]) -> ::Result<Pk> {
+    pub fn private_custom_algo(algo_id: &[u64], pk: &[u8], sk: &[u8]) -> Result<Pk> {
         let mut ret = Self::init();
         unsafe {
             pk_setup(&mut ret.inner, &CUSTOM_PK_INFO).into_result()?;
@@ -248,9 +250,9 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn custom_algo_id(&self) -> ::Result<&[u64]> {
+    pub fn custom_algo_id(&self) -> Result<&[u64]> {
         if self.pk_type() != Type::Custom {
-            return Err(::Error::PkInvalidAlg);
+            return Err(Error::PkInvalidAlg);
         }
 
         unsafe {
@@ -259,24 +261,24 @@ impl Pk {
         }
     }
 
-    pub fn custom_public_key(&self) -> ::Result<&[u8]> {
+    pub fn custom_public_key(&self) -> Result<&[u8]> {
         if self.pk_type() != Type::Custom {
-            return Err(::Error::PkInvalidAlg);
+            return Err(Error::PkInvalidAlg);
         }
 
         let ctx = self.inner.pk_ctx as *const CustomPkContext;
         unsafe { Ok(&(*ctx).pk) }
     }
 
-    pub fn custom_private_key(&self) -> ::Result<&[u8]> {
+    pub fn custom_private_key(&self) -> Result<&[u8]> {
         if self.pk_type() != Type::Custom {
-            return Err(::Error::PkInvalidAlg);
+            return Err(Error::PkInvalidAlg);
         }
 
         let ctx = self.inner.pk_ctx as *const CustomPkContext;
         unsafe {
             if (*ctx).sk.len() == 0 {
-                return Err(::Error::PkTypeMismatch);
+                return Err(Error::PkTypeMismatch);
             }
             Ok(&(*ctx).sk)
         }
@@ -317,16 +319,16 @@ impl Pk {
     getter!(len() -> usize = fn pk_get_bitlen);
     getter!(pk_type() -> Type = fn pk_get_type);
 
-    pub fn curve(&self) -> ::Result<EcGroupId> {
+    pub fn curve(&self) -> Result<EcGroupId> {
         match self.pk_type() {
             Type::Eckey | Type::EckeyDh | Type::Ecdsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         unsafe { Ok((*(self.inner.pk_ctx as *const ecp_keypair)).grp.id.into()) }
     }
 
-    pub fn curve_oid(&self) -> ::Result<Vec<u64>> {
+    pub fn curve_oid(&self) -> Result<Vec<u64>> {
         match self.curve()? {
             EcGroupId::Bp256R1 => Ok(vec![1, 3, 36, 3, 3, 2, 8, 1, 1, 7]),
             EcGroupId::Bp384R1 => Ok(vec![1, 3, 36, 3, 3, 2, 8, 1, 1, 11]),
@@ -339,14 +341,14 @@ impl Pk {
             EcGroupId::SecP256R1 => Ok(vec![1, 2, 840, 10045, 3, 1, 7]),
             EcGroupId::SecP384R1 => Ok(vec![1, 3, 132, 0, 34]),
             EcGroupId::SecP521R1 => Ok(vec![1, 3, 132, 0, 35]),
-            _ => Err(::Error::OidNotFound),
+            _ => Err(Error::OidNotFound),
         }
     }
 
-    pub fn ec_group(&self) -> ::Result<EcGroup> {
+    pub fn ec_group(&self) -> Result<EcGroup> {
         match self.pk_type() {
             Type::Eckey | Type::EckeyDh | Type::Ecdsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         match self.curve()? {
@@ -368,30 +370,30 @@ impl Pk {
         }
     }
 
-    pub fn ec_public(&self) -> ::Result<EcPoint> {
+    pub fn ec_public(&self) -> Result<EcPoint> {
         match self.pk_type() {
             Type::Eckey | Type::EckeyDh | Type::Ecdsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let q = &unsafe { (*(self.inner.pk_ctx as *const ecp_keypair)).Q };
         EcPoint::copy(q)
     }
 
-    pub fn ec_private(&self) -> ::Result<Mpi> {
+    pub fn ec_private(&self) -> Result<Mpi> {
         match self.pk_type() {
             Type::Eckey | Type::EckeyDh | Type::Ecdsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let d = &unsafe { (*(self.inner.pk_ctx as *const ecp_keypair)).d };
         Mpi::copy(d)
     }
 
-    pub fn rsa_public_modulus(&self) -> ::Result<Mpi> {
+    pub fn rsa_public_modulus(&self) -> Result<Mpi> {
         match self.pk_type() {
             Type::Rsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let mut n = Mpi::new(0)?;
@@ -411,10 +413,10 @@ impl Pk {
         Ok(n)
     }
 
-    pub fn rsa_private_prime1(&self) -> ::Result<Mpi> {
+    pub fn rsa_private_prime1(&self) -> Result<Mpi> {
         match self.pk_type() {
             Type::Rsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let mut p = Mpi::new(0)?;
@@ -434,10 +436,10 @@ impl Pk {
         Ok(p)
     }
 
-    pub fn rsa_private_prime2(&self) -> ::Result<Mpi> {
+    pub fn rsa_private_prime2(&self) -> Result<Mpi> {
         match self.pk_type() {
             Type::Rsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let mut q = Mpi::new(0)?;
@@ -457,10 +459,10 @@ impl Pk {
         Ok(q)
     }
 
-    pub fn rsa_public_exponent(&self) -> ::Result<u32> {
+    pub fn rsa_public_exponent(&self) -> Result<u32> {
         match self.pk_type() {
             Type::Rsa => {}
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
 
         let mut e: [u8; 4] = [0, 0, 0, 0];
@@ -483,17 +485,17 @@ impl Pk {
         Ok(BigEndian::read_u32(&e))
     }
 
-    pub fn name(&self) -> ::Result<&str> {
-        let s = unsafe { ::private::cstr_to_slice(pk_get_name(&self.inner)) };
+    pub fn name(&self) -> Result<&str> {
+        let s = unsafe { crate::private::cstr_to_slice(pk_get_name(&self.inner)) };
         Ok(::core::str::from_utf8(s)?)
     }
 
-    pub fn decrypt<F: ::rng::Random>(
+    pub fn decrypt<F: Random>(
         &mut self,
         cipher: &[u8],
         plain: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
+    ) -> Result<usize> {
         let mut ret;
         unsafe {
             ret = ::core::mem::uninitialized();
@@ -512,12 +514,12 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn encrypt<F: ::rng::Random>(
+    pub fn encrypt<F: Random>(
         &mut self,
         plain: &[u8],
         cipher: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
+    ) -> Result<usize> {
         let mut ret;
         unsafe {
             ret = ::core::mem::uninitialized();
@@ -546,26 +548,26 @@ impl Pk {
     /// otherwise `sign()` fails with `Error::PkSigLenMismatch`.
     ///
     /// On success, returns the actual number of bytes written to `sig`.
-    pub fn sign<F: ::rng::Random>(
+    pub fn sign<F: Random>(
         &mut self,
-        md: ::hash::Type,
+        md: MdType,
         hash: &[u8],
         sig: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
+    ) -> Result<usize> {
         let mut ret;
         match self.pk_type() {
             Type::Rsa | Type::RsaAlt | Type::RsassaPss => {
                 if sig.len() < (self.len() / 8) {
-                    return Err(::Error::PkSigLenMismatch);
+                    return Err(Error::PkSigLenMismatch);
                 }
             }
             Type::Eckey | Type::Ecdsa => {
                 if sig.len() < ECDSA_MAX_LEN {
-                    return Err(::Error::PkSigLenMismatch);
+                    return Err(Error::PkSigLenMismatch);
                 }
             }
-            _ => return Err(::Error::PkSigLenMismatch),
+            _ => return Err(Error::PkSigLenMismatch),
         }
         unsafe {
             ret = ::core::mem::uninitialized();
@@ -584,19 +586,19 @@ impl Pk {
         Ok(ret)
     }
 
-    pub fn sign_deterministic<F: ::rng::Random>(
+    pub fn sign_deterministic<F: Random>(
         &mut self,
-        md: ::hash::Type,
+        md: MdType,
         hash: &[u8],
         sig: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
-        use rng::RngCallback;
+    ) -> Result<usize> {
+        use crate::rng::RngCallback;
 
         if self.pk_type() == Type::Ecdsa || self.pk_type() == Type::Eckey {
             // RFC 6979 signature scheme
 
-            let q = ::ecp::EcGroup::new(self.curve()?)?.order()?;
+            let q = EcGroup::new(self.curve()?)?.order()?;
             let x = self.ec_private()?;
 
             let mut random_seed = [0u8; 64];
@@ -623,18 +625,18 @@ impl Pk {
         } else if self.pk_type() == Type::Rsa {
             // Reject sign_deterministic being use for PSS
             if unsafe { (*(self.inner.pk_ctx as *mut rsa_context)).padding } != RSA_PKCS_V15 {
-                return Err(::Error::PkInvalidAlg);
+                return Err(Error::PkInvalidAlg);
             }
 
             // This is a PKCSv1.5 signature which is already deterministic; just pass it to sign
             return self.sign(md, hash, sig, rng);
         } else {
             // Some non-deterministic scheme
-            return Err(::Error::PkInvalidAlg);
+            return Err(Error::PkInvalidAlg);
         }
     }
 
-    pub fn verify(&mut self, md: ::hash::Type, hash: &[u8], sig: &[u8]) -> ::Result<()> {
+    pub fn verify(&mut self, md: MdType, hash: &[u8], sig: &[u8]) -> Result<()> {
         unsafe {
             pk_verify(
                 &mut self.inner,
@@ -650,12 +652,12 @@ impl Pk {
     }
 
     /// Agree on a shared secret with another public key.
-    pub fn agree<F: ::rng::Random>(
+    pub fn agree<F: Random>(
         &mut self,
         other: &Pk,
         shared: &mut [u8],
         rng: &mut F,
-    ) -> ::Result<usize> {
+    ) -> Result<usize> {
         match (self.pk_type(), other.pk_type()) {
             (Type::Eckey, Type::Eckey)
             | (Type::EckeyDh, Type::Eckey)
@@ -667,77 +669,77 @@ impl Pk {
                 )?;
                 ecdh.calc_secret(shared, rng)
             },
-            _ => return Err(::Error::PkTypeMismatch),
+            _ => return Err(Error::PkTypeMismatch),
         }
     }
 
-    pub fn write_private_der<'buf>(&mut self, buf: &'buf mut [u8]) -> ::Result<Option<&'buf [u8]>> {
+    pub fn write_private_der<'buf>(&mut self, buf: &'buf mut [u8]) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             pk_write_key_der(&mut self.inner, buf.as_mut_ptr(), buf.len()).into_result()
         } {
-            Err(::Error::Asn1BufTooSmall) => Ok(None),
+            Err(Error::Asn1BufTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_private_der_vec(&mut self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn write_private_der_vec(&mut self) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe { pk_write_key_der(&mut self.inner, buf, size) },
             true,
         )
     }
 
-    pub fn write_private_pem<'buf>(&mut self, buf: &'buf mut [u8]) -> ::Result<Option<&'buf [u8]>> {
+    pub fn write_private_pem<'buf>(&mut self, buf: &'buf mut [u8]) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             pk_write_key_pem(&mut self.inner, buf.as_mut_ptr(), buf.len()).into_result()
         } {
-            Err(::Error::Base64BufferTooSmall) => Ok(None),
+            Err(Error::Base64BufferTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_private_pem_string(&mut self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn write_private_pem_string(&mut self) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             match pk_write_key_pem(&mut self.inner, buf as _, size) {
-                0 => ::private::cstr_to_slice(buf as _).len() as _,
+                0 => crate::private::cstr_to_slice(buf as _).len() as _,
                 r => r,
             }
         })
     }
 
-    pub fn write_public_der<'buf>(&mut self, buf: &'buf mut [u8]) -> ::Result<Option<&'buf [u8]>> {
+    pub fn write_public_der<'buf>(&mut self, buf: &'buf mut [u8]) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             pk_write_pubkey_der(&mut self.inner, buf.as_mut_ptr(), buf.len()).into_result()
         } {
-            Err(::Error::Asn1BufTooSmall) => Ok(None),
+            Err(Error::Asn1BufTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_public_der_vec(&mut self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn write_public_der_vec(&mut self) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe { pk_write_pubkey_der(&mut self.inner, buf, size) },
             true,
         )
     }
 
-    pub fn write_public_pem<'buf>(&mut self, buf: &'buf mut [u8]) -> ::Result<Option<&'buf [u8]>> {
+    pub fn write_public_pem<'buf>(&mut self, buf: &'buf mut [u8]) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             pk_write_pubkey_pem(&mut self.inner, buf.as_mut_ptr(), buf.len()).into_result()
         } {
-            Err(::Error::Base64BufferTooSmall) => Ok(None),
+            Err(Error::Base64BufferTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_public_pem_string(&mut self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn write_public_pem_string(&mut self) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             match pk_write_pubkey_pem(&mut self.inner, buf as _, size) {
-                0 => ::private::cstr_to_slice(buf as _).len() as _,
+                0 => crate::private::cstr_to_slice(buf as _).len() as _,
                 r => r,
             }
         })
@@ -762,8 +764,8 @@ impl Pk {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mbedtls::hash::Type;
-    use mbedtls::pk::Type as PkType;
+    use crate::hash::Type;
+    use crate::pk::Type as PkType;
 
     // This is test data that must match library output *exactly*
     const TEST_PEM: &'static str = "-----BEGIN RSA PRIVATE KEY-----
@@ -881,7 +883,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn generate_rsa() {
         let mut pk =
-            Pk::generate_rsa(&mut ::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
+            Pk::generate_rsa(&mut crate::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
         let generated = pk.write_private_pem_string().unwrap();
         assert_eq!(0x10001, pk.rsa_public_exponent().unwrap());
         assert_eq!(generated, TEST_PEM[..TEST_PEM.len() - 1]);
@@ -890,14 +892,14 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn generate_ec_curve25519() {
         let _generated =
-            Pk::generate_ec(&mut ::test_support::rand::test_rng(), EcGroupId::Curve25519).unwrap();
+            Pk::generate_ec(&mut crate::test_support::rand::test_rng(), EcGroupId::Curve25519).unwrap();
         // mbedtls does not have an OID for Curve25519, so can't write it as PEM
     }
 
     #[test]
     fn generate_ec_secp192r1() {
         let _generated =
-            Pk::generate_ec(&mut ::test_support::rand::test_rng(), EcGroupId::SecP192R1)
+            Pk::generate_ec(&mut crate::test_support::rand::test_rng(), EcGroupId::SecP192R1)
                 .unwrap()
                 .write_private_pem_string()
                 .unwrap();
@@ -906,12 +908,12 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn generate_ec_secp256r1() {
         let mut key1 =
-            Pk::generate_ec(&mut ::test_support::rand::test_rng(), EcGroupId::SecP256R1).unwrap();
+            Pk::generate_ec(&mut crate::test_support::rand::test_rng(), EcGroupId::SecP256R1).unwrap();
         let pem1 = key1.write_private_pem_string().unwrap();
 
-        let secp256r1 = ::ecp::EcGroup::new(EcGroupId::SecP256R1).unwrap();
+        let secp256r1 = EcGroup::new(EcGroupId::SecP256R1).unwrap();
         let mut key2 =
-            Pk::generate_ec(&mut ::test_support::rand::test_rng(), secp256r1.clone())
+            Pk::generate_ec(&mut crate::test_support::rand::test_rng(), secp256r1.clone())
                 .unwrap();
         let pem2 = key2.write_private_pem_string().unwrap();
 
@@ -936,7 +938,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn generate_ec_secp256k1() {
         let _generated =
-            Pk::generate_ec(&mut ::test_support::rand::test_rng(), EcGroupId::SecP256K1)
+            Pk::generate_ec(&mut crate::test_support::rand::test_rng(), EcGroupId::SecP256K1)
                 .unwrap()
                 .write_private_pem_string()
                 .unwrap();
@@ -963,7 +965,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn rsa_sign_verify_pkcs1v15() {
         let mut pk =
-            Pk::generate_rsa(&mut ::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
+            Pk::generate_rsa(&mut crate::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
         let data = b"SIGNATURE TEST SIGNATURE TEST SI";
         let mut signature = vec![0u8; (pk.len() + 7) / 8];
 
@@ -986,7 +988,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
                     *digest,
                     data,
                     &mut signature,
-                    &mut ::test_support::rand::test_rng(),
+                    &mut crate::test_support::rand::test_rng(),
                 )
                 .unwrap();
             pk.verify(*digest, data, &signature[0..len]).unwrap();
@@ -996,7 +998,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
     #[test]
     fn rsa_sign_verify_pss() {
         let mut pk =
-            Pk::generate_rsa(&mut ::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
+            Pk::generate_rsa(&mut crate::test_support::rand::test_rng(), 2048, 0x10001).unwrap();
         let data = b"SIGNATURE TEST SIGNATURE TEST SI";
         let mut signature = vec![0u8; (pk.len() + 7) / 8];
 
@@ -1024,7 +1026,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
                         *digest,
                         data,
                         &mut signature,
-                        &mut ::test_support::rand::test_rng()
+                        &mut crate::test_support::rand::test_rng()
                     )
                     .is_err());
             } else {
@@ -1033,7 +1035,7 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
                         *digest,
                         data,
                         &mut signature,
-                        &mut ::test_support::rand::test_rng(),
+                        &mut crate::test_support::rand::test_rng(),
                     )
                     .unwrap();
                 pk.verify(*digest, data, &signature[0..len]).unwrap();
@@ -1047,17 +1049,17 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
         let mut cipher1 = [0u8; 2048 / 8];
         let mut cipher2 = [0u8; 2048 / 8];
         assert_eq!(
-            pk.encrypt(b"test", &mut cipher1, &mut ::test_support::rand::test_rng())
+            pk.encrypt(b"test", &mut cipher1, &mut crate::test_support::rand::test_rng())
                 .unwrap(),
             cipher1.len()
         );
         pk.set_options(Options::Rsa {
             padding: RsaPadding::Pkcs1V21 {
-                mgf: ::hash::Type::Sha256,
+                mgf: Type::Sha256,
             },
         });
         assert_eq!(
-            pk.encrypt(b"test", &mut cipher2, &mut ::test_support::rand::test_rng())
+            pk.encrypt(b"test", &mut cipher2, &mut crate::test_support::rand::test_rng())
                 .unwrap(),
             cipher2.len()
         );

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 use mbedtls_sys::*;
 
 use mbedtls_sys::types::raw_types::c_void;

--- a/mbedtls/src/pk/rfc6979.rs
+++ b/mbedtls/src/pk/rfc6979.rs
@@ -12,12 +12,13 @@ use alloc_prelude::*;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 
-use rng::{HmacDrbg, Random, RngCallback};
+use crate::rng::{HmacDrbg, Random, RngCallback};
 
-use bignum::Mpi;
-use hash::{MdInfo, Type};
+use crate::error::Result;
+use crate::bignum::Mpi;
+use crate::hash::{MdInfo, Type};
 
-fn generate_rfc6979_nonce(md: &MdInfo, x: &Mpi, q: &Mpi, digest_bytes: &[u8]) -> ::Result<Vec<u8>> {
+fn generate_rfc6979_nonce(md: &MdInfo, x: &Mpi, q: &Mpi, digest_bytes: &[u8]) -> Result<Vec<u8>> {
     let q_bits = q.bit_length()?;
     let q_bytes = q.byte_length()?;
 
@@ -77,7 +78,7 @@ impl Rfc6979Rng {
         x: &Mpi,
         digest_bytes: &[u8],
         random_seed: &[u8],
-    ) -> ::Result<Rfc6979Rng> {
+    ) -> Result<Rfc6979Rng> {
         let md: MdInfo = match md_type.into() {
             Some(md) => md,
             None => panic!("no such digest"),
@@ -92,7 +93,7 @@ impl Rfc6979Rng {
         })
     }
 
-    fn random_callback(&mut self, data: &mut [u8]) -> ::Result<()> {
+    fn random_callback(&mut self, data: &mut [u8]) -> Result<()> {
         let avail_k = self.k.len() - self.k_read;
 
         if data.len() <= avail_k {

--- a/mbedtls/src/pk/rfc6979.rs
+++ b/mbedtls/src/pk/rfc6979.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -36,11 +36,11 @@ use yasna::tags::*;
 pub use yasna::{ASN1Error, ASN1ErrorKind};
 use yasna::{ASN1Result, BERDecodable, BERReader, BERReaderSeq, Tag};
 
-use cipher::raw::{CipherId, CipherMode};
-use cipher::{Cipher, Decryption, Fresh, Traditional};
-use hash::{pbkdf_pkcs12, Md, MdInfo, Type as MdType};
-use pk::Pk;
-use x509::Certificate;
+use crate::cipher::raw::{CipherId, CipherMode};
+use crate::cipher::{Cipher, Decryption, Fresh, Traditional};
+use crate::hash::{pbkdf_pkcs12, Md, MdInfo, Type as MdType};
+use crate::pk::Pk;
+use crate::x509::Certificate;
 use Error as MbedtlsError;
 
 // Constants for various object identifiers used in PKCS12:
@@ -734,7 +734,7 @@ impl Pfx {
 
             let md_info: MdInfo = match md.into() {
                 Some(md) => md,
-                None => return Err(Pkcs12Error::from(::Error::MdBadInputData)),
+                None => return Err(Pkcs12Error::from(Error::MdBadInputData)),
             };
 
             if stored_mac.len() != md_info.size() {
@@ -1066,7 +1066,7 @@ mod tests {
         assert!(pfx.is_err());
         assert_eq!(
             pfx.unwrap_err(),
-            Pkcs12Error::Crypto(::error::Error::CipherInvalidPadding)
+            Pkcs12Error::Crypto(::errorError::CipherInvalidPadding)
         );
 
         let pfx = parsed_pfx.decrypt(&wrong_password_correct_padding, None);

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -41,7 +41,7 @@ use crate::cipher::{Cipher, Decryption, Fresh, Traditional};
 use crate::hash::{pbkdf_pkcs12, Md, MdInfo, Type as MdType};
 use crate::pk::Pk;
 use crate::x509::Certificate;
-use Error as MbedtlsError;
+use crate::Error as MbedtlsError;
 
 // Constants for various object identifiers used in PKCS12:
 
@@ -734,7 +734,7 @@ impl Pfx {
 
             let md_info: MdInfo = match md.into() {
                 Some(md) => md,
-                None => return Err(Pkcs12Error::from(Error::MdBadInputData)),
+                None => return Err(Pkcs12Error::from(MbedtlsError::MdBadInputData)),
             };
 
             if stored_mac.len() != md_info.size() {
@@ -923,7 +923,7 @@ impl BERDecodable for Pfx {
 #[cfg(test)]
 mod tests {
 
-    use mbedtls::pkcs12::{ASN1Error, ASN1ErrorKind, Pfx, Pkcs12Error};
+    use crate::mbedtls::pkcs12::{ASN1Error, ASN1ErrorKind, Pfx, Pkcs12Error};
 
     #[test]
     fn parse_shibboleth() {
@@ -1066,7 +1066,7 @@ mod tests {
         assert!(pfx.is_err());
         assert_eq!(
             pfx.unwrap_err(),
-            Pkcs12Error::Crypto(::errorError::CipherInvalidPadding)
+            Pkcs12Error::Crypto(crate::Error::CipherInvalidPadding)
         );
 
         let pfx = parsed_pfx.decrypt(&wrong_password_correct_padding, None);

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -15,7 +15,7 @@
 
 #[forbid(unsafe_code)]
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use core::result::Result as StdResult;
 

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use mbedtls_sys::types::raw_types::c_char;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar};

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -13,16 +13,16 @@ use mbedtls_sys::types::raw_types::c_char;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar};
 use mbedtls_sys::types::size_t;
 
-use error::IntoResult;
+use crate::error::{Error, IntoResult, Result};
 
 pub trait UnsafeFrom<T>
 where
     Self: Sized,
 {
-    unsafe fn from(T) -> Option<Self>;
+    unsafe fn from(_: T) -> Option<Self>;
 }
 
-pub fn alloc_vec_repeat<F>(mut f: F, data_at_end: bool) -> ::Result<Vec<u8>>
+pub fn alloc_vec_repeat<F>(mut f: F, data_at_end: bool) -> Result<Vec<u8>>
 where
     F: FnMut(*mut c_uchar, size_t) -> c_int,
 {
@@ -36,14 +36,14 @@ where
     let mut vec = Vec::with_capacity(2048 /* big because of bug in x509write */);
     loop {
         match f(vec.as_mut_ptr(), vec.capacity()).into_result() {
-            Err(::Error::Asn1BufTooSmall)
-            | Err(::Error::Base64BufferTooSmall)
-            | Err(::Error::EcpBufferTooSmall)
-            | Err(::Error::MpiBufferTooSmall)
-            | Err(::Error::NetBufferTooSmall)
-            | Err(::Error::OidBufTooSmall)
-            | Err(::Error::SslBufferTooSmall)
-            | Err(::Error::X509BufferTooSmall)
+            Err(Error::Asn1BufTooSmall)
+            | Err(Error::Base64BufferTooSmall)
+            | Err(Error::EcpBufferTooSmall)
+            | Err(Error::MpiBufferTooSmall)
+            | Err(Error::NetBufferTooSmall)
+            | Err(Error::OidBufTooSmall)
+            | Err(Error::SslBufferTooSmall)
+            | Err(Error::X509BufferTooSmall)
                 if vec.capacity() < MAX_VECTOR_ALLOCATION =>
             {
                 let cap = vec.capacity();
@@ -66,11 +66,11 @@ where
     Ok(vec)
 }
 
-pub fn alloc_string_repeat<F>(mut f: F) -> ::Result<String>
+pub fn alloc_string_repeat<F>(mut f: F) -> Result<String>
 where
     F: FnMut(*mut c_char, size_t) -> c_int,
 {
-    let vec = try!(alloc_vec_repeat(|b, s| f(b as _, s), false));
+    let vec = alloc_vec_repeat(|b, s| f(b as _, s), false)?;
     String::from_utf8(vec).map_err(|e| e.utf8_error().into())
 }
 
@@ -93,6 +93,6 @@ use core_io::{Error as IoError, ErrorKind as IoErrorKind};
 #[cfg(feature = "std")]
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-pub fn error_to_io_error(e: ::Error) -> IoError {
+pub fn error_to_io_error(e: Error) -> IoError {
     IoError::new(IoErrorKind::Other, e.to_string())
 }

--- a/mbedtls/src/rng/ctr_drbg.rs
+++ b/mbedtls/src/rng/ctr_drbg.rs
@@ -15,7 +15,7 @@ use mbedtls_sys::{
 };
 
 use super::{EntropyCallback, RngCallback};
-use error::IntoResult;
+use crate::error::{IntoResult, Result};
 
 // ==== BEGIN IMMOVABLE TYPE KLUDGE ====
 // `ctr_drbg_context` inlines an `aes_context`, which is immovable. See
@@ -109,10 +109,10 @@ impl<'entropy> CtrDrbg<'entropy> {
     pub fn new<F: EntropyCallback>(
         source: &'entropy mut F,
         additional_entropy: Option<&[u8]>,
-    ) -> ::Result<CtrDrbg<'entropy>> {
+    ) -> Result<CtrDrbg<'entropy>> {
         let mut ret = Self::init();
         unsafe {
-            try!(ctr_drbg_seed(
+            ctr_drbg_seed(
                 &mut ret.inner,
                 Some(F::call),
                 source.data_ptr(),
@@ -121,7 +121,7 @@ impl<'entropy> CtrDrbg<'entropy> {
                     .unwrap_or(::core::ptr::null()),
                 additional_entropy.map(<[_]>::len).unwrap_or(0)
             )
-            .into_result())
+            .into_result()?
         };
         Ok(ret)
     }
@@ -148,16 +148,16 @@ impl<'entropy> CtrDrbg<'entropy> {
     getter!(reseed_interval() -> c_int = .reseed_interval);
     setter!(set_reseed_interval(i: c_int) = ctr_drbg_set_reseed_interval);
 
-    pub fn reseed(&mut self, additional_entropy: Option<&[u8]>) -> ::Result<()> {
+    pub fn reseed(&mut self, additional_entropy: Option<&[u8]>) -> Result<()> {
         unsafe {
-            try!(ctr_drbg_reseed(
+            ctr_drbg_reseed(
                 &mut self.inner,
                 additional_entropy
                     .map(<[_]>::as_ptr)
                     .unwrap_or(::core::ptr::null()),
                 additional_entropy.map(<[_]>::len).unwrap_or(0)
             )
-            .into_result())
+            .into_result()?
         };
         Ok(())
     }

--- a/mbedtls/src/rng/ctr_drbg.rs
+++ b/mbedtls/src/rng/ctr_drbg.rs
@@ -40,7 +40,7 @@ use crate::error::{IntoResult, Result};
 
 use self::private::CtrDrbgInner;
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 use core::ops::{Deref, DerefMut};
 
 mod private {

--- a/mbedtls/src/rng/mod.rs
+++ b/mbedtls/src/rng/mod.rs
@@ -23,7 +23,7 @@ pub use self::os_entropy::OsEntropy;
 #[cfg(feature = "rdrand")]
 pub use self::rdrand::{Entropy as Rdseed, Nrbg as Rdrand};
 
-use error::IntoResult;
+use crate::error::{Result, IntoResult};
 use mbedtls_sys::types::raw_types::{c_int, c_uchar};
 use mbedtls_sys::types::size_t;
 
@@ -31,8 +31,8 @@ callback!(EntropyCallback:Sync(data: *mut c_uchar, len: size_t) -> c_int);
 callback!(RngCallback:Sync(data: *mut c_uchar, len: size_t) -> c_int);
 
 pub trait Random: RngCallback {
-    fn random(&mut self, data: &mut [u8]) -> ::Result<()> {
-        try!(unsafe { Self::call(self.data_ptr(), data.as_mut_ptr(), data.len()) }.into_result());
+    fn random(&mut self, data: &mut [u8]) -> Result<()> {
+        unsafe { Self::call(self.data_ptr(), data.as_mut_ptr(), data.len()) }.into_result()?;
         Ok(())
     }
 }

--- a/mbedtls/src/rng/os_entropy.rs
+++ b/mbedtls/src/rng/os_entropy.rs
@@ -10,7 +10,7 @@ use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 use mbedtls_sys::*;
 
-use error::IntoResult;
+use crate::error::{IntoResult, Result};
 
 callback!(EntropySourceCallback(data: *mut c_uchar, size: size_t, out: *mut size_t) -> c_int);
 
@@ -30,9 +30,9 @@ impl<'source> OsEntropy<'source> {
         source: &'source mut F,
         threshold: size_t,
         strong: bool,
-    ) -> ::Result<()> {
+    ) -> Result<()> {
         unsafe {
-            try!(entropy_add_source(
+            entropy_add_source(
                 &mut self.inner,
                 Some(F::call),
                 source.data_ptr(),
@@ -43,20 +43,18 @@ impl<'source> OsEntropy<'source> {
                     ENTROPY_SOURCE_WEAK
                 }
             )
-            .into_result())
+            .into_result()?
         };
         Ok(())
     }
 
-    pub fn gather(&mut self) -> ::Result<()> {
-        unsafe { try!(entropy_gather(&mut self.inner).into_result()) };
+    pub fn gather(&mut self) -> Result<()> {
+        unsafe { entropy_gather(&mut self.inner) }.into_result()?;
         Ok(())
     }
 
-    pub fn update_manual(&mut self, data: &[u8]) -> ::Result<()> {
-        unsafe {
-            try!(entropy_update_manual(&mut self.inner, data.as_ptr(), data.len()).into_result())
-        };
+    pub fn update_manual(&mut self, data: &[u8]) -> Result<()> {
+        unsafe { entropy_update_manual(&mut self.inner, data.as_ptr(), data.len()) }.into_result()?;
         Ok(())
     }
 

--- a/mbedtls/src/ssl/ticket.rs
+++ b/mbedtls/src/ssl/ticket.rs
@@ -6,8 +6,8 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use cipher::raw::CipherType;
-use error::IntoResult;
+use crate::cipher::raw::CipherType;
+use crate::error::{IntoResult, Result};
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 use mbedtls_sys::*;
@@ -39,11 +39,11 @@ define!(
 );
 
 impl<'rng> TicketContext<'rng> {
-    pub fn new<F: ::rng::Random>(
+    pub fn new<F: crate::rng::Random>(
         rng: &'rng mut F,
         cipher: CipherType,
         lifetime: u32,
-    ) -> ::Result<TicketContext<'rng>> {
+    ) -> Result<TicketContext<'rng>> {
         let mut ret = Self::init();
         unsafe {
             ssl_ticket_setup(

--- a/mbedtls/src/threading.rs
+++ b/mbedtls/src/threading.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 #[cfg(feature = "spin_threading")]
 extern crate spin;

--- a/mbedtls/src/wrapper_macros.rs
+++ b/mbedtls/src/wrapper_macros.rs
@@ -206,7 +206,7 @@ macro_rules! define_struct {
     };
     { unsafe_from $name:ident inner $inner:ident $(lifetime $l:tt)* lifetime2 $l2:tt } => {
         as_item!(
-        impl<$l2,$($l),*> ::private::UnsafeFrom<*const $inner> for &$l2 $name<$($l)*> {
+        impl<$l2,$($l),*> crate::private::UnsafeFrom<*const $inner> for &$l2 $name<$($l)*> {
             unsafe fn from(ptr: *const $inner) -> Option<Self> {
                 (ptr as *const $name).as_ref()
             }
@@ -214,7 +214,7 @@ macro_rules! define_struct {
         );
 
         as_item!(
-        impl<$l2,$($l),*> ::private::UnsafeFrom<*mut $inner> for &$l2 mut $name<$($l)*> {
+        impl<$l2,$($l),*> crate::private::UnsafeFrom<*mut $inner> for &$l2 mut $name<$($l)*> {
             unsafe fn from(ptr: *mut $inner) -> Option<Self> {
                 (ptr as *mut $name).as_mut()
             }

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -17,8 +17,11 @@ use alloc_prelude::*;
 use mbedtls_sys::types::raw_types::c_char;
 use mbedtls_sys::*;
 
-use error::IntoResult;
-use private::UnsafeFrom;
+use crate::pk::Pk;
+use crate::error::{Error, IntoResult, Result};
+use crate::private::UnsafeFrom;
+use crate::rng::Random;
+use crate::hash::Type as MdType;
 
 define!(
     #[c_ty(x509_crt)]
@@ -28,16 +31,16 @@ define!(
 );
 
 impl Certificate {
-    pub fn from_der(der: &[u8]) -> ::Result<Certificate> {
+    pub fn from_der(der: &[u8]) -> Result<Certificate> {
         let mut ret = Self::init();
-        unsafe { try!(x509_crt_parse_der(&mut ret.inner, der.as_ptr(), der.len()).into_result()) };
+        unsafe { x509_crt_parse_der(&mut ret.inner, der.as_ptr(), der.len()) }.into_result()?;
         Ok(ret)
     }
 
     /// Input must be NULL-terminated
-    pub fn from_pem(pem: &[u8]) -> ::Result<Certificate> {
+    pub fn from_pem(pem: &[u8]) -> Result<Certificate> {
         let mut ret = Self::init();
-        unsafe { try!(x509_crt_parse(&mut ret.inner, pem.as_ptr(), pem.len()).into_result()) };
+        unsafe { x509_crt_parse(&mut ret.inner, pem.as_ptr(), pem.len()) }.into_result()?;
         let mut fake = Self::init();
         ::core::mem::swap(&mut fake.inner.next, &mut ret.inner.next);
         Ok(ret)
@@ -45,12 +48,12 @@ impl Certificate {
 
     /// Input must be NULL-terminated
     #[cfg(buggy)]
-    pub fn from_pem_multiple(pem: &[u8]) -> ::Result<Vec<Certificate>> {
+    pub fn from_pem_multiple(pem: &[u8]) -> Result<Vec<Certificate>> {
         let mut vec;
         unsafe {
             // first, find out how many certificates we're parsing
             let mut dummy = Certificate::init();
-            try!(x509_crt_parse(&mut dummy.inner, pem.as_ptr(), pem.len()).into_result());
+            x509_crt_parse(&mut dummy.inner, pem.as_ptr(), pem.len()).into_result()?;
 
             // then allocate enough certs with our allocator
             vec = Vec::new();
@@ -64,7 +67,7 @@ impl Certificate {
             let list = List::from_vec(&mut vec).unwrap();
 
             // load the data again but into our allocated list
-            try!(x509_crt_parse(&mut list.head.inner, pem.as_ptr(), pem.len()).into_result());
+            x509_crt_parse(&mut list.head.inner, pem.as_ptr(), pem.len()).into_result()?;
         };
         Ok(vec)
     }
@@ -72,7 +75,7 @@ impl Certificate {
 
 impl fmt::Debug for Certificate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match ::private::alloc_string_repeat(|buf, size| unsafe {
+        match crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_crt_info(buf, size, b"\0".as_ptr() as *const _, &self.inner)
         }) {
             Err(_) => Err(fmt::Error),
@@ -126,50 +129,50 @@ impl LinkedCertificate {
         .is_ok()
     }
 
-    pub fn issuer(&self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn issuer(&self) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_dn_gets(buf, size, &self.inner.issuer)
         })
     }
 
-    pub fn issuer_raw(&self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn issuer_raw(&self) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe { x509_dn_gets(buf as _, size, &self.inner.issuer) },
             false,
         )
     }
 
-    pub fn subject(&self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn subject(&self) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_dn_gets(buf, size, &self.inner.subject)
         })
     }
 
-    pub fn subject_raw(&self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn subject_raw(&self) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe { x509_dn_gets(buf as _, size, &self.inner.subject) },
             false,
         )
     }
 
-    pub fn serial(&self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn serial(&self) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_serial_gets(buf, size, &self.inner.serial)
         })
     }
 
-    pub fn serial_raw(&self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn serial_raw(&self) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe { x509_serial_gets(buf as _, size, &self.inner.serial) },
             false,
         )
     }
 
-    pub fn public_key(&self) -> &::pk::Pk {
+    pub fn public_key(&self) -> &Pk {
         unsafe { &*(&self.inner.pk as *const _ as *const _) }
     }
 
-    pub fn public_key_mut(&mut self) -> &mut ::pk::Pk {
+    pub fn public_key_mut(&mut self) -> &mut Pk {
         unsafe { &mut *(&mut self.inner.pk as *mut _ as *mut _) }
     }
 
@@ -177,15 +180,15 @@ impl LinkedCertificate {
         unsafe { ::core::slice::from_raw_parts(self.inner.raw.p, self.inner.raw.len) }
     }
 
-    pub fn digest_type(&self) -> ::hash::Type {
-        ::hash::Type::from(self.inner.sig_md)
+    pub fn digest_type(&self) -> MdType {
+        MdType::from(self.inner.sig_md)
     }
 
     pub fn verify(
         &mut self,
         trust_ca: &mut Certificate,
         err_info: Option<&mut String>,
-    ) -> ::Result<()> {
+    ) -> Result<()> {
         let mut flags = 0;
         let result = unsafe {
             x509_crt_verify(
@@ -202,7 +205,7 @@ impl LinkedCertificate {
 
         if result.is_err() {
             if let Some(err_info) = err_info {
-                let verify_info = ::private::alloc_string_repeat(|buf, size| unsafe {
+                let verify_info = crate::private::alloc_string_repeat(|buf, size| unsafe {
                     x509_crt_verify_info(buf, size, ptr::null_mut(), flags)
                 });
                 if let Ok(error_str) = verify_info {
@@ -225,7 +228,7 @@ impl LinkedCertificate {
 
 impl fmt::Debug for LinkedCertificate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match ::private::alloc_string_repeat(|buf, size| unsafe {
+        match crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_crt_info(buf, size, b"\0".as_ptr() as *const _, &self.inner)
         }) {
             Err(_) => Err(fmt::Error),
@@ -407,98 +410,89 @@ define!(
 );
 
 impl<'a> Builder<'a> {
-    unsafe fn subject_with_nul_unchecked(&mut self, subject: &[u8]) -> ::Result<&mut Self> {
-        try!(
-            x509write_crt_set_subject_name(&mut self.inner, subject.as_ptr() as *const _)
-                .into_result()
-        );
+    unsafe fn subject_with_nul_unchecked(&mut self, subject: &[u8]) -> Result<&mut Self> {
+        x509write_crt_set_subject_name(&mut self.inner, subject.as_ptr() as *const _).into_result()?;
         Ok(self)
     }
 
     #[cfg(feature = "std")]
-    pub fn subject(&mut self, subject: &str) -> ::Result<&mut Self> {
+    pub fn subject(&mut self, subject: &str) -> Result<&mut Self> {
         match ::std::ffi::CString::new(subject) {
-            Err(_) => Err(::Error::X509InvalidName),
+            Err(_) => Err(Error::X509InvalidName),
             Ok(s) => unsafe { self.subject_with_nul_unchecked(s.as_bytes_with_nul()) },
         }
     }
 
-    pub fn subject_with_nul(&mut self, subject: &str) -> ::Result<&mut Self> {
+    pub fn subject_with_nul(&mut self, subject: &str) -> Result<&mut Self> {
         if subject.as_bytes().iter().any(|&c| c == 0) {
             unsafe { self.subject_with_nul_unchecked(subject.as_bytes()) }
         } else {
-            Err(::Error::X509InvalidName)
+            Err(Error::X509InvalidName)
         }
     }
 
-    unsafe fn issuer_with_nul_unchecked(&mut self, issuer: &[u8]) -> ::Result<&mut Self> {
-        try!(
-            x509write_crt_set_issuer_name(&mut self.inner, issuer.as_ptr() as *const _)
-                .into_result()
-        );
+    unsafe fn issuer_with_nul_unchecked(&mut self, issuer: &[u8]) -> Result<&mut Self> {
+        x509write_crt_set_issuer_name(&mut self.inner, issuer.as_ptr() as *const _).into_result()?;
         Ok(self)
     }
 
     #[cfg(feature = "std")]
-    pub fn issuer(&mut self, issuer: &str) -> ::Result<&mut Self> {
+    pub fn issuer(&mut self, issuer: &str) -> Result<&mut Self> {
         match ::std::ffi::CString::new(issuer) {
-            Err(_) => Err(::Error::X509InvalidName),
+            Err(_) => Err(Error::X509InvalidName),
             Ok(s) => unsafe { self.issuer_with_nul_unchecked(s.as_bytes_with_nul()) },
         }
     }
 
-    pub fn issuer_with_nul(&mut self, issuer: &str) -> ::Result<&mut Self> {
+    pub fn issuer_with_nul(&mut self, issuer: &str) -> Result<&mut Self> {
         if issuer.as_bytes().iter().any(|&c| c == 0) {
             unsafe { self.issuer_with_nul_unchecked(issuer.as_bytes()) }
         } else {
-            Err(::Error::X509InvalidName)
+            Err(Error::X509InvalidName)
         }
     }
 
-    pub fn subject_key(&mut self, key: &'a mut ::pk::Pk) -> &mut Self {
+    pub fn subject_key(&mut self, key: &'a mut Pk) -> &mut Self {
         unsafe { x509write_crt_set_subject_key(&mut self.inner, key.into()) };
         self
     }
 
-    pub fn issuer_key(&mut self, key: &'a mut ::pk::Pk) -> &mut Self {
+    pub fn issuer_key(&mut self, key: &'a mut Pk) -> &mut Self {
         unsafe { x509write_crt_set_issuer_key(&mut self.inner, key.into()) };
         self
     }
 
-    pub fn signature_hash(&mut self, md: ::hash::Type) -> &mut Self {
+    pub fn signature_hash(&mut self, md: MdType) -> &mut Self {
         unsafe { x509write_crt_set_md_alg(&mut self.inner, md.into()) };
         self
     }
 
-    pub fn key_usage(&mut self, usage: ::x509::KeyUsage) -> ::Result<&mut Self> {
-        unsafe { try!(x509write_crt_set_key_usage(&mut self.inner, usage.bits()).into_result()) };
+    pub fn key_usage(&mut self, usage: crate::x509::KeyUsage) -> Result<&mut Self> {
+        unsafe { x509write_crt_set_key_usage(&mut self.inner, usage.bits()) }.into_result()?;
         Ok(self)
     }
 
-    pub fn extension(&mut self, oid: &[u8], val: &[u8], critical: bool) -> ::Result<&mut Self> {
+    pub fn extension(&mut self, oid: &[u8], val: &[u8], critical: bool) -> Result<&mut Self> {
         unsafe {
-            try!(x509write_crt_set_extension(
+            x509write_crt_set_extension(
                 &mut self.inner,
                 oid.as_ptr() as *const _,
                 oid.len(),
                 critical as _,
                 val.as_ptr(),
                 val.len()
-            )
-            .into_result())
-        };
+            ) }.into_result()?;
         Ok(self)
     }
 
-    pub fn basic_constraints(&mut self, ca: bool, pathlen: Option<u32>) -> ::Result<&mut Self> {
+    pub fn basic_constraints(&mut self, ca: bool, pathlen: Option<u32>) -> Result<&mut Self> {
         unsafe {
-            try!(x509write_crt_set_basic_constraints(
+            x509write_crt_set_basic_constraints(
                 &mut self.inner,
                 ca as _,
                 pathlen.unwrap_or(0) as _
             )
-            .into_result())
-        };
+        }.into_result()?;
         Ok(self)
     }
 
@@ -506,29 +500,28 @@ impl<'a> Builder<'a> {
         &mut self,
         not_before: super::Time,
         not_after: super::Time,
-    ) -> ::Result<&mut Self> {
+    ) -> Result<&mut Self> {
         unsafe {
-            try!(x509write_crt_set_validity(
+            x509write_crt_set_validity(
                 &mut self.inner,
                 not_before.to_x509_time().as_ptr() as _,
                 not_after.to_x509_time().as_ptr() as _
             )
-            .into_result())
-        };
+        }.into_result()?;
         Ok(self)
     }
 
-    pub fn serial(&mut self, serial: &[u8]) -> ::Result<&mut Self> {
-        let serial = try!(::bignum::Mpi::from_binary(serial));
-        unsafe { try!(x509write_crt_set_serial(&mut self.inner, (&serial).into()).into_result()) };
+    pub fn serial(&mut self, serial: &[u8]) -> Result<&mut Self> {
+        let serial = crate::bignum::Mpi::from_binary(serial)?;
+        unsafe { x509write_crt_set_serial(&mut self.inner, (&serial).into()) }.into_result()?;
         Ok(self)
     }
 
-    pub fn write_der<'buf, F: ::rng::Random>(
+    pub fn write_der<'buf, F: Random>(
         &mut self,
         buf: &'buf mut [u8],
         rng: &mut F,
-    ) -> ::Result<Option<&'buf [u8]>> {
+    ) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             x509write_crt_der(
                 &mut self.inner,
@@ -539,14 +532,14 @@ impl<'a> Builder<'a> {
             )
             .into_result()
         } {
-            Err(::Error::Asn1BufTooSmall) => Ok(None),
+            Err(Error::Asn1BufTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_der_vec<F: ::rng::Random>(&mut self, rng: &mut F) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn write_der_vec<F: Random>(&mut self, rng: &mut F) -> Result<Vec<u8>> {
+        crate::private::alloc_vec_repeat(
             |buf, size| unsafe {
                 x509write_crt_der(&mut self.inner, buf, size, Some(F::call), rng.data_ptr())
             },
@@ -554,11 +547,11 @@ impl<'a> Builder<'a> {
         )
     }
 
-    pub fn write_pem<'buf, F: ::rng::Random>(
+    pub fn write_pem<'buf, F: Random>(
         &mut self,
         buf: &'buf mut [u8],
         rng: &mut F,
-    ) -> ::Result<Option<&'buf [u8]>> {
+    ) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             x509write_crt_der(
                 &mut self.inner,
@@ -569,14 +562,14 @@ impl<'a> Builder<'a> {
             )
             .into_result()
         } {
-            Err(::Error::Base64BufferTooSmall) => Ok(None),
+            Err(Error::Base64BufferTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_pem_string<F: ::rng::Random>(&mut self, rng: &mut F) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn write_pem_string<F: Random>(&mut self, rng: &mut F) -> Result<String> {
+        crate::private::alloc_string_repeat(|buf, size| unsafe {
             match x509write_crt_pem(
                 &mut self.inner,
                 buf as _,
@@ -584,7 +577,7 @@ impl<'a> Builder<'a> {
                 Some(F::call),
                 rng.data_ptr(),
             ) {
-                0 => ::private::cstr_to_slice(buf as _).len() as _,
+                0 => crate::private::cstr_to_slice(buf as _).len() as _,
                 r => r,
             }
         })
@@ -601,7 +594,6 @@ impl<'a> Builder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pk::Pk;
 
     struct Test {
         key1: Pk,
@@ -611,13 +603,13 @@ mod tests {
     impl Test {
         fn new() -> Self {
             Test {
-                key1: Pk::from_private_key(::test_support::keys::PEM_KEY, None).unwrap(),
-                key2: Pk::from_private_key(::test_support::keys::PEM_KEY, None).unwrap(),
+                key1: Pk::from_private_key(crate::test_support::keys::PEM_KEY, None).unwrap(),
+                key2: Pk::from_private_key(crate::test_support::keys::PEM_KEY, None).unwrap(),
             }
         }
 
         fn builder<'a>(&'a mut self) -> Builder<'a> {
-            use x509::Time;
+            use crate::x509::Time;
 
             let mut b = Builder::new();
             b.subject_key(&mut self.key1)
@@ -710,8 +702,8 @@ JS7pkcufTIoN0Yj0SxAWLW711FgB
         let output = t
             .builder()
             .serial(&[5]).unwrap()
-            .signature_hash(::hash::Type::Sha256)
-            .write_der_vec(&mut ::test_support::rand::test_rng())
+            .signature_hash(MdType::Sha256)
+            .write_der_vec(&mut crate::test_support::rand::test_rng())
             .unwrap();
         assert!(output == TEST_DER);
     }
@@ -722,8 +714,8 @@ JS7pkcufTIoN0Yj0SxAWLW711FgB
         let output = t
             .builder()
             .serial(&[5]).unwrap()
-            .signature_hash(::hash::Type::Sha256)
-            .write_pem_string(&mut ::test_support::rand::test_rng())
+            .signature_hash(MdType::Sha256)
+            .write_pem_string(&mut crate::test_support::rand::test_rng())
             .unwrap();
         assert_eq!(output, TEST_PEM);
     }
@@ -758,21 +750,21 @@ cYp0bH/RcPTC0Z+ZaqSWMtfxRrk63MJQF9EXpDCdvQRcTMD9D85DJrMKn8aumq0M
             cert.serial().unwrap(),
             "B6:34:49:2E:69:63:D6:1B:FD:A2:07:BD:20:2F:98:EB"
         );
-        assert_eq!(cert.digest_type(), ::hash::Type::Sha256);
+        assert_eq!(cert.digest_type(), MdType::Sha256);
 
         let pk = cert.public_key();
 
-        assert_eq!(pk.pk_type(), ::pk::Type::Rsa);
+        assert_eq!(pk.pk_type(), crate::pk::Type::Rsa);
         assert_eq!(pk.rsa_public_exponent().unwrap(), 0x10001);
 
         let channel_binding_hash = match cert.digest_type() {
-            ::hash::Type::Md5 | ::hash::Type::Sha1 => ::hash::Type::Sha256,
+            MdType::Md5 | MdType::Sha1 => MdType::Sha256,
             digest => digest,
         };
 
         let mut digest = [0u8; 64];
         let digest_len =
-            ::hash::Md::hash(channel_binding_hash, cert.as_der(), &mut digest).unwrap();
+            crate::hash::Md::hash(channel_binding_hash, cert.as_der(), &mut digest).unwrap();
 
         assert_eq!(
             digest[0..digest_len],

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -12,7 +12,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr;
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use mbedtls_sys::types::raw_types::c_char;
 use mbedtls_sys::*;

--- a/mbedtls/src/x509/crl.rs
+++ b/mbedtls/src/x509/crl.rs
@@ -10,7 +10,7 @@ use core::fmt;
 
 use mbedtls_sys::*;
 
-use error::IntoResult;
+use crate::error::{IntoResult, Result};
 
 define!(
     #[c_ty(x509_crl)]
@@ -22,7 +22,7 @@ define!(
 );
 
 impl Crl {
-    pub fn push_from_der(&mut self, der: &[u8]) -> ::Result<()> {
+    pub fn push_from_der(&mut self, der: &[u8]) -> Result<()> {
         unsafe {
             x509_crl_parse_der(&mut self.inner, der.as_ptr(), der.len())
                 .into_result()
@@ -30,7 +30,7 @@ impl Crl {
         }
     }
 
-    pub fn push_from_pem(&mut self, pem: &[u8]) -> ::Result<()> {
+    pub fn push_from_pem(&mut self, pem: &[u8]) -> Result<()> {
         unsafe {
             x509_crl_parse(&mut self.inner, pem.as_ptr(), pem.len())
                 .into_result()
@@ -41,7 +41,7 @@ impl Crl {
 
 impl fmt::Debug for Crl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match ::private::alloc_string_repeat(|buf, size| unsafe {
+        match crate::private::alloc_string_repeat(|buf, size| unsafe {
             x509_crl_info(buf, size, b"\0".as_ptr() as *const _, &self.inner)
         }) {
             Err(_) => Err(fmt::Error),

--- a/mbedtls/src/x509/csr.rs
+++ b/mbedtls/src/x509/csr.rs
@@ -9,7 +9,7 @@
 use core::fmt;
 
 #[cfg(not(feature = "std"))]
-use alloc_prelude::*;
+use crate::alloc_prelude::*;
 
 use mbedtls_sys::*;
 

--- a/mbedtls/src/x509/csr.rs
+++ b/mbedtls/src/x509/csr.rs
@@ -13,7 +13,11 @@ use alloc_prelude::*;
 
 use mbedtls_sys::*;
 
-use error::IntoResult;
+use crate::private::{alloc_string_repeat, alloc_vec_repeat};
+use crate::error::{Error, IntoResult, Result};
+use crate::pk::Pk;
+use crate::hash::Type as MdType;
+use crate::rng::Random;
 
 define!(
     #[c_ty(x509_csr)]
@@ -24,32 +28,32 @@ define!(
 );
 
 impl Csr {
-    pub fn from_der(der: &[u8]) -> ::Result<Csr> {
+    pub fn from_der(der: &[u8]) -> Result<Csr> {
         let mut ret = Self::init();
-        unsafe { try!(x509_csr_parse_der(&mut ret.inner, der.as_ptr(), der.len()).into_result()) };
+        unsafe { x509_csr_parse_der(&mut ret.inner, der.as_ptr(), der.len()) }.into_result()?;
         Ok(ret)
     }
 
-    pub fn from_pem(pem: &[u8]) -> ::Result<Csr> {
+    pub fn from_pem(pem: &[u8]) -> Result<Csr> {
         let mut ret = Self::init();
-        unsafe { try!(x509_csr_parse(&mut ret.inner, pem.as_ptr(), pem.len()).into_result()) };
+        unsafe { x509_csr_parse(&mut ret.inner, pem.as_ptr(), pem.len()) }.into_result()?;
         Ok(ret)
     }
 
-    pub fn subject(&self) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn subject(&self) -> Result<String> {
+        alloc_string_repeat(|buf, size| unsafe {
             x509_dn_gets(buf, size, &self.inner.subject)
         })
     }
 
-    pub fn subject_raw(&self) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn subject_raw(&self) -> Result<Vec<u8>> {
+        alloc_vec_repeat(
             |buf, size| unsafe { x509_dn_gets(buf as _, size, &self.inner.subject) },
             false,
         )
     }
 
-    pub fn public_key(&self) -> &::pk::Pk {
+    pub fn public_key(&self) -> &Pk {
         unsafe { &*(&self.inner.pk as *const _ as *const _) }
     }
 
@@ -60,7 +64,7 @@ impl Csr {
 
 impl fmt::Debug for Csr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match ::private::alloc_string_repeat(|buf, size| unsafe {
+        match alloc_string_repeat(|buf, size| unsafe {
             x509_csr_info(buf, size, b"\0".as_ptr() as *const _, &self.inner)
         }) {
             Err(_) => Err(fmt::Error),
@@ -77,72 +81,66 @@ define!(
 );
 
 impl<'a> Builder<'a> {
-    unsafe fn subject_with_nul_unchecked(&mut self, subject: &[u8]) -> ::Result<&mut Self> {
-        try!(
-            x509write_csr_set_subject_name(&mut self.inner, subject.as_ptr() as *const _)
-                .into_result()
-        );
+    unsafe fn subject_with_nul_unchecked(&mut self, subject: &[u8]) -> Result<&mut Self> {
+        x509write_csr_set_subject_name(&mut self.inner, subject.as_ptr() as *const _).into_result()?;
         Ok(self)
     }
 
     #[cfg(feature = "std")]
-    pub fn subject(&mut self, subject: &str) -> ::Result<&mut Self> {
+    pub fn subject(&mut self, subject: &str) -> Result<&mut Self> {
         match ::std::ffi::CString::new(subject) {
-            Err(_) => Err(::Error::X509InvalidName),
+            Err(_) => Err(Error::X509InvalidName),
             Ok(s) => unsafe { self.subject_with_nul_unchecked(s.as_bytes_with_nul()) },
         }
     }
 
-    pub fn subject_with_nul(&mut self, subject: &str) -> ::Result<&mut Self> {
+    pub fn subject_with_nul(&mut self, subject: &str) -> Result<&mut Self> {
         if subject.as_bytes().iter().any(|&c| c == 0) {
             unsafe { self.subject_with_nul_unchecked(subject.as_bytes()) }
         } else {
-            Err(::Error::X509InvalidName)
+            Err(Error::X509InvalidName)
         }
     }
 
-    pub fn key(&mut self, key: &'a mut ::pk::Pk) -> &mut Self {
+    pub fn key(&mut self, key: &'a mut Pk) -> &mut Self {
         unsafe { x509write_csr_set_key(&mut self.inner, key.into()) };
         self
     }
 
-    pub fn signature_hash(&mut self, md: ::hash::Type) -> &mut Self {
+    pub fn signature_hash(&mut self, md: MdType) -> &mut Self {
         unsafe { x509write_csr_set_md_alg(&mut self.inner, md.into()) };
         self
     }
 
-    pub fn key_usage(&mut self, usage: ::x509::KeyUsage) -> ::Result<&mut Self> {
+    pub fn key_usage(&mut self, usage: crate::x509::KeyUsage) -> Result<&mut Self> {
         let usage = usage.bits();
         if (usage & !0xfe) != 0 {
             // according to x509write_**crt**_set_key_usage
-            return Err(::Error::X509FeatureUnavailable);
+            return Err(Error::X509FeatureUnavailable);
         }
 
-        unsafe {
-            try!(x509write_csr_set_key_usage(&mut self.inner, (usage & 0xfe) as u8).into_result())
-        };
+        unsafe { x509write_csr_set_key_usage(&mut self.inner, (usage & 0xfe) as u8) }.into_result()?;
         Ok(self)
     }
 
-    pub fn extension(&mut self, oid: &[u8], val: &[u8]) -> ::Result<&mut Self> {
+    pub fn extension(&mut self, oid: &[u8], val: &[u8]) -> Result<&mut Self> {
         unsafe {
-            try!(x509write_csr_set_extension(
+            x509write_csr_set_extension(
                 &mut self.inner,
                 oid.as_ptr() as *const _,
                 oid.len(),
                 val.as_ptr(),
                 val.len()
             )
-            .into_result())
-        };
+        }.into_result()?;
         Ok(self)
     }
 
-    pub fn write_der<'buf, F: ::rng::Random>(
+    pub fn write_der<'buf, F: Random>(
         &mut self,
         buf: &'buf mut [u8],
         rng: &mut F,
-    ) -> ::Result<Option<&'buf [u8]>> {
+    ) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             x509write_csr_der(
                 &mut self.inner,
@@ -153,14 +151,14 @@ impl<'a> Builder<'a> {
             )
             .into_result()
         } {
-            Err(::Error::Asn1BufTooSmall) => Ok(None),
+            Err(Error::Asn1BufTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_der_vec<F: ::rng::Random>(&mut self, rng: &mut F) -> ::Result<Vec<u8>> {
-        ::private::alloc_vec_repeat(
+    pub fn write_der_vec<F: Random>(&mut self, rng: &mut F) -> Result<Vec<u8>> {
+        alloc_vec_repeat(
             |buf, size| unsafe {
                 x509write_csr_der(&mut self.inner, buf, size, Some(F::call), rng.data_ptr())
             },
@@ -168,11 +166,11 @@ impl<'a> Builder<'a> {
         )
     }
 
-    pub fn write_pem<'buf, F: ::rng::Random>(
+    pub fn write_pem<'buf, F: Random>(
         &mut self,
         buf: &'buf mut [u8],
         rng: &mut F,
-    ) -> ::Result<Option<&'buf [u8]>> {
+    ) -> Result<Option<&'buf [u8]>> {
         match unsafe {
             x509write_csr_der(
                 &mut self.inner,
@@ -183,14 +181,14 @@ impl<'a> Builder<'a> {
             )
             .into_result()
         } {
-            Err(::Error::Base64BufferTooSmall) => Ok(None),
+            Err(Error::Base64BufferTooSmall) => Ok(None),
             Err(e) => Err(e),
             Ok(n) => Ok(Some(&buf[buf.len() - (n as usize)..])),
         }
     }
 
-    pub fn write_pem_string<F: ::rng::Random>(&mut self, rng: &mut F) -> ::Result<String> {
-        ::private::alloc_string_repeat(|buf, size| unsafe {
+    pub fn write_pem_string<F: Random>(&mut self, rng: &mut F) -> Result<String> {
+        alloc_string_repeat(|buf, size| unsafe {
             match x509write_csr_pem(
                 &mut self.inner,
                 buf as _,
@@ -198,7 +196,7 @@ impl<'a> Builder<'a> {
                 Some(F::call),
                 rng.data_ptr(),
             ) {
-                0 => ::private::cstr_to_slice(buf as _).len() as _,
+                0 => crate::private::cstr_to_slice(buf as _).len() as _,
                 r => r,
             }
         })
@@ -212,7 +210,6 @@ impl<'a> Builder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pk::Pk;
 
     struct Test {
         key: Pk,
@@ -221,7 +218,7 @@ mod tests {
     impl Test {
         fn new() -> Self {
             Test {
-                key: Pk::from_private_key(::test_support::keys::PEM_KEY, None).unwrap(),
+                key: Pk::from_private_key(crate::test_support::keys::PEM_KEY, None).unwrap(),
             }
         }
 
@@ -299,8 +296,8 @@ S8qlfwzPdie+Prd73sTapfFAUYei0t274xW/b0eWeo20QzI=
         let mut t = Test::new();
         let output = t
             .builder()
-            .signature_hash(::hash::Type::Sha256)
-            .write_der_vec(&mut ::test_support::rand::test_rng())
+            .signature_hash(MdType::Sha256)
+            .write_der_vec(&mut crate::test_support::rand::test_rng())
             .unwrap();
         assert!(output == TEST_DER);
     }
@@ -310,8 +307,8 @@ S8qlfwzPdie+Prd73sTapfFAUYei0t274xW/b0eWeo20QzI=
         let mut t = Test::new();
         let output = t
             .builder()
-            .signature_hash(::hash::Type::Sha256)
-            .write_pem_string(&mut ::test_support::rand::test_rng())
+            .signature_hash(MdType::Sha256)
+            .write_pem_string(&mut crate::test_support::rand::test_rng())
             .unwrap();
         assert_eq!(output, TEST_PEM);
     }

--- a/mbedtls/tests/support/entropy.rs
+++ b/mbedtls/tests/support/entropy.rs
@@ -7,13 +7,13 @@
  * according to those terms. */
 
 #[cfg(all(feature = "std", not(feature = "rdrand")))]
-pub fn entropy_new<'a>() -> ::mbedtls::rng::OsEntropy<'a> {
-    ::mbedtls::rng::OsEntropy::new()
+pub fn entropy_new<'a>() -> crate::mbedtls::rng::OsEntropy<'a> {
+    crate::mbedtls::rng::OsEntropy::new()
 }
 
 #[cfg(feature = "rdrand")]
-pub fn entropy_new() -> ::mbedtls::rng::Rdseed {
-    ::mbedtls::rng::Rdseed
+pub fn entropy_new() -> crate::mbedtls::rng::Rdseed {
+    crate::mbedtls::rng::Rdseed
 }
 
 #[cfg(all(not(feature = "std"), not(feature = "rdrand")))]

--- a/mbedtls/tests/support/rand.rs
+++ b/mbedtls/tests/support/rand.rs
@@ -18,7 +18,7 @@ use self::rand::{Rng, XorShiftRng};
 /// Not cryptographically secure!!! Use for testing only!!!
 pub struct TestRandom(XorShiftRng);
 
-impl ::mbedtls::rng::RngCallback for TestRandom {
+impl crate::mbedtls::rng::RngCallback for TestRandom {
     unsafe extern "C" fn call(p_rng: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         (*(p_rng as *mut TestRandom))
             .0


### PR DESCRIPTION
This only updates `mbedtls` and not `mbedtls-sys` because the bindings get generated to use `::types::...` when they should use `crate::types::...` in 2018. I couldn't figure out a way to fix this. It probably requires upgrading bindgen.