### PR TITLE
Version bump 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -21,7 +21,7 @@ libc = { version = "0.2.0", optional = true }
 libz-sys = { version = "1.0.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.19.0"
+bindgen = "0.19.2"
 cmake = "0.1.17"
 
 [features]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
Updates the Cargo.toml of mbedtls so that other crates depending on it use the correct version of bindgen.