### PR TITLE
update bitflags and remove mem::uninitialized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ script:
   - rustup toolchain add nightly
   - rustup target add --toolchain nightly x86_64-fortanix-unknown-sgx
   - ./ct.sh
-cache: cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "block-cipher-trait"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,7 +205,7 @@ dependencies = [
 name = "mbedtls"
 version = "0.4.0"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -541,6 +546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bindgen 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb3928f5b6694e40942ad191fc7e23052d0df5d2fe0600f582ac2e766e817f4"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://docs.rs/mbedtls/"
 keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
-bitflags = "0.7.0"
+bitflags = "1"
 core_io = { version = "0.1", features = ["collections"], optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -496,21 +496,20 @@ impl Pk {
         plain: &mut [u8],
         rng: &mut F,
     ) -> Result<usize> {
-        let mut ret;
-        unsafe {
-            ret = ::core::mem::uninitialized();
+        let mut ret = ::core::mem::MaybeUninit::uninit();
+        let ret = unsafe {
             pk_decrypt(
                 &mut self.inner,
                 cipher.as_ptr(),
                 cipher.len(),
                 plain.as_mut_ptr(),
-                &mut ret,
+                ret.as_mut_ptr(),
                 plain.len(),
                 Some(F::call),
                 rng.data_ptr(),
-            )
-            .into_result()?;
-        }
+            ).into_result()?;
+            ret.assume_init()
+        };
         Ok(ret)
     }
 
@@ -520,21 +519,20 @@ impl Pk {
         cipher: &mut [u8],
         rng: &mut F,
     ) -> Result<usize> {
-        let mut ret;
-        unsafe {
-            ret = ::core::mem::uninitialized();
+        let mut ret = ::core::mem::MaybeUninit::uninit();
+        let ret = unsafe {
             pk_encrypt(
                 &mut self.inner,
                 plain.as_ptr(),
                 plain.len(),
                 cipher.as_mut_ptr(),
-                &mut ret,
+                ret.as_mut_ptr(),
                 cipher.len(),
                 Some(F::call),
                 rng.data_ptr(),
-            )
-            .into_result()?;
-        }
+            ).into_result()?;
+            ret.assume_init()
+        };
         Ok(ret)
     }
 
