### PR TITLE
Fix ECDSA side channel

### DIFF
--- a/mbedtls-sys/vendor/library/ecdsa.c
+++ b/mbedtls-sys/vendor/library/ecdsa.c
@@ -358,6 +358,7 @@ modn:
         MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi( &e, &e, s ) );
         MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( &e, &e, &t ) );
         MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( pk, pk, &t ) );
+        MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( pk, pk, &grp->N ) ); // CVE-2019-18222
         MBEDTLS_MPI_CHK( mbedtls_mpi_inv_mod( s, pk, &grp->N ) );
         MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi( s, s, &e ) );
         MBEDTLS_MPI_CHK( mbedtls_mpi_mod_mpi( s, s, &grp->N ) );


### PR DESCRIPTION
Backport of https://github.com/ARMmbed/mbed-crypto/commit/247c4d3c8876dbf52c6c100600ea9b9840cbc904
which addresses the attack described in https://eprint.iacr.org/2020/055.pdf