### PR TITLE
Add support for RSA OAEP encryption/decryption with custom labels

### DIFF
--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -539,6 +539,42 @@ impl Pk {
         Ok(ret)
     }
 
+    /// Decrypt using a custom label.
+    ///
+    /// This function may only be called on an RSA key with its padding set to RSA_PKCS_V21.
+    pub fn decrypt_with_label<F: Random>(
+        &mut self,
+        cipher: &[u8],
+        plain: &mut [u8],
+        rng: &mut F,
+        label: &[u8],
+    ) -> Result<usize> {
+        if self.pk_type() != Type::Rsa {
+            return Err(Error::PkTypeMismatch);
+        }
+        let ctx = self.inner.pk_ctx as *mut rsa_context;
+        if unsafe { (*ctx).padding != RSA_PKCS_V21 } {
+            return Err(Error::RsaInvalidPadding);
+        }
+
+        let mut ret = 0usize;
+        unsafe {
+            rsa_rsaes_oaep_decrypt(
+                ctx,
+                Some(F::call),
+                rng.data_ptr(),
+                RSA_PRIVATE,
+                label.as_ptr(),
+                label.len(),
+                &mut ret,
+                cipher.as_ptr(),
+                plain.as_mut_ptr(),
+                plain.len(),
+            ).into_result()?;
+        }
+        Ok(ret)
+    }
+
     pub fn encrypt<F: Random>(
         &mut self,
         plain: &[u8],
@@ -560,6 +596,44 @@ impl Pk {
             ret.assume_init()
         };
         Ok(ret)
+    }
+
+    /// Encrypt using a custom label.
+    ///
+    /// This function may only be called on an RSA key with its padding set to RSA_PKCS_V21.
+    pub fn encrypt_with_label<F: Random>(
+        &mut self,
+        plain: &[u8],
+        cipher: &mut [u8],
+        rng: &mut F,
+        label: &[u8],
+    ) -> Result<usize> {
+        if self.pk_type() != Type::Rsa {
+            return Err(Error::PkTypeMismatch);
+        }
+        let ctx = self.inner.pk_ctx as *mut rsa_context;
+        if unsafe { (*ctx).padding != RSA_PKCS_V21 } {
+            return Err(Error::RsaInvalidPadding);
+        }
+        let olen = self.len() / 8;
+        if cipher.len() < olen {
+            return Err(Error::RsaOutputTooLarge);
+        }
+
+        unsafe {
+            rsa_rsaes_oaep_encrypt(
+                ctx,
+                Some(F::call),
+                rng.data_ptr(),
+                RSA_PUBLIC,
+                label.as_ptr(),
+                label.len(),
+                plain.len(),
+                plain.as_ptr(),
+                cipher.as_mut_ptr()
+            ).into_result()?;
+        }
+        Ok(olen)
     }
 
     /// Sign the hash `hash` of type `md`, placing the signature in `sig`. `rng` must be a


### PR DESCRIPTION
This exposes the `mbedtls_rsa_rsaes_oaep_encrypt()` and `mbedtls_rsa_rsaes_oaep_decrypt()` functions in rust-mbedtls.