### PR TITLE
Add ability to read arbitrary certificate extensions

### DIFF
--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -25,7 +25,7 @@ spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
 byteorder = "1.0.0"
-yasna = { version = "0.2", optional = true }
+yasna = "0.2"
 block-modes = { version = "0.3", optional = true }
 rc2 = { version = "0.3", optional = true }
 
@@ -66,7 +66,7 @@ zlib = ["mbedtls-sys-auto/zlib"]
 time = ["mbedtls-sys-auto/time"]
 padlock = ["mbedtls-sys-auto/padlock"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
-pkcs12 = ["yasna"]
+pkcs12 = []
 pkcs12_rc2 = ["pkcs12", "rc2", "block-modes"]
 
 [[example]]

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -38,9 +38,6 @@ extern crate rs_libc;
 #[macro_use]
 mod wrapper_macros;
 
-#[cfg(feature = "pkcs12")]
-extern crate yasna;
-
 #[cfg(feature="pkcs12_rc2")]
 extern crate rc2;
 #[cfg(feature="pkcs12_rc2")]

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -26,6 +26,8 @@ extern crate mbedtls_sys;
 
 extern crate byteorder;
 
+extern crate yasna;
+
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -19,8 +19,6 @@ use crate::alloc_prelude::*;
 
 use core::result::Result as StdResult;
 
-extern crate yasna;
-
 #[cfg(feature = "pkcs12_rc2")]
 extern crate block_modes;
 #[cfg(feature = "pkcs12_rc2")]


### PR DESCRIPTION
mbedtls ignores extensions it doesn't know about, but the entire DER buffer is available in the v3_ext field so we can parse it ourselves to f.ex read the appid out of our custom extensions.