### PR TITLE
Use quotes not brackets for MBEDTLS_CONFIG_FILE

### DIFF
--- a/ct.sh
+++ b/ct.sh
@@ -11,7 +11,8 @@ fi
 
 if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [ $TRAVIS_RUST_VERSION = "nightly" ]; then
     rustup default $TRAVIS_RUST_VERSION
-    cargo test
+    # make sure that explicitly providing the default target works
+    cargo test --target x86_64-unknown-linux-gnu
     cargo test --features spin_threading
     cargo test --features rust_threading
     cargo test --features zlib

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -43,7 +43,7 @@ impl super::BuildConfig {
             .log(&logger)
             .clang_arg("-Dmbedtls_t_udbl=mbedtls_t_udbl;") // bindgen can't handle unused uint128
             .clang_arg(format!(
-                "-DMBEDTLS_CONFIG_FILE=<{}>",
+                "-DMBEDTLS_CONFIG_FILE=\"{}\"",
                 self.config_h.to_str().expect("config.h UTF-8 error")
             )).clang_arg(format!(
                 "-I{}",

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -14,7 +14,7 @@ impl super::BuildConfig {
     pub fn cmake(&self) {
         let mut cmk = cmake::Config::new(&self.mbedtls_src);
         cmk.cflag(format!(
-            r#"-DMBEDTLS_CONFIG_FILE="<{}>""#,
+            r#"-DMBEDTLS_CONFIG_FILE="\"{}\"""#,
             self.config_h.to_str().expect("config.h UTF-8 error")
         ))
         .define("ENABLE_PROGRAMS", "OFF")


### PR DESCRIPTION
When using angle brackets for defining MBEDTLS_CONFIG_FILE, the C
compiler replaces `linux` in `x86_64-unknown-linux-gnu` with `1`,
causing the build to fail because it looks for a file in an
`x86_64-unknown-1-gnu` directory that doesn't exist. By using quotes
instead we can prevent the replacement.

Fixes #113 