### PR TITLE
Adding mpi_force_c_code feature

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.18.3"
+version = "2.18.4"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0/GPL-2.0+"
@@ -49,3 +49,4 @@ pkcs11 = []
 aesni = []
 padlock = []
 legacy_protocols = []
+mpi_force_c_code = []

--- a/mbedtls-sys/build/config.rs
+++ b/mbedtls-sys/build/config.rs
@@ -407,6 +407,7 @@ pub const FEATURE_DEFINES: &'static [(&'static str, CDefine)] = &[
     ("legacy_protocols",   ("MBEDTLS_SSL_CBC_RECORD_SPLITTING",Defined)),
     ("aes_alt",            ("MBEDTLS_AES_ENCRYPT_ALT",         Defined)),
     ("aes_alt",            ("MBEDTLS_AES_DECRYPT_ALT",         Defined)),
+    ("mpi_force_c_code",   ("MBEDTLS_MPI_FORCE_C_CODE",        Defined)),
 ];
 
 pub const SUFFIX: &'static str = r#"

--- a/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
+++ b/mbedtls-sys/vendor/include/mbedtls/bn_mul.h
@@ -46,7 +46,7 @@
 
 #include "bignum.h"
 
-#if defined(MBEDTLS_HAVE_ASM)
+#if defined(MBEDTLS_HAVE_ASM) && !defined(MBEDTLS_MPI_FORCE_C_CODE)
 
 #ifndef asm
 #define asm __asm
@@ -863,7 +863,7 @@
 #endif /* SSE2 */
 #endif /* MSVC */
 
-#endif /* MBEDTLS_HAVE_ASM */
+#endif /* MBEDTLS_HAVE_ASM && !MBEDTLS_MPI_FORCE_C_CODE */
 
 #if !defined(MULADDC_CORE)
 #if defined(MBEDTLS_HAVE_UDBL)

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
@@ -57,6 +57,7 @@ spin_threading = ["threading","spin","mbedtls-sys-auto/custom_threading"]
 sgx = ["std", "rust_threading", "rdrand", "force_aesni_support"]
 rust_threading = ["threading", "mbedtls-sys-auto/custom_threading", "std"]
 force_aesni_support = ["mbedtls-sys-auto/custom_has_support","mbedtls-sys-auto/aes_alt","aesni"]
+mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []
 use_libc = ["mbedtls-sys-auto/libc"]
 custom_gmtime_r = ["mbedtls-sys-auto/custom_gmtime_r", "chrono"]


### PR DESCRIPTION
Adding C code for mpi so that LVI passes can be optimized.