### PR TITLE
Add `fn verify_result` in `ssl::Context`

### DIFF
--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -157,6 +157,13 @@ impl<'config> Context<'config> {
         }
     }
 
+    pub fn verify_result(&self) -> StdResult<(), VerifyError> {
+        match unsafe { ssl_get_verify_result(&self.inner) } {
+            0 => Ok(()),
+            flags => Err(VerifyError::from_bits_truncate(flags)),
+        }
+    }
+
     pub fn config(&self) -> &'config Config {
         unsafe { UnsafeFrom::from(self.inner.conf).expect("not null") }
     }

--- a/mbedtls/tests/ssl_conf_verify.rs
+++ b/mbedtls/tests/ssl_conf_verify.rs
@@ -54,7 +54,12 @@ fn client(mut conn: TcpStream, test: Test) -> TlsResult<()> {
             .err()
             .expect("should have failed"),
     ) {
-        (Test::CallbackSetVerifyFlags, Error::X509CertVerifyFailed) => {}
+        (Test::CallbackSetVerifyFlags, Error::X509CertVerifyFailed) => {
+            assert_eq!(
+                ctx.verify_result().unwrap_err(),
+                VerifyError::CERT_OTHER | VerifyError::CERT_NOT_TRUSTED,
+            );
+        }
         (Test::CallbackError, Error::Asn1InvalidData) => {}
         (_, err) => assert!(false, "Unexpected error from ctx.establish(): {:?}", err),
     }


### PR DESCRIPTION
This would be helpful in getting more details about `Context::establish()` failures