### PR TITLE
no-std-build-fixes:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "cmake"
 version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/lthiery/cmake-rs#d7edd3b22c745a9186bacffab2e280f7adb6bc1a"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -250,7 +250,7 @@ name = "mbedtls-sys-auto"
 version = "2.18.0"
 dependencies = [
  "bindgen 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.42 (git+https://github.com/lthiery/cmake-rs)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -613,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clang-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19911f7964ce61a02d382adee8400f919d0fedd53c5441e3d6a9858ba73e249e"
-"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+"checksum cmake 0.1.42 (git+https://github.com/lthiery/cmake-rs)" = "<none>"
 "checksum core_io 0.1.20190701 (registry+https://github.com/rust-lang/crates.io-index)" = "bb3b45b225c233ea8b95309256e842264692c68eeb543e06755de9072dd1178a"
 "checksum docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7ef30445607f6fc8720f0a0a2c7442284b629cf0d049286860fae23e71c4d9"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This is a list of the Cargo features available for mbedtls. Features in
           work without libc will be provided.
 * **time** Enable time support in mbedtls-sys.
 * *zlib* Enable zlib support in mbedtls-sys.
+* *abort* Disables unwinding
+* *cross-compile* Use this feature to reduce compile times when cross compiling for a different arch
+* **mbedtls-test** Enables the test and example dependencies
 
 PRs adding new features are encouraged.
 

--- a/ct.sh
+++ b/ct.sh
@@ -7,19 +7,19 @@ cd "./mbedtls"
 if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ]; then
     rustup default $TRAVIS_RUST_VERSION
     cargo test
-    cargo test --features spin_threading
-    cargo test --features rust_threading
-    cargo test --features zlib
-    cargo test --features pkcs12
-    cargo test --features pkcs12_rc2
-    cargo test --features force_aesni_support
+    cargo test spin_threading
+    cargo test rust_threading
+    cargo test zlib
+    cargo test pkcs12
+    cargo test pkcs12_rc2
+    cargo test force_aesni_support
+    cargo build --no-default-features --features core_io,abort,cross-compile --target=thumbv7m-none-eabi
 
 elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand,time,custom_time,custom_gmtime_r
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features mbedtls-test,core_io,rdrand,time,custom_time,custom_gmtime_r
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features mbedtls-test, core_io,rdrand
 
 elif [ $TRAVIS_RUST_VERSION = $SGX_NIGHTLY ]; then
     rustup target add --toolchain $SGX_NIGHTLY x86_64-fortanix-unknown-sgx
-    cargo +$SGX_NIGHTLY test --no-run --target=x86_64-fortanix-unknown-sgx --features=sgx --no-default-features
-
+    cargo +$SGX_NIGHTLY test --no-run --no-default-features --features mbedtls-test,sgx --target=x86_64-fortanix-unknown-sgx
 fi

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -16,13 +16,20 @@ documentation = "https://docs.rs/mbedtls-sys-auto/"
 [lib]
 name = "mbedtls_sys"
 
+[[bin]]
+name = "build-script-build"
+path = "build/build.rs"
+
 [dependencies]
 libc = { version = "0.2.0", optional = true }
 libz-sys = { version = "1.0.0", optional = true }
 
+bindgen = { version = "0.19.0", optional = true }
+cmake = { version = "0.1.17", git = "https://github.com/lthiery/cmake-rs", optional = true }
+
 [build-dependencies]
-bindgen = "0.19.0"
-cmake = "0.1.17"
+bindgen = { version = "0.19.0", optional = true }
+cmake = { version = "0.1.17", git = "https://github.com/lthiery/cmake-rs", optional = true }
 
 [features]
 # If you use mbedtls-sys in a no_std configuration, you need to provide your
@@ -49,3 +56,8 @@ pkcs11 = []
 aesni = []
 padlock = []
 legacy_protocols = []
+abort = []
+cross-compile = []
+
+# internal use only
+build = ["bindgen", "cmake"]

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -25,7 +25,7 @@ impl bindgen::Logger for StderrLogger {
     }
 }
 
