### PR TITLE
Update bindgen to 0.19.2

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = { version = "0.2.0", optional = true }
 libz-sys = { version = "1.0.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.19.0"
+bindgen = "0.19.2"
 cmake = "0.1.17"
 
 [features]


### PR DESCRIPTION
This change makes it so that update also applies to crates that rely on
mbedtls.