@@ -555,7 +553,6 @@ impl Pk {
         sig: &mut [u8],
         rng: &mut F,
     ) -> Result<usize> {
-        let mut ret;
         match self.pk_type() {
             Type::Rsa | Type::RsaAlt | Type::RsassaPss => {
                 if sig.len() < (self.len() / 8) {
@@ -569,20 +566,20 @@ impl Pk {
             }
             _ => return Err(Error::PkSigLenMismatch),
         }
-        unsafe {
-            ret = ::core::mem::uninitialized();
+        let mut ret = ::core::mem::MaybeUninit::uninit();
+        let ret = unsafe {
             pk_sign(
                 &mut self.inner,
                 md.into(),
                 hash.as_ptr(),
                 hash.len(),
                 sig.as_mut_ptr(),
-                &mut ret,
+                ret.as_mut_ptr(),
                 Some(F::call),
                 rng.data_ptr(),
-            )
-            .into_result()?;
-        }
+            ).into_result()?;
+            ret.assume_init()
+        };
         Ok(ret)
     }
 
@@ -606,21 +603,20 @@ impl Pk {
 
             let mut rng = Rfc6979Rng::new(md, &q, &x, hash, &random_seed)?;
 
-            let mut ret;
-            unsafe {
-                ret = ::core::mem::uninitialized();
+            let mut ret = ::core::mem::MaybeUninit::uninit();
+            let ret = unsafe {
                 pk_sign(
                     &mut self.inner,
                     md.into(),
                     hash.as_ptr(),
                     hash.len(),
                     sig.as_mut_ptr(),
-                    &mut ret,
+                    ret.as_mut_ptr(),
                     Some(Rfc6979Rng::call),
                     rng.data_ptr(),
-                )
-                .into_result()?;
-            }
+                ).into_result()?;
+                ret.assume_init()
+            };
             Ok(ret)
         } else if self.pk_type() == Type::Rsa {
             // Reject sign_deterministic being use for PSS

--- a/mbedtls/src/rng/ctr_drbg.rs
+++ b/mbedtls/src/rng/ctr_drbg.rs
@@ -54,10 +54,10 @@ mod private {
 
     impl<'entropy> CtrDrbgInner<'entropy> {
         pub(super) fn init() -> Self {
-            let mut inner;
-            unsafe {
-                inner = ::core::mem::uninitialized();
-                ctr_drbg_init(&mut inner)
+            let mut inner = ::core::mem::MaybeUninit::uninit();
+            let inner = unsafe {
+                ctr_drbg_init(inner.as_mut_ptr());
+                inner.assume_init()
             };
             CtrDrbgInner {
                 inner,

--- a/mbedtls/src/wrapper_macros.rs
+++ b/mbedtls/src/wrapper_macros.rs
@@ -150,10 +150,10 @@ macro_rules! define_struct {
         #[allow(dead_code)]
         impl<$($l)*> $name<$($l)*> {
             $($vis)* fn $new() -> Self {
-                let mut inner;
-                unsafe{
-                    inner=::core::mem::uninitialized();
-                    ::mbedtls_sys::$ctor(&mut inner)
+                let mut inner = ::core::mem::MaybeUninit::uninit();
+                let inner = unsafe {
+                    ::mbedtls_sys::$ctor(inner.as_mut_ptr());
+                    inner.assume_init()
                 };
                 $name{
                     inner:inner,

--- a/mbedtls/src/x509/mod.rs
+++ b/mbedtls/src/x509/mod.rs
@@ -22,69 +22,60 @@ pub use self::csr::Csr;
 #[doc(inline)]
 pub use self::profile::Profile;
 
-pub mod key_usage {
-    use mbedtls_sys::types::raw_types::c_uint;
-    use mbedtls_sys::*;
-
-    bitflags! {
-        pub flags KeyUsage: c_uint {
-            const DIGITAL_SIGNATURE  = X509_KU_DIGITAL_SIGNATURE as c_uint,
-            const NON_REPUDIATION    = X509_KU_NON_REPUDIATION as c_uint,
-            const KEY_ENCIPHERMENT   = X509_KU_KEY_ENCIPHERMENT as c_uint,
-            const DATA_ENCIPHERMENT  = X509_KU_DATA_ENCIPHERMENT as c_uint,
-            const KEY_AGREEMENT      = X509_KU_KEY_AGREEMENT as c_uint,
-            const KEY_CERT_SIGN      = X509_KU_KEY_CERT_SIGN as c_uint,
-            const CRL_SIGN           = X509_KU_CRL_SIGN as c_uint,
-            const ENCIPHER_ONLY      = X509_KU_ENCIPHER_ONLY as c_uint,
-            const DECIPHER_ONLY      = X509_KU_DECIPHER_ONLY as c_uint,
-        }
+use mbedtls_sys::*;
+use mbedtls_sys::types::raw_types::c_uint;
+bitflags! {
+    #[doc(inline)]
+    pub struct KeyUsage: c_uint {
+        const DIGITAL_SIGNATURE  = X509_KU_DIGITAL_SIGNATURE as c_uint;
+        const NON_REPUDIATION    = X509_KU_NON_REPUDIATION as c_uint;
+        const KEY_ENCIPHERMENT   = X509_KU_KEY_ENCIPHERMENT as c_uint;
+        const DATA_ENCIPHERMENT  = X509_KU_DATA_ENCIPHERMENT as c_uint;
+        const KEY_AGREEMENT      = X509_KU_KEY_AGREEMENT as c_uint;
+        const KEY_CERT_SIGN      = X509_KU_KEY_CERT_SIGN as c_uint;
+        const CRL_SIGN           = X509_KU_CRL_SIGN as c_uint;
+        const ENCIPHER_ONLY      = X509_KU_ENCIPHER_ONLY as c_uint;
+        const DECIPHER_ONLY      = X509_KU_DECIPHER_ONLY as c_uint;
     }
 }
-#[doc(inline)]
-pub use self::key_usage::KeyUsage;
 
-pub mod verify_error {
-    use mbedtls_sys::*;
-
-    bitflags! {
-        pub flags VerifyError: u32 {
-            const CERT_BAD_KEY       = X509_BADCERT_BAD_KEY as u32,
-            const CERT_BAD_MD        = X509_BADCERT_BAD_MD as u32,
-            const CERT_BAD_PK        = X509_BADCERT_BAD_PK as u32,
-            const CERT_CN_MISMATCH   = X509_BADCERT_CN_MISMATCH as u32,
-            const CERT_EXPIRED       = X509_BADCERT_EXPIRED as u32,
-            const CERT_EXT_KEY_USAGE = X509_BADCERT_EXT_KEY_USAGE as u32,
-            const CERT_FUTURE        = X509_BADCERT_FUTURE as u32,
-            const CERT_KEY_USAGE     = X509_BADCERT_KEY_USAGE as u32,
-            const CERT_MISSING       = X509_BADCERT_MISSING as u32,
-            const CERT_NOT_TRUSTED   = X509_BADCERT_NOT_TRUSTED as u32,
-            const CERT_NS_CERT_TYPE  = X509_BADCERT_NS_CERT_TYPE as u32,
-            const CERT_OTHER         = X509_BADCERT_OTHER as u32,
-            const CERT_REVOKED       = X509_BADCERT_REVOKED as u32,
-            const CERT_SKIP_VERIFY   = X509_BADCERT_SKIP_VERIFY as u32,
-            const CRL_BAD_KEY        = X509_BADCRL_BAD_KEY as u32,
-            const CRL_BAD_MD         = X509_BADCRL_BAD_MD as u32,
-            const CRL_BAD_PK         = X509_BADCRL_BAD_PK as u32,
-            const CRL_EXPIRED        = X509_BADCRL_EXPIRED as u32,
-            const CRL_FUTURE         = X509_BADCRL_FUTURE as u32,
-            const CRL_NOT_TRUSTED    = X509_BADCRL_NOT_TRUSTED as u32,
-            const CUSTOM_BIT_20      = 0x10_0000,
-            const CUSTOM_BIT_21      = 0x20_0000,
-            const CUSTOM_BIT_22      = 0x40_0000,
-            const CUSTOM_BIT_23      = 0x80_0000,
-            const CUSTOM_BIT_24      = 0x100_0000,
-            const CUSTOM_BIT_25      = 0x200_0000,
-            const CUSTOM_BIT_26      = 0x400_0000,
-            const CUSTOM_BIT_27      = 0x800_0000,
-            const CUSTOM_BIT_28      = 0x1000_0000,
-            const CUSTOM_BIT_29      = 0x2000_0000,
-            const CUSTOM_BIT_30      = 0x4000_0000,
-            const CUSTOM_BIT_31      = 0x8000_0000,
-        }
+bitflags! {
+    #[doc(inline)]
+    pub struct VerifyError: u32 {
+        const CERT_BAD_KEY       = X509_BADCERT_BAD_KEY as u32;
+        const CERT_BAD_MD        = X509_BADCERT_BAD_MD as u32;
+        const CERT_BAD_PK        = X509_BADCERT_BAD_PK as u32;
+        const CERT_CN_MISMATCH   = X509_BADCERT_CN_MISMATCH as u32;
+        const CERT_EXPIRED       = X509_BADCERT_EXPIRED as u32;
+        const CERT_EXT_KEY_USAGE = X509_BADCERT_EXT_KEY_USAGE as u32;
+        const CERT_FUTURE        = X509_BADCERT_FUTURE as u32;
+        const CERT_KEY_USAGE     = X509_BADCERT_KEY_USAGE as u32;
+        const CERT_MISSING       = X509_BADCERT_MISSING as u32;
+        const CERT_NOT_TRUSTED   = X509_BADCERT_NOT_TRUSTED as u32;
+        const CERT_NS_CERT_TYPE  = X509_BADCERT_NS_CERT_TYPE as u32;
+        const CERT_OTHER         = X509_BADCERT_OTHER as u32;
+        const CERT_REVOKED       = X509_BADCERT_REVOKED as u32;
+        const CERT_SKIP_VERIFY   = X509_BADCERT_SKIP_VERIFY as u32;
+        const CRL_BAD_KEY        = X509_BADCRL_BAD_KEY as u32;
+        const CRL_BAD_MD         = X509_BADCRL_BAD_MD as u32;
+        const CRL_BAD_PK         = X509_BADCRL_BAD_PK as u32;
+        const CRL_EXPIRED        = X509_BADCRL_EXPIRED as u32;
+        const CRL_FUTURE         = X509_BADCRL_FUTURE as u32;
+        const CRL_NOT_TRUSTED    = X509_BADCRL_NOT_TRUSTED as u32;
+        const CUSTOM_BIT_20      = 0x10_0000;
+        const CUSTOM_BIT_21      = 0x20_0000;
+        const CUSTOM_BIT_22      = 0x40_0000;
+        const CUSTOM_BIT_23      = 0x80_0000;
+        const CUSTOM_BIT_24      = 0x100_0000;
+        const CUSTOM_BIT_25      = 0x200_0000;
+        const CUSTOM_BIT_26      = 0x400_0000;
+        const CUSTOM_BIT_27      = 0x800_0000;
+        const CUSTOM_BIT_28      = 0x1000_0000;
+        const CUSTOM_BIT_29      = 0x2000_0000;
+        const CUSTOM_BIT_30      = 0x4000_0000;
+        const CUSTOM_BIT_31      = 0x8000_0000;
     }
 }
-#[doc(inline)]
-pub use self::verify_error::VerifyError;
 
 /// A specific moment in time in UTC
 pub struct Time {

--- a/mbedtls/tests/ssl_conf_verify.rs
+++ b/mbedtls/tests/ssl_conf_verify.rs
@@ -16,7 +16,7 @@ use mbedtls::pk::Pk;
 use mbedtls::rng::CtrDrbg;
 use mbedtls::ssl::config::{Endpoint, Preset, Transport};
 use mbedtls::ssl::{Config, Context};
-use mbedtls::x509::{verify_error, Certificate, LinkedCertificate, VerifyError};
+use mbedtls::x509::{Certificate, LinkedCertificate, VerifyError};
 use mbedtls::Error;
 use mbedtls::Result as TlsResult;
 
@@ -37,7 +37,7 @@ fn client(mut conn: TcpStream, test: Test) -> TlsResult<()> {
     let verify_callback =
         &mut |_: &mut LinkedCertificate, _, verify_flags: &mut VerifyError| match test {
             Test::CallbackSetVerifyFlags => {
-                *verify_flags |= verify_error::CERT_OTHER;
+                *verify_flags |= VerifyError::CERT_OTHER;
                 Ok(())
             }
             Test::CallbackError => Err(Error::Asn1InvalidData),


### PR DESCRIPTION
As the title says, solves deprecation warning associated with those two issues. Probably worth making an issue or otherwise noting that a better strategy around `MaybeUninit` is required.

This is also required to get CI passing again