### PR TITLE
Remove libgcc dependency

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -25,7 +25,6 @@ impl super::BuildConfig {
                 .map(|s| (s == "x86_64-unknown-none-gnu") || (s == "x86_64-fortanix-unknown-sgx"))
                 == Ok(true)
         {
-            println!("cargo:rustc-link-lib=gcc");
             cmk.cflag("-fno-builtin")
                 .cflag("-D_FORTIFY_SOURCE=0")
                 .cflag("-fno-stack-protector");


### PR DESCRIPTION
Remove the dependency on libgcc. This dependency appears to be no longer needed, and it causes a build failure with the latest rust nightly.

The dependency is probably no longer needed because the symbols provided by libgcc are now covered by the compiler_builtins crate.