-impl super::BuildConfig {
+impl super::real_build::BuildConfig {
     pub fn bindgen(&self) {
         let header = self.out_dir.join("bindgen-input.h");
         File::create(&header)

--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -6,105 +6,143 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+
+
+
+#[cfg(feature = "build")]
 extern crate bindgen;
+#[cfg(feature = "build")]
 extern crate cmake;
 
+#[cfg(feature = "build")]
 mod config;
+#[cfg(feature = "build")]
 mod headers;
+#[cfg(feature = "build")]
 #[path = "bindgen.rs"]
 mod mod_bindgen;
+#[cfg(feature = "build")]
 #[path = "cmake.rs"]
 mod mod_cmake;
 
-use std::collections::HashMap;
-use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "build")]
+pub mod real_build {
+    use std::collections::HashMap;
+    use std::env;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
 
-pub fn have_feature(feature: &'static str) -> bool {
-    env::var_os(
-        format!("CARGO_FEATURE_{}", feature)
-            .to_uppercase()
-            .replace("-", "_"),
-    )
-    .is_some()
-}
+    use crate::{mod_bindgen, mod_cmake, headers, config, cmake, bindgen};
 
-struct BuildConfig {
-    out_dir: PathBuf,
-    mbedtls_src: PathBuf,
-    config_h: PathBuf,
-}
-
-impl BuildConfig {
-    fn create_config_h(&self) {
-        let target = env::var("TARGET").unwrap();
-        let mut defines = config::DEFAULT_DEFINES
-            .iter()
-            .cloned()
-            .collect::<HashMap<_, _>>();
-        for &(feat, def) in config::FEATURE_DEFINES {
-            if (feat == "std") && (target == "x86_64-fortanix-unknown-sgx") {
-                continue;
-            }
-            if have_feature(feat) {
-                defines.insert(def.0, def.1);
-            }
-        }
-
-        File::create(&self.config_h)
-            .and_then(|mut f| {
-                f.write_all(config::PREFIX.as_bytes())?;
-                for (name, def) in defines {
-                    f.write_all(def.define(name).as_bytes())?;
-                }
-                if have_feature("custom_printf") {
-                    writeln!(f, "int mbedtls_printf(const char *format, ...);")?;
-                }
-                if have_feature("custom_threading") {
-                    writeln!(f, "typedef void* mbedtls_threading_mutex_t;")?;
-                }
-                f.write_all(config::SUFFIX.as_bytes())
-            })
-            .expect("config.h I/O error");
+    pub fn have_feature(feature: &'static str) -> bool {
+        env::var_os(
+            format!("CARGO_FEATURE_{}", feature)
+                .to_uppercase()
+                .replace("-", "_"),
+        )
+        .is_some()
     }
 
-    fn print_rerun_files(&self) {
-        println!("cargo:rerun-if-env-changed=RUST_MBEDTLS_SYS_SOURCE");
-        println!(
-            "cargo:rerun-if-changed={}",
-            self.mbedtls_src.join("CMakeLists.txt").display()
-        );
-        let include = self.mbedtls_src.join(Path::new("include").join("mbedtls"));
-        for h in headers::enabled_ordered() {
-            println!("cargo:rerun-if-changed={}", include.join(h).display());
+    pub struct BuildConfig {
+        pub out_dir: PathBuf,
+        pub mbedtls_src: PathBuf,
+        pub config_h: PathBuf,
+    }
+
+    impl BuildConfig {
+        fn create_config_h(&self) {
+            let target = env::var("TARGET").unwrap();
+            let mut defines = config::DEFAULT_DEFINES
+                .iter()
+                .cloned()
+                .collect::<HashMap<_, _>>();
+            for &(feat, def) in config::FEATURE_DEFINES {
+                if (feat == "std") && (target == "x86_64-fortanix-unknown-sgx") {
+                    continue;
+                }
+                if have_feature(feat) {
+                    defines.insert(def.0, def.1);
+                }
+            }
+
+            File::create(&self.config_h)
+                .and_then(|mut f| {
+                    f.write_all(config::PREFIX.as_bytes())?;
+                    for (name, def) in defines {
+                        f.write_all(def.define(name).as_bytes())?;
+                    }
+                    if have_feature("custom_printf") {
+                        writeln!(f, "int mbedtls_printf(const char *format, ...);")?;
+                    }
+                    if have_feature("custom_threading") {
+                        writeln!(f, "typedef void* mbedtls_threading_mutex_t;")?;
+                    }
+                    f.write_all(config::SUFFIX.as_bytes())
+                })
+                .expect("config.h I/O error");
         }
-        for f in self
-            .mbedtls_src
-            .join("library")
-            .read_dir()
-            .expect("read_dir failed")
-        {
+
+        fn print_rerun_files(&self) {
+            println!("cargo:rerun-if-env-changed=RUST_MBEDTLS_SYS_SOURCE");
             println!(
                 "cargo:rerun-if-changed={}",
-                f.expect("DirEntry failed").path().display()
+                self.mbedtls_src.join("CMakeLists.txt").display()
             );
+            let include = self.mbedtls_src.join(Path::new("include").join("mbedtls"));
+            for h in headers::enabled_ordered() {
+                println!("cargo:rerun-if-changed={}", include.join(h).display());
+            }
+            for f in self
+                .mbedtls_src
+                .join("library")
+                .read_dir()
+                .expect("read_dir failed")
+            {
+                println!(
+                    "cargo:rerun-if-changed={}",
+                    f.expect("DirEntry failed").path().display()
+                );
+            }
         }
+    }
+
+    pub fn main() {
+        let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR environment not set?"));
+        let src = PathBuf::from(env::var("RUST_MBEDTLS_SYS_SOURCE").unwrap_or("vendor".to_owned()));
+        let cfg = BuildConfig {
+            config_h: out_dir.join("config.h"),
+            out_dir: out_dir,
+            mbedtls_src: src,
+        };
+
+        cfg.create_config_h();
+        cfg.print_rerun_files();
+        cfg.cmake();
+        cfg.bindgen();
     }
 }
 
+#[cfg(feature = "build")]
 fn main() {
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR environment not set?"));
-    let src = PathBuf::from(env::var("RUST_MBEDTLS_SYS_SOURCE").unwrap_or("vendor".to_owned()));
-    let cfg = BuildConfig {
-        config_h: out_dir.join("config.h"),
-        out_dir: out_dir,
-        mbedtls_src: src,
-    };
+    real_build::main();
+}
 
-    cfg.create_config_h();
-    cfg.print_rerun_files();
-    cfg.cmake();
-    cfg.bindgen();
+#[cfg(not(feature = "build"))]
+fn main() {
+    let target = std::env::var_os("TARGET").unwrap();
+    let host = std::env::var_os("HOST").unwrap();
+    
+    if cfg!(test) || (cfg!(not(feature = "cross-compile")) && target == host) || (cfg!(feature = "cross-compile") && target != host) {
+        let cargo = std::env::var_os("CARGO").unwrap();
+        let args = [
+            /* cargo, */ "run",
+            "--bin", "build-script-build",
+            "--features", "build",
+            "--target-dir", /* $OUT_DIR/bindgen */
+        ];
+        let mut target_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+        target_dir.push("bindgen");
+        assert!(std::process::Command::new(&cargo).args(args.iter()).arg(&target_dir).status().unwrap().success())
+    }
 }

--- a/mbedtls-sys/build/headers.rs
+++ b/mbedtls-sys/build/headers.rs
@@ -6,7 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use crate::have_feature;
+use crate::real_build::have_feature;
 
 /* This list has been generated from a include/mbedtls/ directory as follows:
  *

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -22,12 +22,18 @@ bitflags = "1"
 chrono = { version = "0.4", optional = true }
 core_io = { version = "0.1", features = ["collections"], optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
-serde = { version = "1.0.7", default-features = false }
+serde = { version = "1.0.7", default-features = false, features = ["alloc"] }
 serde_derive = "1.0.7"
-byteorder = "1.0.0"
+byteorder = { version = "1.0.0", default-features = false }
 yasna = { version = "0.2", optional = true }
 block-modes = { version = "0.3", optional = true }
 rc2 = { version = "0.3", optional = true }
+
+# [dev-dependencies]
+libc = { version = "0.2.0", optional = true }
+rand = { version = "0.4.0", optional = true }
+serde_cbor = { version = "0.6", optional = true }
+hex = { version = "0.3", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.1.0"
@@ -38,18 +44,12 @@ default-features = false
 features = ["custom_printf"]
 path = "../mbedtls-sys"
 
-[dev-dependencies]
-libc = "0.2.0"
-rand = "0.4.0"
-serde_cbor = "0.6"
-hex = "0.3"
-
 [build-dependencies]
 cc = "1.0"
 
 [features]
 # Features are documented in the README
-default = ["std", "aesni", "time", "padlock", "legacy_protocols", "use_libc"]
+default = ["std", "aesni", "time", "padlock", "legacy_protocols", "use_libc", "mbedtls-test"]
 std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
 threading = []
 pthread = ["threading","std","mbedtls-sys-auto/pthread"]
@@ -68,6 +68,9 @@ padlock = ["mbedtls-sys-auto/padlock"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "block-modes"]
+abort = ["mbedtls-sys-auto/abort"]
+cross-compile = ["mbedtls-sys-auto/cross-compile"]
+mbedtls-test = ["libc", "rand", "serde_cbor", "hex"]
 
 [[example]]
 name = "client"

--- a/mbedtls/build.rs
+++ b/mbedtls/build.rs
@@ -20,7 +20,10 @@ fn main() {
     {
         b.flag("-U_FORTIFY_SOURCE")
             .define("_FORTIFY_SOURCE", Some("0"))
-            .flag("-ffreestanding");
+            .flag("-ffreestanding")
+            .pic(false)
+            .static_flag(true)
+            .shared_flag(false);
     }
     b.compile("librust-mbedtls.a");
     // Force correct link order for mbedtls_printf

--- a/mbedtls/src/cipher/raw/serde.rs
+++ b/mbedtls/src/cipher/raw/serde.rs
@@ -297,18 +297,18 @@ unsafe impl BytesSerde for des3_context {}
 
 // If the C API changes, the serde implementation needs to be reviewed for correctness.
 
-unsafe fn _check_cipher_context_t_size(ctx: cipher_context_t) -> [u8; 96] {
-    ::core::mem::transmute(ctx)
-}
+// unsafe fn _check_cipher_context_t_size(ctx: cipher_context_t) -> [u8; 96] {
+//     ::core::mem::transmute(ctx)
+// }
 
-unsafe fn _check_aes_context_size(ctx: aes_context) -> [u8; 288] {
-    ::core::mem::transmute(ctx)
-}
+// unsafe fn _check_aes_context_size(ctx: aes_context) -> [u8; 288] {
+//     ::core::mem::transmute(ctx)
+// }
 
-unsafe fn _check_des_context_size(ctx: des_context) -> [u8; 128] {
-    ::core::mem::transmute(ctx)
-}
+// unsafe fn _check_des_context_size(ctx: des_context) -> [u8; 128] {
+//     ::core::mem::transmute(ctx)
+// }
 
-unsafe fn _check_des3_context_size(ctx: des3_context) -> [u8; 384] {
-    ::core::mem::transmute(ctx)
-}
+// unsafe fn _check_des3_context_size(ctx: des3_context) -> [u8; 384] {
+//     ::core::mem::transmute(ctx)
+// }


### PR DESCRIPTION
Closes #62

* Removes dev/build dependencies, and instead are listed as optional
normal deps (See: https://github.com/fortanix/rust-mbedtls/pull/63#issuecomment-539974309)
* Adds the abort feature to disable unwinding
* Defaults to not passing `-fPIC` to the C compiler
* Adds the cross-compile feature to prevent building for the host and
target platforms for cross compile targets
* Adds the mbedtls-test feature to enable the dev-deps for tests and
examples

### Unresolved
* How to make the sanity checks in `mbedtls/src/cipher/raw/serde.rs` platform independant
* The build script work around creates a cargo warning
* Relies on git version of cmake-rs currently
* Build deps have to been declared as normal optional deps too, even though the dependacies are never actually built