### PR TITLE
fix wrong cert use in example/client.rs

### DIFF
--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -25,7 +25,7 @@ use support::keys;
 fn result_main(addr: &str) -> TlsResult<()> {
     let mut entropy = entropy_new();
     let mut rng = CtrDrbg::new(&mut entropy, None)?;
-    let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
+    let mut cert = Certificate::from_pem(keys::ROOT_CA_CERT)?;
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
     config.set_rng(Some(&mut rng));
     config.set_ca_list(Some(&mut *cert), None);


### PR DESCRIPTION
I was trying to run the demo in the `example`.

The client report the following error:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: X509CertVerifyFailed', src/main.rs:44:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/576d27c5a6c80cd39ef57d7398831d8e177573cc/library/std/src/panicking.rs:475
   1: core::panicking::panic_fmt
             at /rustc/576d27c5a6c80cd39ef57d7398831d8e177573cc/library/core/src/panicking.rs:85
   2: core::option::expect_none_failed
             at /rustc/576d27c5a6c80cd39ef57d7398831d8e177573cc/library/core/src/option.rs:1274
   3: core::result::Result<T,E>::unwrap
             at /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:1005
   4: client_tls::main
             at ./src/main.rs:39
   5: core::ops::function::FnOnce::call_once
             at /root/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:233
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I found it was caused by using the wrong cert in `client.rs`, I changed the cert from
```
let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
```
to
```
let mut cert = Certificate::from_pem(keys::ROOT_CA_CERT)?;
```
It succeed, and connection established.