### PR TITLE
Avoid using inline asm for RDSEED/RDRAND

### DIFF
--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -7,7 +7,6 @@
  * according to those terms. */
 
 #![deny(warnings)]
-#![cfg_attr(feature = "rdrand", feature(asm))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(all(not(feature = "std"), not(feature = "core_io")))]

--- a/mbedtls/src/rng/rdrand.rs
+++ b/mbedtls/src/rng/rdrand.rs
@@ -7,8 +7,50 @@
  * according to those terms. */
 
 use core::slice::from_raw_parts_mut;
+
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
+
+// Intel documentation claims that if hardware is working RDRAND will produce output
+// after at most 10 attempts
+const RDRAND_READ_ATTEMPTS : i32 = 10;
+
+// Intel does not document the number of times RDSEED might consecutively fail, but in
+// example code uses 75 as the upper bound.
+const RDSEED_READ_ATTEMPTS : i32 = 75;
+
+fn call_cpu_rng<T: Sized + Copy>(attempts: i32, intrin: unsafe fn(&mut T) -> i32) -> Option<T> {
+    let mut attempts = attempts;
+    while attempts > 0 {
+        let mut out : T = unsafe { std::mem::uninitialized() };
+        let status = unsafe { intrin(&mut out) };
+        if status == 1 {
+            return Some(out);
+        }
+        attempts -= 1;
+    }
+    None
+}
+
+#[cfg(target_arch = "x86_64")]
+fn rdrand() -> Option<u64> {
+    call_cpu_rng(RDRAND_READ_ATTEMPTS, core::arch::x86_64::_rdrand64_step)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn rdseed() -> Option<u64> {
+    call_cpu_rng(RDSEED_READ_ATTEMPTS, core::arch::x86_64::_rdseed64_step)
+}
+
+#[cfg(target_arch = "x86")]
+fn rdrand() -> Option<u32> {
+    call_cpu_rng(RDRAND_READ_ATTEMPTS, core::arch::x86::_rdrand32_step)
+}
+
+#[cfg(target_arch = "x86")]
+fn rdseed() -> Option<u32> {
+    call_cpu_rng(RDSEED_READ_ATTEMPTS, core::arch::x86::_rdseed32_step)
+}
 
 use super::{EntropyCallback, RngCallback};
 
@@ -17,23 +59,19 @@ pub struct Entropy;
 impl EntropyCallback for Entropy {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         let outbuf = from_raw_parts_mut(data, len);
-        for chunk in outbuf.chunks_mut(8) {
-            let ret;
-            let mut retry = 10;
-            asm!("
-1:
-                rdseed $0
-                jc 2f
-                dec $1
-                jnz 1b
-2:
-            ":"=r"(ret),"=r"(retry):"1"(retry)::"volatile");
-            if retry == 0 {
+
+        let stepsize = if cfg!(target_arch = "x86_64") { 8 } else { 4 };
+
+        for chunk in outbuf.chunks_mut(stepsize) {
+            if let Some(val) = rdseed() {
+                let mut buf = [0u8; 8];
+                ::core::ptr::copy_nonoverlapping(&val as *const _ as *const u8, buf.as_mut_ptr(), stepsize);
+                let ptr = &buf[..chunk.len()];
+                chunk.copy_from_slice(ptr);
+            }
+            else {
                 return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
             }
-            let rand = ::core::mem::transmute::<u64, [u8; 8]>(ret);
-            let ptr = &rand[..chunk.len()];
-            chunk.copy_from_slice(ptr);
         }
         0
     }
@@ -48,23 +86,19 @@ pub struct Nrbg;
 impl RngCallback for Nrbg {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         let outbuf = from_raw_parts_mut(data, len);
-        for chunk in outbuf.chunks_mut(8) {
-            let ret;
-            let mut retry = 10;
-            asm!("
-1:
-                rdrand $0
-                jc 2f
-                dec $1
-                jnz 1b
-2:
-            ":"=r"(ret),"=r"(retry):"1"(retry)::"volatile");
-            if retry == 0 {
+
+        let stepsize = if cfg!(target_arch = "x86_64") { 8 } else { 4 };
+
+        for chunk in outbuf.chunks_mut(stepsize) {
+            if let Some(val) = rdrand() {
+                let mut buf = [0u8; 8];
+                ::core::ptr::copy_nonoverlapping(&val as *const _ as *const u8, buf.as_mut_ptr(), stepsize);
+                let ptr = &buf[..chunk.len()];
+                chunk.copy_from_slice(ptr);
+            }
+            else {
                 return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
             }
-            let rand = ::core::mem::transmute::<u64, [u8; 8]>(ret);
-            let ptr = &rand[..chunk.len()];
-            chunk.copy_from_slice(ptr);
         }
         0
     }

--- a/mbedtls/src/rng/rdrand.rs
+++ b/mbedtls/src/rng/rdrand.rs
@@ -13,43 +13,61 @@ use mbedtls_sys::types::size_t;
 
 // Intel documentation claims that if hardware is working RDRAND will produce output
 // after at most 10 attempts
-const RDRAND_READ_ATTEMPTS : i32 = 10;
+const RDRAND_READ_ATTEMPTS: usize = 10;
 
 // Intel does not document the number of times RDSEED might consecutively fail, but in
 // example code uses 75 as the upper bound.
-const RDSEED_READ_ATTEMPTS : i32 = 75;
+const RDSEED_READ_ATTEMPTS: usize = 75;
 
-fn call_cpu_rng<T: Sized + Copy>(attempts: i32, intrin: unsafe fn(&mut T) -> i32) -> Option<T> {
-    let mut attempts = attempts;
-    while attempts > 0 {
-        let mut out : T = unsafe { std::mem::uninitialized() };
+fn call_cpu_rng<T, F>(attempts: usize, intrin: unsafe fn(&mut T) -> i32, cast_to_usize: F) -> Option<usize>
+where
+    T: Sized + Copy + Default,
+    F: FnOnce(T) -> usize,
+{
+    for _ in 0..attempts {
+        let mut out = T::default();
         let status = unsafe { intrin(&mut out) };
         if status == 1 {
-            return Some(out);
+            return Some(cast_to_usize(out));
         }
-        attempts -= 1;
     }
     None
 }
 
 #[cfg(target_arch = "x86_64")]
-fn rdrand() -> Option<u64> {
-    call_cpu_rng(RDRAND_READ_ATTEMPTS, core::arch::x86_64::_rdrand64_step)
+fn rdrand() -> Option<usize> {
+    call_cpu_rng(
+        RDRAND_READ_ATTEMPTS,
+        core::arch::x86_64::_rdrand64_step,
+        |x:u64| -> usize { x as usize }
+    )
 }
 
 #[cfg(target_arch = "x86_64")]
-fn rdseed() -> Option<u64> {
-    call_cpu_rng(RDSEED_READ_ATTEMPTS, core::arch::x86_64::_rdseed64_step)
+fn rdseed() -> Option<usize> {
+    call_cpu_rng(
+        RDSEED_READ_ATTEMPTS,
+        core::arch::x86_64::_rdseed64_step,
+        |x:u64| -> usize { x as usize }
+    )
 }
 
 #[cfg(target_arch = "x86")]
-fn rdrand() -> Option<u32> {
-    call_cpu_rng(RDRAND_READ_ATTEMPTS, core::arch::x86::_rdrand32_step)
+fn rdrand() -> Option<usize> {
+    call_cpu_rng(
+        RDRAND_READ_ATTEMPTS,
+        core::arch::x86::_rdrand32_step,
+        |x:u32| -> usize { x as usize }
+    )
 }
 
 #[cfg(target_arch = "x86")]
-fn rdseed() -> Option<u32> {
-    call_cpu_rng(RDSEED_READ_ATTEMPTS, core::arch::x86::_rdseed32_step)
+fn rdseed() -> Option<usize> {
+    call_cpu_rng(
+        RDSEED_READ_ATTEMPTS,
+        core::arch::x86::_rdseed32_step,
+        |x:u32| -> usize { x as usize }
+    )
 }
 
 use super::{EntropyCallback, RngCallback};
@@ -60,16 +78,14 @@ impl EntropyCallback for Entropy {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         let outbuf = from_raw_parts_mut(data, len);
 
-        let stepsize = if cfg!(target_arch = "x86_64") { 8 } else { 4 };
+        let stepsize = core::mem::size_of::<usize>();
 
         for chunk in outbuf.chunks_mut(stepsize) {
             if let Some(val) = rdseed() {
-                let mut buf = [0u8; 8];
-                ::core::ptr::copy_nonoverlapping(&val as *const _ as *const u8, buf.as_mut_ptr(), stepsize);
+                let buf = val.to_ne_bytes();
                 let ptr = &buf[..chunk.len()];
                 chunk.copy_from_slice(ptr);
-            }
-            else {
+            } else {
                 return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
             }
         }
@@ -87,16 +103,14 @@ impl RngCallback for Nrbg {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         let outbuf = from_raw_parts_mut(data, len);
 
-        let stepsize = if cfg!(target_arch = "x86_64") { 8 } else { 4 };
+        let stepsize = core::mem::size_of::<usize>();
 
         for chunk in outbuf.chunks_mut(stepsize) {
             if let Some(val) = rdrand() {
-                let mut buf = [0u8; 8];
-                ::core::ptr::copy_nonoverlapping(&val as *const _ as *const u8, buf.as_mut_ptr(), stepsize);
+                let buf = val.to_ne_bytes();
                 let ptr = &buf[..chunk.len()];
                 chunk.copy_from_slice(ptr);
-            }
-            else {
+            } else {
                 return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
             }
         }

--- a/mbedtls/src/rng/rdrand.rs
+++ b/mbedtls/src/rng/rdrand.rs
@@ -11,6 +11,11 @@ use core::slice::from_raw_parts_mut;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86_64::{_rdrand32_step as _rdrand_step, _rdseed32_step as _rdseed_step};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{_rdrand64_step as _rdrand_step, _rdseed64_step as _rdseed_step};
+
 // Intel documentation claims that if hardware is working RDRAND will produce output
 // after at most 10 attempts
 const RDRAND_READ_ATTEMPTS: usize = 10;
@@ -19,55 +24,44 @@ const RDRAND_READ_ATTEMPTS: usize = 10;
 // example code uses 75 as the upper bound.
 const RDSEED_READ_ATTEMPTS: usize = 75;
 
-fn call_cpu_rng<T, F>(attempts: usize, intrin: unsafe fn(&mut T) -> i32, cast_to_usize: F) -> Option<usize>
+fn call_cpu_rng<T, F>(attempts: usize, intrin: unsafe fn(&mut T) -> i32, cast: F) -> Option<usize>
 where
-    T: Sized + Copy + Default,
+    T: Sized + Default,
     F: FnOnce(T) -> usize,
 {
+    assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<usize>());
+
     for _ in 0..attempts {
         let mut out = T::default();
         let status = unsafe { intrin(&mut out) };
         if status == 1 {
-            return Some(cast_to_usize(out));
+            return Some(cast(out));
         }
     }
     None
 }
 
-#[cfg(target_arch = "x86_64")]
 fn rdrand() -> Option<usize> {
-    call_cpu_rng(
-        RDRAND_READ_ATTEMPTS,
-        core::arch::x86_64::_rdrand64_step,
-        |x:u64| -> usize { x as usize }
-    )
+    call_cpu_rng(RDRAND_READ_ATTEMPTS, _rdrand_step, |x| x as usize)
 }
 
-#[cfg(target_arch = "x86_64")]
 fn rdseed() -> Option<usize> {
-    call_cpu_rng(
-        RDSEED_READ_ATTEMPTS,
-        core::arch::x86_64::_rdseed64_step,
-        |x:u64| -> usize { x as usize }
-    )
+    call_cpu_rng(RDSEED_READ_ATTEMPTS, _rdseed_step, |x| x as usize)
 }
 
-#[cfg(target_arch = "x86")]
-fn rdrand() -> Option<usize> {
-    call_cpu_rng(
-        RDRAND_READ_ATTEMPTS,
-        core::arch::x86::_rdrand32_step,
-        |x:u32| -> usize { x as usize }
-    )
-}
+fn write_rng_to_slice(outbuf: &mut [u8], rng: fn() -> Option<usize>) -> c_int {
+    let stepsize = core::mem::size_of::<usize>();
 
-#[cfg(target_arch = "x86")]
-fn rdseed() -> Option<usize> {
-    call_cpu_rng(
-        RDSEED_READ_ATTEMPTS,
-        core::arch::x86::_rdseed32_step,
-        |x:u32| -> usize { x as usize }
-    )
+    for chunk in outbuf.chunks_mut(stepsize) {
+        if let Some(val) = rng() {
+            let buf = val.to_ne_bytes();
+            let ptr = &buf[..chunk.len()];
+            chunk.copy_from_slice(ptr);
+        } else {
+            return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
+        }
+    }
+    0
 }
 
 use super::{EntropyCallback, RngCallback};
@@ -76,20 +70,8 @@ pub struct Entropy;
 
 impl EntropyCallback for Entropy {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
-        let outbuf = from_raw_parts_mut(data, len);
-
-        let stepsize = core::mem::size_of::<usize>();
-
-        for chunk in outbuf.chunks_mut(stepsize) {
-            if let Some(val) = rdseed() {
-                let buf = val.to_ne_bytes();
-                let ptr = &buf[..chunk.len()];
-                chunk.copy_from_slice(ptr);
-            } else {
-                return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
-            }
-        }
-        0
+        let mut outbuf = from_raw_parts_mut(data, len);
+        write_rng_to_slice(&mut outbuf, rdseed)
     }
 
     fn data_ptr(&mut self) -> *mut c_void {
@@ -101,20 +83,8 @@ pub struct Nrbg;
 
 impl RngCallback for Nrbg {
     unsafe extern "C" fn call(_: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
-        let outbuf = from_raw_parts_mut(data, len);
-
-        let stepsize = core::mem::size_of::<usize>();
-
-        for chunk in outbuf.chunks_mut(stepsize) {
-            if let Some(val) = rdrand() {
-                let buf = val.to_ne_bytes();
-                let ptr = &buf[..chunk.len()];
-                chunk.copy_from_slice(ptr);
-            } else {
-                return ::mbedtls_sys::ERR_ENTROPY_SOURCE_FAILED;
-            }
-        }
-        0
+        let mut outbuf = from_raw_parts_mut(data, len);
+        write_rng_to_slice(&mut outbuf, rdrand)
     }
 
     fn data_ptr(&mut self) -> *mut c_void {


### PR DESCRIPTION
This also allows the RDRAND/RDSEED code to work correctly in 32-bit mode.