### PR TITLE
update to bindgen 0.51.0

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = { version = "0.2.0", optional = true }
 libz-sys = { version = "1.0.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.19.0"
+bindgen = "0.51.0"
 cmake = "0.1.17"
 
 [features]

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -6,22 +6,60 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use bindgen;
-
 use std::fs::File;
-use std::io::{stderr, Write};
+use std::io::Write;
+
+use bindgen;
+use bindgen::callbacks::IntKind;
 
 use crate::headers;
 
 #[derive(Debug)]
-struct StderrLogger;
+struct ParseCallback;
 
-impl bindgen::Logger for StderrLogger {
-    fn error(&self, msg: &str) {
-        let _ = writeln!(stderr(), "Bindgen ERROR: {}", msg);
+impl bindgen::callbacks::ParseCallbacks for ParseCallback {
+    fn int_macro(&self, name: &str, _value: i64) -> Option<IntKind> {
+        if name.starts_with("MBEDTLS_") {
+            Some(IntKind::Int)
+        } else {
+            None
+        }
     }
-    fn warn(&self, msg: &str) {
-        let _ = writeln!(stderr(), "Bindgen WARNING: {}", msg);
+    fn enum_variant_name(
+        &self,
+        _enum_name: Option<&str>,
+        original_variant_name: &str,
+        _variant_value: bindgen::callbacks::EnumVariantValue,
+    ) -> Option<String> {
+        if original_variant_name.starts_with("MBEDTLS_") {
+            Some(
+                original_variant_name
+                    .trim_start_matches("MBEDTLS_")
+                    .to_string(),
+            )
+        } else {
+            None
+        }
+    }
+
+    fn item_name(&self, original_item_name: &str) -> Option<String> {
+       if original_item_name.eq("mbedtls_time_t") {
+            None
+        } else if original_item_name.starts_with("mbedtls_") {
+            Some(
+                original_item_name
+                    .trim_start_matches("mbedtls_")
+                    .to_string(),
+            )
+        } else if original_item_name.starts_with("MBEDTLS_") {
+            Some(
+                original_item_name
+                    .trim_start_matches("MBEDTLS_")
+                    .to_string(),
+            )
+        } else {
+            None
+        }
     }
 }
 
@@ -33,49 +71,55 @@ impl super::BuildConfig {
                 Ok(for h in headers::enabled_ordered() {
                     writeln!(f, "#include <mbedtls/{}>", h)?;
                 })
-            }).expect("bindgen-input.h I/O error");
+            })
+            .expect("bindgen-input.h I/O error");
 
         let include = self.mbedtls_src.join("include");
 
-        let logger = StderrLogger;
-        let mut bindgen = bindgen::Builder::new(header.into_os_string().into_string().unwrap());
-        let bindings = bindgen
-            .log(&logger)
-            .clang_arg("-Dmbedtls_t_udbl=mbedtls_t_udbl;") // bindgen can't handle unused uint128
+        let bindings = bindgen::Builder::default()
+            .header(header.into_os_string().into_string().unwrap())
             .clang_arg(format!(
                 "-DMBEDTLS_CONFIG_FILE=<{}>",
                 self.config_h.to_str().expect("config.h UTF-8 error")
-            )).clang_arg(format!(
+            ))
+            .clang_arg(format!(
                 "-I{}",
                 include.to_str().expect("include/ UTF-8 error")
-            )).match_pat(include.to_str().expect("include/ UTF-8 error"))
-            .match_pat(self.config_h.to_str().expect("config.h UTF-8 error"))
-            .use_core(true)
+            ))
+            .use_core()
             .derive_debug(false) // buggy :(
-            .ctypes_prefix(vec!["types".to_owned(), "raw_types".to_owned()])
-            .remove_prefix("mbedtls_")
-            .rust_enums(false)
-            .convert_macros(true)
-            .macro_int_types(
-                vec![
-                    "sint",
-                    "sint",
-                    "sint",
-                    "slonglong",
-                    "sint",
-                    "sint",
-                    "sint",
-                    "slonglong",
-                ].into_iter(),
-            ).generate()
+            .parse_callbacks(Box::new(ParseCallback))
+            .ctypes_prefix("crate::types::raw_types")
+            .blacklist_function("strtold")
+            .blacklist_function("qecvt_r")
+            .blacklist_function("qecvt")
+            .blacklist_function("qfcvt_r")
+            .blacklist_function("qgcvt")
+            .blacklist_function("qfcvt")
+            .opaque_type("std::*")
+            .opaque_type("time_t")
+            .generate_comments(false)
+            .prepend_enum_name(false)
+            .generate()
             .expect("bindgen error");
 
         let bindings_rs = self.out_dir.join("bindings.rs");
         File::create(&bindings_rs)
             .and_then(|mut f| {
+                f.write_all(br#"
+                #![allow(nonstandard_style)]
+                #![allow(unused_imports)]
+                "#)?;
+
                 bindings.write(Box::new(&mut f))?;
-                f.write_all(b"use crate::types::*;\n") // for FILE, time_t, etc.
-            }).expect("bindings.rs I/O error");
+
+                f.write_all(br#"
+                // for FILE, time_t, etc.
+                use crate::types::*;
+                "#)
+
+            })
+            .expect("bindings.rs I/O error");
 
         let mod_bindings = self.out_dir.join("mod-bindings.rs");
         File::create(&mod_bindings)


### PR DESCRIPTION
This patch lets us compile mbedtls-sys with recent clang versions.

~~It still has a hack calling "sed" in it, which fixes some of the enum
generated names, but it is a good starting point.~~