### PR TITLE
MbedTLS Reference counted instead of lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,9 +181,50 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "httparse"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -184,6 +234,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -238,6 +293,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_io 0.1.20190701 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls-sys-auto 2.24.0",
@@ -278,6 +334,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nom"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,8 +367,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -412,6 +490,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -544,9 +627,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -559,6 +689,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +706,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vcpkg"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -605,6 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bindgen 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)" = "003f95e0fb6cf3d1fee8c62b2ec35135509477989fab15c358e0efa3972bdef6"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -626,8 +772,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+"checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
@@ -636,10 +787,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -654,6 +808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rs-libc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80a671d6c4696a49b78e0a271c99bc58bc1a17a64893a3684a1ba1a944b26ca9"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "defbb8a83d7f34cc8380751eeb892b825944222888aff18996ea7901f24aec88"
@@ -669,11 +824,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tinyvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+"checksum tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+"checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = [
   "continuous-integration/travis-ci/push",
 ]
+timeout_sec = 36000 # ten hours

--- a/ct.sh
+++ b/ct.sh
@@ -19,6 +19,7 @@ if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [
     cargo test --features pkcs12
     cargo test --features pkcs12_rc2
     cargo test --features force_aesni_support
+    cargo test --features default,pthread
 
 elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
     cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand,time,custom_time,custom_gmtime_r

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -12,6 +12,7 @@ This version generates the correct bindings at compile time using bindgen."""
 readme = "../README.md"
 repository = "https://github.com/fortanix/rust-mbedtls"
 documentation = "https://docs.rs/mbedtls-sys-auto/"
+links = "mbedtls"
 
 [lib]
 name = "mbedtls_sys"

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -49,5 +49,8 @@ impl super::BuildConfig {
         println!("cargo:rustc-link-lib=mbedtls");
         println!("cargo:rustc-link-lib=mbedx509");
         println!("cargo:rustc-link-lib=mbedcrypto");
+
+        println!("cargo:include={}/{}", ::std::env::current_dir().unwrap().display(), self.mbedtls_src.join("include").display());
+        println!("cargo:config_h={}", self.config_h.to_str().expect("config.h UTF-8 error"));
     }
 }

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.4.0"
 serde_cbor = "0.6"
 hex = "0.3"
 matches = "0.1.8"
+hyper = { version = "0.10.16", default-features = false }
 
 [build-dependencies]
 cc = "1.0"
@@ -119,3 +120,9 @@ required-features = ["std"]
 name = "ssl_conf_verify"
 path = "tests/ssl_conf_verify.rs"
 required-features = ["std"]
+
+
+[[test]]
+name = "hyper"
+path = "tests/hyper.rs"
+required-features = ["std", "threading"]

--- a/mbedtls/build.rs
+++ b/mbedtls/build.rs
@@ -12,6 +12,12 @@ use std::env;
 
 fn main() {
     let mut b = cc::Build::new();
+    b.include(env::var_os("DEP_MBEDTLS_INCLUDE").expect("Links was not properly set in mbedtls-sys package, missing DEP_MBEDTLS_INCLUDE"));
+    let config_file = format!("\"{}\"", env::var_os("DEP_MBEDTLS_CONFIG_H").expect("Links was not properly set in mbedtls-sys package, missing DEP_MBEDTLS_CONFIG_H").to_str().unwrap());
+    b.define("MBEDTLS_CONFIG_FILE",
+             Some(config_file.as_str()));
+    
+    b.file("src/mbedtls_malloc.c");
     b.file("src/rust_printf.c");
     if env::var_os("CARGO_FEATURE_STD").is_none()
         || ::std::env::var("TARGET")

--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -10,6 +10,7 @@ extern crate mbedtls;
 
 use std::io::{self, stdin, stdout, Write};
 use std::net::TcpStream;
+use std::sync::Arc;
 
 use mbedtls::rng::CtrDrbg;
 use mbedtls::ssl::config::{Endpoint, Preset, Transport};
@@ -23,21 +24,21 @@ use support::entropy::entropy_new;
 use support::keys;
 
 fn result_main(addr: &str) -> TlsResult<()> {
-    let mut entropy = entropy_new();
-    let mut rng = CtrDrbg::new(&mut entropy, None)?;
-    let mut cert = Certificate::from_pem(keys::ROOT_CA_CERT)?;
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None)?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT)?);
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
-    config.set_rng(Some(&mut rng));
-    config.set_ca_list(Some(&mut *cert), None);
-    let mut ctx = Context::new(&config)?;
+    config.set_rng(rng);
+    config.set_ca_list(cert, None);
+    let mut ctx = Context::new(Arc::new(config));
 
-    let mut conn = TcpStream::connect(addr).unwrap();
-    let mut session = ctx.establish(&mut conn, None)?;
+    let conn = TcpStream::connect(addr).unwrap();
+    ctx.establish(conn, None)?;
 
     let mut line = String::new();
     stdin().read_line(&mut line).unwrap();
-    session.write_all(line.as_bytes()).unwrap();
-    io::copy(&mut session, &mut stdout()).unwrap();
+    ctx.write_all(line.as_bytes()).unwrap();
+    io::copy(&mut ctx, &mut stdout()).unwrap();
     Ok(())
 }
 

--- a/mbedtls/examples/server.rs
+++ b/mbedtls/examples/server.rs
@@ -10,6 +10,7 @@ extern crate mbedtls;
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
 
 use mbedtls::pk::Pk;
 use mbedtls::rng::CtrDrbg;
@@ -29,21 +30,25 @@ fn listen<E, F: FnMut(TcpStream) -> Result<(), E>>(mut handle_client: F) -> Resu
         println!("Connection from {}", conn.peer_addr().unwrap());
         handle_client(conn)?;
     }
+
     Ok(())
 }
 
 fn result_main() -> TlsResult<()> {
-    let mut entropy = entropy_new();
-    let mut rng = CtrDrbg::new(&mut entropy, None)?;
-    let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
-    let mut key = Pk::from_private_key(keys::PEM_KEY, None)?;
+    let entropy = entropy_new();
+    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT)?);
+    let key = Arc::new(Pk::from_private_key(keys::PEM_KEY, None)?);
     let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
-    config.set_rng(Some(&mut rng));
-    config.push_cert(&mut *cert, &mut key)?;
-    let mut ctx = Context::new(&config)?;
+    config.set_rng(rng);
+    config.push_cert(cert, key)?;
 
-    listen(|mut conn| {
-        let mut session = BufReader::new(ctx.establish(&mut conn, None)?);
+    let rc_config = Arc::new(config);
+
+    listen(move |conn| {
+        let mut ctx = Context::new(rc_config.clone());
+        ctx.establish(conn, None)?;
+        let mut session = BufReader::new(ctx);
         let mut line = Vec::new();
         session.read_until(b'\n', &mut line).unwrap();
         session.get_mut().write_all(&line).unwrap();

--- a/mbedtls/src/alloc.rs
+++ b/mbedtls/src/alloc.rs
@@ -1,0 +1,65 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or
+ * https://www.gnu.org/licenses/gpl-2.0.html> or the Apache License, Version
+ * 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, at your
+ * option. This file may not be copied, modified, or distributed except
+ * according to those terms. */
+
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
+use core::ptr::drop_in_place;
+use core::mem::ManuallyDrop;
+
+use mbedtls_sys::types::raw_types::c_void;
+
+extern "C" {
+    pub(crate) fn forward_mbedtls_free(n: *mut mbedtls_sys::types::raw_types::c_void);
+}
+
+#[repr(transparent)]
+pub struct Box<T> {
+    pub(crate) inner: NonNull<T>
+}
+
+impl<T> Box<T> {
+    pub(crate) fn into_raw(self) -> *mut T {
+        let v = ManuallyDrop::new(self);
+        v.inner.as_ptr()
+    }
+}
+
+impl<T> Deref for Box<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { self.inner.as_ref() }
+    }
+}
+
+impl<T> DerefMut for Box<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { self.inner.as_mut() }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Box<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T> Drop for Box<T> {
+    fn drop(&mut self) {
+        unsafe {
+            drop_in_place(self.inner.as_ptr());
+            forward_mbedtls_free(self.inner.as_ptr() as *mut c_void)
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct List<T> {
+    pub(crate) inner: Option<Box<T>>
+}
+

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -15,7 +15,7 @@ const ERROR: _MUST_USE_EITHER_STD_OR_CORE_IO_ = ();
 
 #[cfg(not(feature = "std"))]
 #[macro_use]
-extern crate alloc;
+extern crate alloc as rust_alloc;
 #[cfg(feature = "std")]
 extern crate core;
 #[cfg(not(feature = "std"))]
@@ -59,6 +59,7 @@ pub mod rng;
 pub mod self_test;
 pub mod ssl;
 pub mod x509;
+pub mod alloc;
 
 #[cfg(feature = "pkcs12")]
 pub mod pkcs12;
@@ -112,11 +113,13 @@ mod mbedtls {
 #[cfg(not(feature = "std"))]
 mod alloc_prelude {
     #![allow(unused)]
-    pub(crate) use alloc::borrow::ToOwned;
-    pub(crate) use alloc::boxed::Box;
-    pub(crate) use alloc::string::String;
-    pub(crate) use alloc::string::ToString;
-    pub(crate) use alloc::vec::Vec;
+    pub(crate) use rust_alloc::borrow::ToOwned;
+    pub(crate) use rust_alloc::boxed::Box;
+    pub(crate) use rust_alloc::sync::Arc;
+    pub(crate) use rust_alloc::string::String;
+    pub(crate) use rust_alloc::string::ToString;
+    pub(crate) use rust_alloc::vec::Vec;
+    pub(crate) use rust_alloc::borrow::Cow;
 }
 
 #[cfg(all(feature="time", any(feature="custom_gmtime_r", feature="custom_time")))]
@@ -163,3 +166,11 @@ pub unsafe extern "C" fn mbedtls_time(tp: *mut time_t) -> time_t {
     }
     timestamp
 }
+
+// Debug not available in SGX
+#[cfg(not(target_env = "sgx"))]
+pub unsafe fn set_global_debug_threshold(threshold: i32) {
+    mbedtls_sys::debug_set_threshold(threshold);
+}
+
+

--- a/mbedtls/src/mbedtls_malloc.c
+++ b/mbedtls/src/mbedtls_malloc.c
@@ -1,0 +1,31 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or
+ * https://www.gnu.org/licenses/gpl-2.0.html> or the Apache License, Version
+ * 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, at your
+ * option. This file may not be copied, modified, or distributed except
+ * according to those terms. */
+
+// Follow same pattern for config and alloc/free as everywhere in mbedtls
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdlib.h>
+#define mbedtls_calloc    calloc
+#define mbedtls_free      free
+#endif
+
+extern void *forward_mbedtls_calloc( size_t n, size_t size ) {
+    return mbedtls_calloc(n, size);
+}
+
+extern void forward_mbedtls_free( void *ptr ) {
+    mbedtls_free(ptr);
+}
+

--- a/mbedtls/src/pk/dhparam.rs
+++ b/mbedtls/src/pk/dhparam.rs
@@ -22,7 +22,7 @@ impl Dhm {
     /// Takes both DER and PEM forms of FFDH parameters in `DHParams` format.
     ///
     /// When calling on PEM-encoded data, `params` must be NULL-terminated
-    pub(crate) fn from_params(params: &[u8]) -> Result<Dhm> {
+    pub fn from_params(params: &[u8]) -> Result<Dhm> {
         let mut ret = Self::init();
         unsafe { dhm_parse_dhm(&mut ret.inner, params.as_ptr(), params.len()) }.into_result()?;
         Ok(ret)

--- a/mbedtls/src/pk/rfc6979.rs
+++ b/mbedtls/src/pk/rfc6979.rs
@@ -12,7 +12,7 @@ use crate::alloc_prelude::*;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 
-use crate::rng::{HmacDrbg, Random, RngCallback};
+use crate::rng::{HmacDrbg, Random, RngCallbackMut};
 
 use crate::error::Result;
 use crate::bignum::Mpi;
@@ -67,7 +67,7 @@ fn generate_rfc6979_nonce(md: &MdInfo, x: &Mpi, q: &Mpi, digest_bytes: &[u8]) ->
 pub(crate) struct Rfc6979Rng {
     pub k: Vec<u8>,
     pub k_read: usize,
-    pub rng: HmacDrbg<'static>,
+    pub rng: HmacDrbg,
 }
 
 /// An RNG which first outputs the k for RFC 6797 followed by random data
@@ -110,8 +110,8 @@ impl Rfc6979Rng {
     }
 }
 
-impl RngCallback for Rfc6979Rng {
-    unsafe extern "C" fn call(
+impl RngCallbackMut for Rfc6979Rng {
+    unsafe extern "C" fn call_mut(
         user_data: *mut c_void,
         data_ptr: *mut c_uchar,
         len: size_t,
@@ -126,7 +126,7 @@ impl RngCallback for Rfc6979Rng {
         }
     }
 
-    fn data_ptr(&mut self) -> *mut c_void {
+    fn data_ptr_mut(&mut self) -> *mut c_void {
         self as *const _ as *mut _
     }
 }

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -39,6 +39,7 @@ use crate::cipher::{Cipher, Decryption, Fresh, Traditional};
 use crate::hash::{pbkdf_pkcs12, Md, MdInfo, Type as MdType};
 use crate::pk::Pk;
 use crate::x509::Certificate;
+use crate::alloc::{Box as MbedtlsBox};
 use crate::Error as MbedtlsError;
 
 // Constants for various object identifiers used in PKCS12:
@@ -836,7 +837,7 @@ impl Pfx {
     /// of "friendly names" which are associated with said certificate.
     /// Some or all of the certificates stored in a Pfx may be encrypted in which case
     /// decrypt must be called to access them.
-    pub fn certificates<'a>(&'a self) -> impl Iterator<Item=(Result<Certificate, crate::Error>, Vec<String>)> + 'a {
+    pub fn certificates<'a>(&'a self) -> impl Iterator<Item=(Result<MbedtlsBox<Certificate>, crate::Error>, Vec<String>)> + 'a {
         self.authsafe_decrypted_contents()
             .filter_map(|sb| if let Pkcs12BagSet::Cert(CertBag(Some(cert))) = &sb.bag_value {
                 Some((Certificate::from_der(cert), sb.friendly_name()))

--- a/mbedtls/src/rng/mod.rs
+++ b/mbedtls/src/rng/mod.rs
@@ -27,11 +27,11 @@ use crate::error::{Result, IntoResult};
 use mbedtls_sys::types::raw_types::{c_int, c_uchar};
 use mbedtls_sys::types::size_t;
 
-callback!(EntropyCallback:Sync(data: *mut c_uchar, len: size_t) -> c_int);
-callback!(RngCallback:Sync(data: *mut c_uchar, len: size_t) -> c_int);
+callback!(EntropyCallbackMut,EntropyCallback(data: *mut c_uchar, len: size_t) -> c_int);
+callback!(RngCallbackMut,RngCallback(data: *mut c_uchar, len: size_t) -> c_int);
 
 pub trait Random: RngCallback {
-    fn random(&mut self, data: &mut [u8]) -> Result<()> {
+    fn random(&mut self, data: &mut [u8]) -> Result<()> where Self: Sized {
         unsafe { Self::call(self.data_ptr(), data.as_mut_ptr(), data.len()) }.into_result()?;
         Ok(())
     }

--- a/mbedtls/src/rng/os_entropy.rs
+++ b/mbedtls/src/rng/os_entropy.rs
@@ -6,57 +6,77 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+use std::sync::Arc;
+
+use mbedtls_sys::*;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
-use mbedtls_sys::*;
 
 use crate::error::{IntoResult, Result};
+use crate::rng::{EntropyCallback,EntropyCallbackMut};
 
-callback!(EntropySourceCallback(data: *mut c_uchar, size: size_t, out: *mut size_t) -> c_int);
+callback!(EntropySourceCallbackMut,EntropySourceCallback(data: *mut c_uchar, size: size_t, out: *mut size_t) -> c_int);
 
 define!(
     #[c_ty(entropy_context)]
-    struct OsEntropy<'source>;
-    pub const new: fn() -> Self = entropy_init;
+    #[repr(C)]
+    struct OsEntropy {
+        sources: Vec<Arc<dyn EntropySourceCallback + 'static>>,
+    };
+    pub const new: fn() -> Self = entropy_init { sources: Vec::with_capacity(1), };
     const drop: fn(&mut Self) = entropy_free;
+    impl<'a> Into<ptr> {}
 );
 
+//
+// Class has interior mutability via function called 'call'.
+// That function has an internal mutex to guarantee thread safety.
+//
+// The other potential conflict is a mutable reference changing class.
+// That is avoided by having any users of the callback hold an 'Arc' to this class.
+// Rust will then ensure that a mutable reference cannot be aquired if more then 1 Arc exists to the same class.
+//
 #[cfg(feature = "threading")]
-unsafe impl<'source> Sync for OsEntropy<'source> {}
+unsafe impl Sync for OsEntropy {}
 
-impl<'source> OsEntropy<'source> {
-    pub fn add_source<F: EntropySourceCallback>(
+#[allow(dead_code)]
+impl OsEntropy {
+    pub fn add_source<F: EntropySourceCallback + 'static>(
         &mut self,
-        source: &'source mut F,
+        source: Arc<F>,
         threshold: size_t,
         strong: bool,
     ) -> Result<()> {
         unsafe {
+            // add_source is guarded with internal mutex: mbedtls-sys/vendor/crypto/library/entropy.c:143
+            // all sources are called at later points via 'entropy_gather_internal' which in turn is called with internal mutex locked.
             entropy_add_source(
-                &mut self.inner,
+                self.inner_ffi_mut(),
                 Some(F::call),
                 source.data_ptr(),
                 threshold,
-                if strong {
-                    ENTROPY_SOURCE_STRONG
-                } else {
-                    ENTROPY_SOURCE_WEAK
-                }
+                if strong { ENTROPY_SOURCE_STRONG } else { ENTROPY_SOURCE_WEAK }
             )
             .into_result()?
         };
+
+        // Rust ensures only one mutable reference is currently in use.
+        self.sources.push(source);
         Ok(())
     }
 
-    pub fn gather(&mut self) -> Result<()> {
-        unsafe { entropy_gather(&mut self.inner) }.into_result()?;
+    pub fn gather(&self) -> Result<()> {
+        // function is guarded with internal mutex: mbedtls-sys/vendor/crypto/library/entropy.c:310
+        unsafe { entropy_gather(self.inner_ffi_mut()) }.into_result()?;
         Ok(())
     }
 
-    pub fn update_manual(&mut self, data: &[u8]) -> Result<()> {
-        unsafe { entropy_update_manual(&mut self.inner, data.as_ptr(), data.len()) }.into_result()?;
+    pub fn update_manual(&self, data: &[u8]) -> Result<()> {
+        // function is guarded with internal mutex: mbedtls-sys/vendor/crypto/library/entropy.c:241
+        unsafe { entropy_update_manual(self.inner_ffi_mut(), data.as_ptr(), data.len()) }.into_result()?;
         Ok(())
     }
+
 
     // TODO
     // entropy_write_seed_file
@@ -64,13 +84,28 @@ impl<'source> OsEntropy<'source> {
     //
 }
 
-impl<'source> super::EntropyCallback for OsEntropy<'source> {
+impl EntropyCallback for OsEntropy {
     #[inline(always)]
     unsafe extern "C" fn call(user_data: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
+        // mutex used in entropy_func: ../../../mbedtls-sys/vendor/crypto/library/entropy.c:348
+        // note: we're not using MBEDTLS_ENTROPY_NV_SEED so the initialization is not present or a race condition.
         entropy_func(user_data, data, len)
     }
 
-    fn data_ptr(&mut self) -> *mut c_void {
-        &mut self.inner as *mut _ as *mut _
+    fn data_ptr(&self) -> *mut c_void {
+        &self.inner as *const _ as *mut _
+    }
+}
+
+impl EntropyCallbackMut for OsEntropy {
+    #[inline(always)]
+    unsafe extern "C" fn call_mut(user_data: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
+        // mutex used in entropy_func: ../../../mbedtls-sys/vendor/crypto/library/entropy.c:348
+        // note: we're not using MBEDTLS_ENTROPY_NV_SEED so the initialization is not present or a race condition.
+        entropy_func(user_data, data, len)
+    }
+
+    fn data_ptr_mut(&mut self) -> *mut c_void {
+        &self.inner as *const _ as *mut _
     }
 }

--- a/mbedtls/src/ssl/ciphersuites.rs
+++ b/mbedtls/src/ssl/ciphersuites.rs
@@ -9,6 +9,7 @@
 use mbedtls_sys::types::raw_types::c_int;
 use mbedtls_sys::*;
 
+/// Always use into() to convert to i32, do not use 'as i32'. (until issue is fixed: https://github.com/fortanix/rust-mbedtls/issues/129)
 define!(
     #[non_exhaustive]
     #[c_ty(c_int)]

--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -6,25 +6,32 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+#[cfg(feature = "std")]
+use std::sync::Arc;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
+
 use core::slice::from_raw_parts;
 
-use mbedtls_sys::types::raw_types::{c_char, c_int, c_uchar, c_uint, c_void};
-use mbedtls_sys::types::size_t;
 use mbedtls_sys::*;
+use mbedtls_sys::types::raw_types::*;
+use mbedtls_sys::types::size_t;
 
-use crate::error::{Error, IntoResult, Result};
-use core::result::Result as StdResult;
-use crate::pk::dhparam::Dhm;
+
+use crate::alloc::{List as MbedtlsList};
+#[cfg(not(feature = "std"))]
+use crate::alloc_prelude::*;
+use crate::error::{Error, Result, IntoResult};
 use crate::pk::Pk;
+use crate::pk::dhparam::Dhm;
 use crate::private::UnsafeFrom;
+use crate::rng::RngCallback;
 use crate::ssl::context::HandshakeContext;
 use crate::ssl::ticket::TicketCallback;
-use crate::x509::{certificate, Crl, LinkedCertificate, Profile, VerifyError};
-
-extern "C" {
-    fn calloc(n: usize, size: usize) -> *mut c_void;
-    fn free(ptr: *mut c_void);
-}
+use crate::x509::Certificate;
+use crate::x509::Crl;
+use crate::x509::Profile;
+use crate::x509::VerifyError;
 
 #[allow(non_camel_case_types)]
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Copy, Clone)]
@@ -83,27 +90,83 @@ define!(
     }
 );
 
-callback!(DbgCallback:Sync(level: c_int, file: *const c_char, line: c_int, message: *const c_char) -> ());
+define!(
+    #[c_ty(c_int)]
+    enum Renegotiation {
+        Enabled = SSL_RENEGOTIATION_ENABLED,
+        Disabled = SSL_RENEGOTIATION_DISABLED,
+    }
+);
+
+callback!(VerifyCallback: Fn(&Certificate, i32, &mut VerifyError) -> Result<()>);
+#[cfg(feature = "std")]
+callback!(DbgCallback: Fn(i32, Cow<'_, str>, i32, Cow<'_, str>) -> ());
+callback!(SniCallback: Fn(&mut HandshakeContext, &[u8]) -> Result<()>);
+callback!(CaCallback: Fn(&MbedtlsList<Certificate>) -> Result<MbedtlsList<Certificate>>);
 
 define!(
     #[c_ty(ssl_config)]
-    struct Config<'c>;
-    const init: fn() -> Self = ssl_config_init;
+    #[repr(C)]
+    struct Config {
+        // Holding reference counters against any structures that ssl_config might hold pointer to.
+        // This allows caller to share structure on multiple configs if needed.
+        own_cert: Vec<Arc<MbedtlsList<Certificate>>>,
+        own_pk: Vec<Arc<Pk>>,
+    
+        ca_cert: Option<Arc<MbedtlsList<Certificate>>>,
+        crl: Option<Arc<Crl>>,
+        
+        rng: Option<Arc<dyn RngCallback + 'static>>,
+        
+        ciphersuites: Vec<Arc<Vec<c_int>>>,
+        curves: Option<Arc<Vec<ecp_group_id>>>,
+        
+        #[allow(dead_code)]
+        dhm: Option<Arc<Dhm>>,
+        
+        verify_callback: Option<Arc<dyn VerifyCallback + 'static>>,
+        #[cfg(feature = "std")]
+        dbg_callback: Option<Arc<dyn DbgCallback + 'static>>,
+        sni_callback: Option<Arc<dyn SniCallback + 'static>>,
+        ticket_callback: Option<Arc<dyn TicketCallback + 'static>>,
+        ca_callback: Option<Arc<dyn CaCallback + 'static>>,
+    };
     const drop: fn(&mut Self) = ssl_config_free;
-    impl<'q> Into<ptr> {}
-    impl<'q> UnsafeFrom<ptr> {}
+    impl<'a> Into<ptr> {}
 );
 
 #[cfg(feature = "threading")]
-unsafe impl<'c> Sync for Config<'c> {}
+unsafe impl Sync for Config {}
 
-impl<'c> Config<'c> {
+impl Config {
     pub fn new(e: Endpoint, t: Transport, p: Preset) -> Self {
-        let mut c = Config::init();
+        let mut inner = ssl_config::default();
+
         unsafe {
-            ssl_config_defaults(&mut c.inner, e.into(), t.into(), p.into());
+            // This is just a memset to 0.
+            ssl_config_init(&mut inner);
+
+            // Set default values - after this point we will need ssl_config_free to be called.
+            ssl_config_defaults(&mut inner, e as c_int, t as c_int, p as c_int);
+        };
+
+        Config {
+            inner,
+            own_cert: vec![],
+            own_pk: vec![],
+            ca_cert: None,
+            crl: None,
+            rng: None,
+            ciphersuites: vec![],
+            curves: None,
+            dhm: None,
+            verify_callback: None,
+            #[cfg(feature = "std")]
+            dbg_callback: None,
+            sni_callback: None,
+            ticket_callback: None,
+            ca_callback: None,
         }
-        c
     }
 
     // need bitfield support getter!(endpoint() -> Endpoint = field endpoint);
@@ -119,21 +182,30 @@ impl<'c> Config<'c> {
         assert!(list.last() == Some(&T::default()));
     }
 
-    pub fn set_ciphersuites(&mut self, list: &'c [c_int]) {
-        Self::check_c_list(list);
-        unsafe { ssl_conf_ciphersuites(&mut self.inner, list.as_ptr()) }
+    pub fn set_ciphersuites(&mut self, list: Arc<Vec<c_int>>) {
+        Self::check_c_list(&list);
+
+        unsafe { ssl_conf_ciphersuites(self.into(), list.as_ptr()) }
+        self.ciphersuites.push(list);
     }
 
-    pub fn set_ciphersuites_for_version(&mut self, list: &'c [c_int], major: c_int, minor: c_int) {
-        Self::check_c_list(list);
-        unsafe { ssl_conf_ciphersuites_for_version(&mut self.inner, list.as_ptr(), major, minor) }
+    pub fn set_ciphersuites_for_version(&mut self, list: Arc<Vec<c_int>>, major: c_int, minor: c_int) {
+        Self::check_c_list(&list);
+        unsafe { ssl_conf_ciphersuites_for_version(self.into(), list.as_ptr(), major, minor) }
+        self.ciphersuites.push(list);
     }
 
-    pub fn set_curves(&mut self, list: &'c [ecp_group_id]) {
-        Self::check_c_list(list);
-        unsafe { ssl_conf_curves(&mut self.inner, list.as_ptr()) }
+    pub fn set_curves(&mut self, list: Arc<Vec<ecp_group_id>>) {
+        Self::check_c_list(&list);
+        unsafe { ssl_conf_curves(self.into(), list.as_ptr()) }
+        self.curves = Some(list);
     }
 
+    pub fn set_rng<T: RngCallback + 'static>(&mut self, rng: Arc<T>) {
+        unsafe { ssl_conf_rng(self.into(), Some(T::call), rng.data_ptr()) };
+        self.rng = Some(rng);
+    }
+    
     pub fn set_min_version(&mut self, version: Version) -> Result<()> {
         let minor = match version {
             Version::Ssl3 => 0,
@@ -143,7 +215,7 @@ impl<'c> Config<'c> {
             _ => { return Err(Error::SslBadHsProtocolVersion); }
         };
 
-        unsafe { ssl_conf_min_version(&mut self.inner, 3, minor) };
+        unsafe { ssl_conf_min_version(self.into(), 3, minor) };
         Ok(())
     }
 
@@ -155,68 +227,59 @@ impl<'c> Config<'c> {
             Version::Tls1_2 => 3,
             _ => { return Err(Error::SslBadHsProtocolVersion); }
         };
-        unsafe { ssl_conf_max_version(&mut self.inner, 3, minor) };
+        unsafe { ssl_conf_max_version(self.into(), 3, minor) };
         Ok(())
     }
 
-    setter!(set_cert_profile(p: &'c Profile) = ssl_conf_cert_profile);
+    // Profile as implemented in profile.rs can only point to global variables from mbedtls which would have 'static lifetime
+    setter!(set_cert_profile(p: &'static Profile) = ssl_conf_cert_profile);
 
     /// Takes both DER and PEM forms of FFDH parameters in `DHParams` format.
     ///
     /// When calling on PEM-encoded data, `params` must be NULL-terminated
-    pub fn set_dh_params(&mut self, params: &[u8]) -> Result<()> {
-        let mut ctx = Dhm::from_params(params)?;
+    pub fn set_dh_params(&mut self, dhm: Arc<Dhm>) -> Result<()> {
         unsafe {
-            ssl_conf_dh_param_ctx(&mut self.inner, (&mut ctx).into())
+            ssl_conf_dh_param_ctx(self.into(), dhm.inner_ffi_mut())
                 .into_result()
-                .map(|_| ())
+                .map(|_| ())?;
         }
+        self.dhm = Some(dhm);
+        Ok(())
     }
 
-    pub fn set_ca_list<C: Into<&'c mut LinkedCertificate>>(
-        &mut self,
-        list: Option<C>,
-        crl: Option<&'c mut Crl>,
-    ) {
-        unsafe {
-            ssl_conf_ca_chain(
-                &mut self.inner,
-                list.map(Into::into)
-                    .map(Into::into)
-                    .unwrap_or(::core::ptr::null_mut()),
-                crl.map(Into::into).unwrap_or(::core::ptr::null_mut()),
-            )
-        }
+    pub fn set_ca_list(&mut self, ca_cert: Arc<MbedtlsList<Certificate>>, crl: Option<Arc<Crl>>) {
+        // This will override internal pointers to what we provide.
+        
+        unsafe { ssl_conf_ca_chain(self.into(), ca_cert.inner_ffi_mut(), crl.as_ref().map(|crl| crl.inner_ffi_mut()).unwrap_or(::core::ptr::null_mut())); }
+
+        self.ca_cert = Some(ca_cert);
+        self.crl = crl;        
     }
 
-    pub fn push_cert<C: Into<&'c mut LinkedCertificate>>(
-        &mut self,
-        chain: C,
-        key: &'c mut Pk,
-    ) -> Result<()> {
-        unsafe {
-            ssl_conf_own_cert(&mut self.inner, chain.into().into(), key.into())
-                .into_result()
-                .map(|_| ())
+    pub fn push_cert(&mut self, own_cert: Arc<MbedtlsList<Certificate>>, own_pk: Arc<Pk>) -> Result<()> {
+        // Need to ensure own_cert/pk_key outlive the config.
+        self.own_cert.push(own_cert.clone());
+        self.own_pk.push(own_pk.clone());
+
+        // This will append pointers to our certificates inside mbedtls
+        unsafe { ssl_conf_own_cert(self.into(), own_cert.inner_ffi_mut(), own_pk.inner_ffi_mut())
+                 .into_result()
+                 .map(|_| ())
         }
     }
-
-    pub fn certs(&'c self) -> KeyCertIter<'c> {
-        KeyCertIter {
-            key_cert: unsafe { UnsafeFrom::from(self.inner.key_cert as *const _) },
-        }
-    }
-
+    
     /// Server only: configure callback to use for generating/interpreting session tickets.
-    pub fn set_session_tickets_callback<F: TicketCallback>(&mut self, cb: &'c mut F) {
+    pub fn set_session_tickets_callback<T: TicketCallback + 'static>(&mut self, cb: Arc<T>) {
         unsafe {
             ssl_conf_session_tickets_cb(
-                &mut self.inner,
-                Some(F::call_write),
-                Some(F::call_parse),
+                self.into(),
+                Some(T::call_write),
+                Some(T::call_parse),
                 cb.data_ptr(),
             )
         };
+
+        self.ticket_callback = Some(cb);
     }
 
     setter!(
@@ -224,43 +287,62 @@ impl<'c> Config<'c> {
         set_session_tickets(u: UseSessionTickets) = ssl_conf_session_tickets
     );
 
+    setter!(set_renegotiation(u: Renegotiation) = ssl_conf_renegotiation);
+
     setter!(
         /// Client only: minimal FFDH group size
         set_ffdh_min_bitlen(bitlen: c_uint) = ssl_conf_dhm_min_bitlen
     );
-
-    // TODO: The lifetime restrictions on HandshakeContext here are too strict.
-    // Once we need something else, we might fix it.
-    pub fn set_sni_callback<F: FnMut(&mut HandshakeContext, &[u8]) -> StdResult<(), ()>>(
-        &mut self,
-        cb: &'c mut F,
-    ) {
-        unsafe extern "C" fn sni_callback<
-            F: FnMut(&mut HandshakeContext, &[u8]) -> StdResult<(), ()>,
-        >(
+    
+    pub fn set_sni_callback<F>(&mut self, cb: F)
+    where
+        F: SniCallback + 'static,
+    {
+        unsafe extern "C" fn sni_callback<F>(
             closure: *mut c_void,
             ctx: *mut ssl_context,
             name: *const c_uchar,
             name_len: size_t,
-        ) -> c_int {
+        ) -> c_int
+        where
+            F: Fn(&mut HandshakeContext, &[u8]) -> Result<()> + 'static,
+        {
+            // This is called from:
+            //
+            // mbedtls/src/ssl/context.rs           - establish
+            // mbedtls-sys/vendor/library/ssl_tls.c - mbedtls_ssl_handshake
+            // mbedtls-sys/vendor/library/ssl_tls.c - mbedtls_ssl_handshake_step
+            // mbedtls-sys/vendor/library/ssl_srv.c - mbedtls_ssl_handshake_server_step
+            // mbedtls-sys/vendor/library/ssl_srv.c - ssl_parse_client_hello
+            // mbedtls-sys/vendor/library/ssl_srv.c - ssl_parse_servername_ext
+            //
+            // As such:
+            // - The ssl_context is a rust 'Context' structure that we have a mutable reference to via 'establish'
+            // - We can pointer cast to it to allow storing additional objects.
+            //
             let cb = &mut *(closure as *mut F);
-            let mut ctx = UnsafeFrom::from(ctx).expect("valid context");
+            let context = UnsafeFrom::from(ctx).unwrap();
+            
+            let mut ctx = HandshakeContext::init(context);
+            
             let name = from_raw_parts(name, name_len);
             match cb(&mut ctx, name) {
                 Ok(()) => 0,
-                Err(()) => -1,
+                Err(_) => -1,
             }
         }
 
-        unsafe { ssl_conf_sni(&mut self.inner, Some(sni_callback::<F>), cb as *mut F as _) }
+        
+        self.sni_callback = Some(Arc::new(cb));
+        unsafe { ssl_conf_sni(self.into(), Some(sni_callback::<F>), &**self.sni_callback.as_mut().unwrap() as *const _ as *mut c_void) }
     }
 
     // The docs for mbedtls_x509_crt_verify say "The [callback] should return 0 for anything but a
     // fatal error.", so verify callbacks should return Ok(()) for anything but a fatal error.
     // Report verification errors by updating the flags in VerifyError.
-    pub fn set_verify_callback<F>(&mut self, cb: &'c mut F)
+    pub fn set_verify_callback<F>(&mut self, cb: F)
     where
-        F: FnMut(&mut LinkedCertificate, i32, &mut VerifyError) -> Result<()>,
+        F: VerifyCallback + 'static,
     {
         unsafe extern "C" fn verify_callback<F>(
             closure: *mut c_void,
@@ -269,17 +351,22 @@ impl<'c> Config<'c> {
             flags: *mut u32,
         ) -> c_int
         where
-            F: FnMut(&mut LinkedCertificate, i32, &mut VerifyError) -> Result<()>,
+            F: VerifyCallback + 'static,
         {
+            if crt.is_null() || closure.is_null() || flags.is_null() {
+                return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA;
+            }
+            
             let cb = &mut *(closure as *mut F);
-            let crt: &mut LinkedCertificate =
-                UnsafeFrom::from(crt).expect("valid certificate");
+            let crt: &mut Certificate = UnsafeFrom::from(crt).expect("valid certificate");
+            
             let mut verify_error = match VerifyError::from_bits(*flags) {
                 Some(ve) => ve,
                 // This can only happen if mbedtls is setting flags in VerifyError that are
                 // missing from our definition.
                 None => return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA,
             };
+            
             let res = cb(crt, depth, &mut verify_error);
             *flags = verify_error.bits();
             match res {
@@ -288,125 +375,76 @@ impl<'c> Config<'c> {
             }
         }
 
-        unsafe {
-            ssl_conf_verify(
-                &mut self.inner,
-                Some(verify_callback::<F>),
-                cb as *mut F as _,
-            )
-        }
+        
+        self.verify_callback = Some(Arc::new(cb));
+        unsafe { ssl_conf_verify(self.into(), Some(verify_callback::<F>), &**self.verify_callback.as_mut().unwrap() as *const _ as *mut c_void) }
     }
 
-    pub fn set_ca_callback<F>(&mut self, cb: &'c mut F)
-        where
-            F: FnMut(&LinkedCertificate, &mut ForeignOwnedCertListBuilder) -> Result<()>,
+    pub fn set_ca_callback<F>(&mut self, cb: F)
+    where
+        F: CaCallback + 'static,
     {
         unsafe extern "C" fn ca_callback<F>(
             closure: *mut c_void,
             child: *const x509_crt,
             candidate_cas: *mut *mut x509_crt
         ) -> c_int
-            where
-                F: FnMut(&LinkedCertificate, &mut ForeignOwnedCertListBuilder) -> Result<()>,
+        where
+            F: CaCallback + 'static,
         {
+            if child.is_null() || closure.is_null() || candidate_cas.is_null() {
+                return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA;
+            }
+
             let cb = &mut *(closure as *mut F);
-            let child: &LinkedCertificate = UnsafeFrom::from(child).expect("valid child certificate");
-            let mut cert_builder = ForeignOwnedCertListBuilder::new();
-            match cb(child, &mut cert_builder) {
-                Ok(()) => {
-                    *candidate_cas = cert_builder.to_x509_crt_ptr();
+            let crt: &MbedtlsList<Certificate> = UnsafeFrom::from(&child as *const *const x509_crt).expect("valid certificate");
+            match cb(&crt) {
+                Ok(list) => {
+                    // This does not leak due to mbedtls taking ownership from us and freeing the certificates itself. (logic is in: mbedtls-sys/vendor/library/x509_crt.c:2904)
+                    *candidate_cas = list.into_raw();
                     0
                 },
                 Err(e) => e.to_int(),
             }
         }
 
-        unsafe {
-            ssl_conf_ca_cb(
-                &mut self.inner,
-                Some(ca_callback::<F>),
-                cb as *mut F as _,
-            )
+        self.ca_callback = Some(Arc::new(cb));
+        unsafe { ssl_conf_ca_cb( self.into(), Some(ca_callback::<F>), &**self.ca_callback.as_mut().unwrap() as *const _ as *mut c_void) }
+    }
+
+    #[cfg(feature = "std")]
+    pub fn set_dbg_callback<F>(&mut self, cb: F)
+    where
+        F: DbgCallback + 'static,
+    {
+        #[allow(dead_code)]
+        unsafe extern "C" fn dbg_callback<F>(
+            closure: *mut c_void,
+            level: c_int,
+            file: *const c_char,
+            line: c_int,
+            message: *const c_char
+        ) -> ()
+        where
+            F: DbgCallback + 'static,
+        {
+            let cb = &mut *(closure as *mut F);
+
+            let file = match file.is_null() {
+                false => std::ffi::CStr::from_ptr(file).to_string_lossy(),
+                true => Cow::from(""),
+            };
+            
+            let message = match message.is_null() {
+                false => std::ffi::CStr::from_ptr(message).to_string_lossy(),
+                true => Cow::from(""),
+            };
+            
+            cb(level, file, line, message);
         }
-    }
-}
 
-/// Builds a linked list of x509_crt instances, all of which are owned by mbedtls. That is, the
-/// memory for these certificates has been allocated by mbedtls, on the C heap. This is needed for
-/// situations in which an mbedtls function takes ownership of a list of certs. The problem with
-/// handing such functions a "normal" cert list such as certificate::LinkedCertificate or
-/// certificate::List, is that those lists (at least partly) consist of memory allocated on the
-/// rust-side and hence cannot be freed on the c-side.
-pub struct ForeignOwnedCertListBuilder {
-    cert_list: *mut x509_crt,
-}
-
-impl ForeignOwnedCertListBuilder {
-    pub(crate) fn new() -> Self {
-        let cert_list = unsafe { calloc(1, core::mem::size_of::<x509_crt>()) } as *mut x509_crt;
-        if cert_list == ::core::ptr::null_mut() {
-            panic!("Out of memory");
-        }
-        unsafe { ::mbedtls_sys::x509_crt_init(cert_list); }
-
-        Self {
-            cert_list
-        }
-    }
-
-    pub fn push_back(&mut self, cert: &LinkedCertificate) {
-        self.try_push_back(cert.as_der()).expect("cert is a valid DER-encoded certificate");
-    }
-
-    pub fn try_push_back(&mut self, cert: &[u8]) -> Result<()> {
-        // x509_crt_parse_der will allocate memory for the cert on the C heap
-        unsafe { x509_crt_parse_der(self.cert_list, cert.as_ptr(), cert.len()) }.into_result()?;
-        Ok(())
-    }
-
-    // The memory pointed to by the return value is managed by mbedtls. If the return value is
-    // dropped without handing it to an mbedtls-function that takes ownership of it, that memory
-    // will be leaked.
-    pub(crate) fn to_x509_crt_ptr(mut self) -> *mut x509_crt {
-        let res = self.cert_list;
-        self.cert_list = ::core::ptr::null_mut();
-        res
-    }
-}
-
-impl Drop for ForeignOwnedCertListBuilder {
-    fn drop(&mut self) {
-        unsafe {
-            ::mbedtls_sys::x509_crt_free(self.cert_list);
-            free(self.cert_list as *mut c_void);
-        }
-    }
-}
-
-setter_callback!(Config<'c>::set_rng(f: crate::rng::Random) = ssl_conf_rng);
-setter_callback!(Config<'c>::set_dbg(f: DbgCallback) = ssl_conf_dbg);
-
-define!(
-    #[c_ty(ssl_key_cert)]
-    struct KeyCert;
-    impl<'a> UnsafeFrom<ptr> {}
-);
-
-pub struct KeyCertIter<'a> {
-    key_cert: Option<&'a KeyCert>,
-}
-
-impl<'a> Iterator for KeyCertIter<'a> {
-    type Item = (certificate::Iter<'a>, &'a Pk);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.key_cert.take().map(|key_cert| unsafe {
-            self.key_cert = UnsafeFrom::from(key_cert.inner.next as *const _);
-            (
-                UnsafeFrom::from(key_cert.inner.cert as *const _).expect("not null"),
-                UnsafeFrom::from(key_cert.inner.key as *const _).expect("not null"),
-            )
-        })
+        self.dbg_callback = Some(Arc::new(cb));
+        unsafe { ssl_conf_dbg(self.into(), Some(dbg_callback::<F>), &**self.dbg_callback.as_mut().unwrap() as *const _ as *mut c_void) }
     }
 }
 

--- a/mbedtls/src/ssl/mod.rs
+++ b/mbedtls/src/ssl/mod.rs
@@ -14,8 +14,8 @@ pub mod ticket;
 #[doc(inline)]
 pub use self::ciphersuites::CipherSuite;
 #[doc(inline)]
-pub use self::config::{Config, Version};
+pub use self::config::{Config, Version, UseSessionTickets};
 #[doc(inline)]
-pub use self::context::{Context, HandshakeContext, Session};
+pub use self::context::Context;
 #[doc(inline)]
 pub use self::ticket::TicketContext;

--- a/mbedtls/src/ssl/ticket.rs
+++ b/mbedtls/src/ssl/ticket.rs
@@ -6,12 +6,21 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use crate::cipher::raw::CipherType;
-use crate::error::{IntoResult, Result};
+#[cfg(feature = "std")]
+use std::sync::Arc;
+
+use mbedtls_sys::*;
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
-use mbedtls_sys::*;
 
+#[cfg(not(feature = "std"))]
+use crate::alloc_prelude::*;
+use crate::cipher::raw::CipherType;
+use crate::error::{IntoResult, Result};
+use crate::rng::RngCallback;
+
+
+#[cfg(not(feature = "threading"))]
 pub trait TicketCallback {
     unsafe extern "C" fn call_write(
         p_ticket: *mut c_void,
@@ -20,46 +29,78 @@ pub trait TicketCallback {
         end: *const c_uchar,
         tlen: *mut size_t,
         lifetime: *mut u32,
-    ) -> c_int;
+    ) -> c_int where Self: Sized;
     unsafe extern "C" fn call_parse(
         p_ticket: *mut c_void,
         session: *mut ssl_session,
         buf: *mut c_uchar,
         len: size_t,
-    ) -> c_int;
+    ) -> c_int where Self: Sized;
 
-    fn data_ptr(&mut self) -> *mut c_void;
+    fn data_ptr(&self) -> *mut c_void;
 }
+
+#[cfg(feature = "threading")]
+pub trait TicketCallback : Sync {
+    unsafe extern "C" fn call_write(
+        p_ticket: *mut c_void,
+        session: *const ssl_session,
+        start: *mut c_uchar,
+        end: *const c_uchar,
+        tlen: *mut size_t,
+        lifetime: *mut u32,
+    ) -> c_int where Self: Sized;
+    unsafe extern "C" fn call_parse(
+        p_ticket: *mut c_void,
+        session: *mut ssl_session,
+        buf: *mut c_uchar,
+        len: size_t,
+    ) -> c_int where Self: Sized;
+
+    fn data_ptr(&self) -> *mut c_void;
+}
+
 
 define!(
     #[c_ty(ssl_ticket_context)]
-    struct TicketContext<'rng>;
-    const init: fn() -> Self = ssl_ticket_init;
+    #[repr(C)]
+    struct TicketContext {
+        // We set rng from constructur, we never read it directly. It is only used to ensure rng lives as long as we need.
+        #[allow(dead_code)]
+        rng: Arc<dyn RngCallback + Send + 'static>,
+    };
     const drop: fn(&mut Self) = ssl_ticket_free;
+    impl<'a> Into<ptr> {}
 );
 
-impl<'rng> TicketContext<'rng> {
-    pub fn new<F: crate::rng::Random>(
-        rng: &'rng mut F,
+#[cfg(feature = "threading")]
+unsafe impl Sync for TicketContext {}
+
+impl TicketContext {
+    pub fn new<T: RngCallback + Send + 'static>(
+        rng: Arc<T>,
         cipher: CipherType,
         lifetime: u32,
-    ) -> Result<TicketContext<'rng>> {
-        let mut ret = Self::init();
+    ) -> Result<TicketContext> {
+
+        let mut ret = TicketContext { inner: ssl_ticket_context::default(), rng };
+
         unsafe {
+            ssl_ticket_init(&mut ret.inner);
             ssl_ticket_setup(
                 &mut ret.inner,
-                Some(F::call),
-                rng.data_ptr(),
+                Some(T::call),
+                ret.rng.data_ptr(),
                 cipher.into(),
                 lifetime,
-            )
+            ).into_result()?;
         }
-        .into_result()
-        .map(|_| ret)
+
+        Ok(ret)
     }
 }
 
-impl<'rng> TicketCallback for TicketContext<'rng> {
+impl TicketCallback for TicketContext {
     unsafe extern "C" fn call_write(
         p_ticket: *mut c_void,
         session: *const ssl_session,
@@ -80,7 +121,7 @@ impl<'rng> TicketCallback for TicketContext<'rng> {
         ssl_ticket_parse(p_ticket, session, buf, len)
     }
 
-    fn data_ptr(&mut self) -> *mut c_void {
-        &mut self.inner as *mut _ as *mut _
+    fn data_ptr(&self) -> *mut c_void {
+        self.handle() as *const _ as *mut _
     }
 }

--- a/mbedtls/src/wrapper_macros.rs
+++ b/mbedtls/src/wrapper_macros.rs
@@ -15,48 +15,101 @@ macro_rules! as_item {
 macro_rules! callback {
     //{ ($($arg:ident: $ty:ty),*) -> $ret:ty } => {
     //};
-    { $n:ident$( : $sync:ident )*($($arg:ident: $ty:ty),*) -> $ret:ty } => {
+    { $n:ident, $m:ident($($arg:ident: $ty:ty),*) -> $ret:ty } => {
         #[cfg(not(feature="threading"))]
         pub trait $n {
-            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret;
+            unsafe extern "C" fn call_mut(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized;
 
-            fn data_ptr(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
+            fn data_ptr_mut(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
         }
 
         #[cfg(feature="threading")]
-        pub trait $n $( : $sync )* {
-            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret;
+        pub trait $n : Sync {
+            unsafe extern "C" fn call_mut(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized;
 
-            fn data_ptr(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
+            fn data_ptr_mut(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
         }
 
         #[cfg(not(feature="threading"))]
         impl<F> $n for F where F: FnMut($($ty),*) -> $ret {
-            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret {
+            unsafe extern "C" fn call_mut(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized {
                 (&mut*(user_data as *mut F))($($arg),*)
             }
 
-            fn data_ptr(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
+            fn data_ptr_mut(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
                 self as *mut F as *mut _
             }
         }
 
         #[cfg(feature="threading")]
         impl<F> $n for F where F: Sync + FnMut($($ty),*) -> $ret {
-            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret {
+            unsafe extern "C" fn call_mut(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized {
                 (&mut*(user_data as *mut F))($($arg),*)
             }
 
-            fn data_ptr(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
-                self as *mut F as *mut _
+            fn data_ptr_mut(&mut self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
+                self as *const F as *mut _
             }
         }
+
+        #[cfg(not(feature="threading"))]
+        pub trait $m {
+            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized;
+            
+            fn data_ptr(&self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
+        }
+
+        #[cfg(feature="threading")]
+        pub trait $m :  Sync {
+            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized;
+            
+            fn data_ptr(&self) -> *mut ::mbedtls_sys::types::raw_types::c_void;
+        }
+
+        #[cfg(not(feature="threading"))]
+        impl<F> $m for F where F: Fn($($ty),*) -> $ret {
+            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized {
+                (&mut*(user_data as *mut F))($($arg),*)
+            }
+            
+            fn data_ptr(&self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
+                self as *const F as *mut F as *mut _
+            }
+        }
+
+        #[cfg(feature="threading")]
+        impl<F> $m for F where F: Sync + Fn($($ty),*) -> $ret {
+            unsafe extern "C" fn call(user_data: *mut ::mbedtls_sys::types::raw_types::c_void, $($arg:$ty),*) -> $ret where Self: Sized {
+                (&mut*(user_data as *mut F))($($arg),*)
+            }
+
+            fn data_ptr(&self) -> *mut ::mbedtls_sys::types::raw_types::c_void {
+                self as *const F as *mut _
+            }
+        }
+    };
+    ($t:ident: $($bound:tt)*) => {
+        #[cfg(not(feature = "threading"))]
+        pub trait $t: $($bound)* {}
+        #[cfg(feature = "threading")]
+        pub trait $t: $($bound)* + Sync {}
+
+        #[cfg(not(feature = "threading"))]
+        impl<F: $($bound)*> $t for F {}
+        #[cfg(feature = "threading")]
+        impl<F: $($bound)* + Sync> $t for F {}
     };
 }
 
 macro_rules! define {
-    { #[c_ty($inner:ident)] $(#[$m:meta])* struct $name:ident$(<$l:tt>)*; $($defs:tt)* } => {
-        define_struct!(define $(#[$m])* struct $name $(lifetime $l)* inner $inner);
+    // When using members, careful with UnsafeFrom, the data casted back must have been allocated on rust side.
+    { #[c_ty($inner:ident)] $(#[$m:meta])* struct $name:ident$(<$l:tt>)* $({ $($(#[$mm:meta])* $member:ident: $member_type:ty,)* })?; $($defs:tt)* } => {
+        define_struct!(define $(#[$m])* struct $name $(lifetime $l)* inner $inner members $($($(#[$mm])* $member: $member_type,)*)*);
+        define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
+    };
+    // Do not use UnsafeFrom with 'c_box_ty'. That is currently not supported as its not needed anywhere, support may be added in the future if needed anywhere.
+    { #[c_box_ty($inner:ident)] $(#[$m:meta])* struct $name:ident$(<$l:tt>)* $({ $($(#[$mm:meta])* $member:ident: $member_type:ty,)* })?; $($defs:tt)* } => {
+        define_struct!(define_box $(#[$m])* struct $name $(lifetime $l)* inner $inner members $($($(#[$mm])* $member: $member_type,)*)*);
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };
     {                   #[c_ty($raw:ty)] $(#[$m:meta])* enum $n:ident { $(#[$doc:meta] $rust:ident = $c:ident,)* } } => { define_enum!(                  $(#[$m])* enum $n ty $raw : $(doc ($doc) rust $rust c $c),*); };
@@ -102,13 +155,14 @@ macro_rules! define_enum {
 }
 
 macro_rules! define_struct {
-    { define $(#[$m:meta])* struct $name:ident $(lifetime $l:tt)* inner $inner:ident } => {
+    { define $(#[$m:meta])* struct $name:ident $(lifetime $l:tt)* inner $inner:ident members $($(#[$mm:meta])* $member:ident: $member_type:ty,)* } => {
         as_item!(
         #[allow(dead_code)]
         $(#[$m])*
         pub struct $name<$($l)*> {
             inner: ::mbedtls_sys::$inner,
             $(r: ::core::marker::PhantomData<&$l ()>,)*
+            $($(#[$mm])* $member: $member_type,)*
         }
         );
 
@@ -137,15 +191,45 @@ macro_rules! define_struct {
         );
     };
 
-    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> const init: fn() -> Self = $ctor:ident; $($defs:tt)* } => {
-        define_struct!(init $name () init $ctor $(lifetime $l)* );
+    { define_box $(#[$m:meta])* struct $name:ident $(lifetime $l:tt)* inner $inner:ident members $($(#[$mm:meta])* $member:ident: $member_type:ty,)* } => {
+        as_item!(
+        #[allow(dead_code)]
+        $(#[$m])*
+        pub struct $name<$($l)*> {
+            inner: Box<::mbedtls_sys::$inner>,
+            $(r: ::core::marker::PhantomData<&$l ()>,)*
+            $($(#[$mm])* $member: $member_type,)*
+        }
+        );
+
+        as_item!(
+        #[allow(dead_code)]
+        impl<$($l)*> $name<$($l)*> {
+            pub(crate) fn handle(&self) -> &::mbedtls_sys::$inner {
+                &*self.inner
+            }
+
+            pub(crate) fn handle_mut(&mut self) -> &mut ::mbedtls_sys::$inner {
+                &mut *self.inner
+            }
+        }
+        );
+
+        as_item!(
+        #[cfg(feature="threading")]
+        unsafe impl<$($l)*> Send for $name<$($l)*> {}
+        );
+    };
+    
+    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> const init: fn() -> Self = $ctor:ident $({ $($member:ident: $member_init:expr,)* })?; $($defs:tt)* } => {
+        define_struct!(init $name () init $ctor $(lifetime $l)* members $($($member: $member_init,)*)* );
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };
-    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> pub const new: fn() -> Self = $ctor:ident; $($defs:tt)* } => {
-        define_struct!(init $name (pub) new $ctor $(lifetime $l)* );
+    { << $name:ident $(lifetime $l:tt)* inner $inner:ident >> pub const new: fn() -> Self = $ctor:ident $({ $($member:ident: $member_init:expr,)* })?; $($defs:tt)* } => {
+        define_struct!(init $name (pub) new $ctor $(lifetime $l)* members $($($member: $member_init,)*)* );
         define_struct!(<< $name $(lifetime $l)* inner $inner >> $($defs)*);
     };
-    { init $name:ident ($($vis:tt)*) $new:ident $ctor:ident $(lifetime $l:tt)* } => {
+    { init $name:ident ($($vis:tt)*) $new:ident $ctor:ident $(lifetime $l:tt)* members $($member:ident: $member_init:expr,)*  } => {
         as_item!(
         #[allow(dead_code)]
         impl<$($l)*> $name<$($l)*> {
@@ -158,6 +242,7 @@ macro_rules! define_struct {
                 $name{
                     inner:inner,
                     $(r: ::core::marker::PhantomData::<&$l _>,)*
+                    $($member: $member_init,)*
                 }
             }
         }
@@ -172,7 +257,7 @@ macro_rules! define_struct {
         as_item!(
         impl<$($l)*> Drop for $name<$($l)*> {
             fn drop(&mut self) {
-                unsafe{::mbedtls_sys::$dtor(&mut self.inner)};
+                unsafe{::mbedtls_sys::$dtor(self.handle_mut())};
             }
         }
         );
@@ -186,7 +271,7 @@ macro_rules! define_struct {
         as_item!(
         impl<$l2,$($l),*> Into<*const $inner> for &$l2 $name<$($l)*> {
             fn into(self) -> *const $inner {
-                &self.inner
+                self.handle()
             }
         }
         );
@@ -194,7 +279,17 @@ macro_rules! define_struct {
         as_item!(
         impl<$l2,$($l),*> Into<*mut $inner> for &$l2 mut $name<$($l)*> {
             fn into(self) -> *mut $inner {
-                &mut self.inner
+                self.handle_mut()
+            }
+        }
+        );
+        as_item!(
+        impl<$($l),*> $name<$($l)*> {
+            /// Needed for compatibility with mbedtls - where we could pass
+            /// `*const` but function signature requires `*mut`
+            #[allow(dead_code)]
+            pub(crate) unsafe fn inner_ffi_mut(&self) -> *mut $inner {
+                self.handle() as *const _ as *mut $inner
             }
         }
         );
@@ -230,26 +325,8 @@ macro_rules! setter {
     { $(#[$m:meta])* $rfn:ident($n:ident : $rty:ty) = $cfn:ident } => {
         $(#[$m])*
         pub fn $rfn(&mut self, $n: $rty) {
-            unsafe{::mbedtls_sys::$cfn(&mut self.inner,$n.into())}
+            unsafe{::mbedtls_sys::$cfn(self.into(),$n.into())}
         }
-    }
-}
-
-// can't make this work without as as_XXX! macro, and there is no as_method!...
-macro_rules! setter_callback {
-    { $(#[$m:meta])* $s:ident<$l:tt>::$rfn:ident($n:ident : $($rty:tt)+) = $cfn:ident } => {
-        as_item!(
-        impl<$l> $s<$l> {
-            $(#[$m])*
-            pub fn $rfn<F: $($rty)+>(&mut self, $n: Option<&$l mut F>) {
-                unsafe{::mbedtls_sys::$cfn(
-                    &mut self.inner,
-                    $n.as_ref().map(|_|F::call as _),
-                    $n.map(|f|f.data_ptr()).unwrap_or(::core::ptr::null_mut())
-                )}
-            }
-        }
-        );
     }
 }
 
@@ -263,7 +340,129 @@ macro_rules! getter {
     { $(#[$m:meta])* $rfn:ident() -> $rty:ty = fn $cfn:ident } => {
         $(#[$m])*
         pub fn $rfn(&self) -> $rty {
-            unsafe{::mbedtls_sys::$cfn(&self.inner).into()}
+            unsafe{::mbedtls_sys::$cfn(self.into()).into()}
         }
     };
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    #[allow(dead_code)]
+    /// Utilities for testing whether types implement certain traits.
+    ///
+    /// For each trait `Trait` that you want to be able to test, you should
+    /// implement:
+    /// ```ignore
+    /// impl<T: “Trait”> Testable<dyn “Trait”> for T {}
+    /// ```
+    ///
+    /// Then, to test whether a type `Type` implements `Trait`, call:
+    /// ```ignore
+    /// TestTrait::<dyn “Trait”, “Type”>::new().impls_trait()
+    /// ```
+    /// This returns a `bool` indicating whether the trait is implemented. 
+    // This relies on auto-deref to distinguish between types that do and don't
+    // implement the trait.
+    mod testtrait {
+        use core::marker::PhantomData;
+
+        pub struct NonImplTrait<T> {
+            inner: PhantomData<T>
+        }
+
+        pub struct TestTrait<TraitObj: ?Sized, Type> {
+            non_impl: NonImplTrait<Type>,
+            phantom: PhantomData<*const TraitObj>,
+        }
+
+        pub trait Testable<T: ?Sized> {}
+
+        impl<TraitObj: ?Sized, Type> TestTrait<TraitObj, Type> {
+            pub fn new() -> Self {
+                TestTrait { non_impl: NonImplTrait { inner: PhantomData }, phantom: PhantomData }
+            }
+        }
+        
+        impl<TraitObj: ?Sized, Type: Testable<TraitObj>> TestTrait<TraitObj, Type> {
+            pub fn impls_trait(&self) -> bool {
+                true
+            }
+        }
+
+        impl<T> NonImplTrait<T> {
+            pub fn impls_trait(&self) -> bool {
+                false
+            }
+        }
+
+        impl<TraitObj: ?Sized, Type> core::ops::Deref for TestTrait<TraitObj, Type> {
+            type Target = NonImplTrait<Type>;
+            
+            fn deref(&self) -> &NonImplTrait<Type> {
+                &self.non_impl
+            }
+        }
+    }
+    
+    use testtrait::{TestTrait, Testable};
+
+    callback!(RustTest: Fn() -> ());
+    callback!(NativeTestMut,NativeTest() -> ());
+
+    impl<T: Sync> Testable<dyn Sync> for T {}
+    impl<T: RustTest> Testable<dyn RustTest> for T {}
+    impl<T: NativeTest> Testable<dyn NativeTest> for T {}
+    impl<T: NativeTestMut> Testable<dyn NativeTestMut> for T {}
+
+    #[test]
+    #[cfg(feature = "threading")]
+    fn callback_sync_with_threading() {
+        fn test_closure<T: RustTest>() {
+            assert!(TestTrait::<dyn Sync, T>::new().impls_trait(), "RustTest should be Sync");
+        }
+        fn test_native_closure<T: NativeTest>() {
+            assert!(TestTrait::<dyn Sync, T>::new().impls_trait(), "NativeTest should be Sync");
+        }
+        fn test_native_mut_closure<T: NativeTestMut>() {
+            assert!(TestTrait::<dyn Sync, T>::new().impls_trait(), "NativeTestMut should be Sync");
+        }
+
+        test_closure::<fn()->()>();
+        test_native_closure::<fn()->()>();
+        test_native_mut_closure::<fn()->()>();
+
+        assert!(!TestTrait::<dyn RustTest, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure shouldn't be RustTest");
+        assert!(TestTrait::<dyn RustTest, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be RustTest");
+        assert!(!TestTrait::<dyn NativeTest, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure shouldn't be NativeTest");
+        assert!(TestTrait::<dyn NativeTest, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be NativeTest");
+        assert!(!TestTrait::<dyn NativeTestMut, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure shouldn't be NativeTestMut");
+        assert!(TestTrait::<dyn NativeTestMut, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be NativeTestMut");
+    }
+
+    #[test]
+    #[cfg(not(feature = "threading"))]
+    fn callback_sync_without_threading() {
+        fn test_closure<T: RustTest>() {
+            assert!(!TestTrait::<dyn Sync, T>::new().impls_trait(), "RustTest shouldn't be Sync");
+        }
+        fn test_native_closure<T: NativeTest>() {
+            assert!(!TestTrait::<dyn Sync, T>::new().impls_trait(), "NativeTest shouldn't be Sync");
+        }
+        fn test_native_mut_closure<T: NativeTestMut>() {
+            assert!(!TestTrait::<dyn Sync, T>::new().impls_trait(), "NativeTestMut shouldn't be Sync");
+        }
+
+        test_closure::<fn()->()>();
+        test_native_closure::<fn()->()>();
+        test_native_mut_closure::<fn()->()>();
+
+        assert!(TestTrait::<dyn RustTest, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure should be RustTest");
+        assert!(TestTrait::<dyn RustTest, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be RustTest");
+        assert!(TestTrait::<dyn NativeTest, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure should be NativeTest");
+        assert!(TestTrait::<dyn NativeTest, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be NativeTest");
+        assert!(TestTrait::<dyn NativeTestMut, &dyn Fn()->()>::new().impls_trait(), "non-Sync closure should be NativeTestMut");
+        assert!(TestTrait::<dyn NativeTestMut, &(dyn Fn()->() + Sync)>::new().impls_trait(), "Sync closure should be NativeTestMut");
+    }
 }

--- a/mbedtls/src/x509/mod.rs
+++ b/mbedtls/src/x509/mod.rs
@@ -18,7 +18,7 @@ pub mod profile;
 // write_csr
 
 #[doc(inline)]
-pub use self::certificate::{Certificate, LinkedCertificate};
+pub use self::certificate::Certificate;
 pub use self::crl::Crl;
 #[doc(inline)]
 pub use self::csr::Csr;

--- a/mbedtls/tests/hyper.rs
+++ b/mbedtls/tests/hyper.rs
@@ -1,0 +1,532 @@
+use hyper::net::{NetworkStream, SslClient, SslServer};
+use std::fmt;
+use std::io;
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::borrow::Cow;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use mbedtls::ssl::{Config, Context};
+
+// Native TLS compatibility - to move to native tls client in the future
+#[derive(Clone)]
+pub struct TlsStream<T> {
+    context: Arc<Mutex<Context>>,
+    phantom: PhantomData<T>,
+}
+
+impl<T> TlsStream<T> {
+    pub fn new(context: Arc<Mutex<Context>>) -> Self {
+        TlsStream {
+            context: context,
+            phantom: PhantomData,
+        }
+    }
+}
+
+unsafe impl<T> Send for TlsStream<T> {}
+unsafe impl<T> Sync for TlsStream<T> {}
+
+impl<T> io::Read for TlsStream<T>
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.context.lock().unwrap().read(buf)
+    }
+}
+
+impl<T> io::Write for TlsStream<T>
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.context.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.context.lock().unwrap().flush()
+    }
+}
+
+impl<T> NetworkStream for TlsStream<T>
+    where T: NetworkStream
+{
+    fn peer_addr(&mut self) -> io::Result<SocketAddr> {
+        self.context.lock().unwrap().io_mut()
+            .ok_or(IoError::new(IoErrorKind::NotFound, "No peer available"))?
+            .downcast_mut::<T>().unwrap().peer_addr()
+    }
+    
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.context.lock().unwrap().io_mut()
+            .ok_or(IoError::new(IoErrorKind::NotFound, "No peer available"))?
+            .downcast_mut::<T>().unwrap().set_read_timeout(dur)
+    }
+
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.context.lock().unwrap().io_mut()
+            .ok_or(IoError::new(IoErrorKind::NotFound, "No peer available"))?
+            .downcast_mut::<T>().unwrap().set_write_timeout(dur)
+    }
+}
+
+
+#[derive(Clone)]
+pub struct MbedSSLServer {
+    rc_config: Arc<Config>,
+}
+
+impl MbedSSLServer {
+    pub fn new(rc_config: Arc<Config>) -> Self {
+        MbedSSLServer {
+            rc_config,
+        }
+    }
+}
+
+unsafe impl Send for MbedSSLServer {}
+
+/// An abstraction to allow any SSL implementation to be used with server-side HttpsStreams.
+impl<T> SslServer<T> for MbedSSLServer
+    where T: NetworkStream + Send + Clone + fmt::Debug + Sync
+{
+    /// The protected stream.
+    type Stream = TlsStream<T>;
+    
+    /// Wrap a server stream with SSL.
+    fn wrap_server(&self, stream: T) -> Result<Self::Stream, hyper::Error> {
+        let mut ctx = Context::new(self.rc_config.clone());
+        ctx.establish(stream, None).map_err(|e| hyper::error::Error::Ssl(e.into()))?;
+        Ok(TlsStream::new(Arc::new(Mutex::new(ctx))))
+    }
+}
+
+#[derive(Clone)]
+pub struct MbedSSLClient {
+    rc_config: Arc<Config>,
+    verify_hostname: bool,
+
+    // This can be used when verify_hostname is set to true.
+    // It will force ssl client to send this specific SNI on all established connections disregarding any host provided by hyper.
+    override_sni: Option<String>,
+}
+
+impl MbedSSLClient {
+    #[allow(dead_code)]
+    pub fn new(rc_config: Arc<Config>, verify_hostname: bool) -> Self {
+        MbedSSLClient {
+            rc_config,
+            verify_hostname,
+            override_sni: None,
+        }
+    }
+    
+    #[allow(dead_code)]
+    pub fn new_with_sni(rc_config: Arc<Config>, verify_hostname: bool, override_sni: Option<String>) -> Self {
+        MbedSSLClient {
+            rc_config,
+            verify_hostname,
+            override_sni,
+        }
+    }
+}
+
+impl<T> SslClient<T> for MbedSSLClient
+    where T: NetworkStream + Send + Clone + fmt::Debug + Sync
+{
+    type Stream = TlsStream<T>;
+
+    fn wrap_client(&self, stream: T, host: &str) -> hyper::Result<TlsStream<T>> {
+        let mut context = Context::new(self.rc_config.clone());
+
+        let verify_hostname = match self.verify_hostname {
+            true => Some(self.override_sni.as_ref().map(|v| v.as_str()).unwrap_or(host)),
+            false => None,
+        };
+        
+        match context.establish(stream, verify_hostname) {
+            Ok(()) => Ok(TlsStream::new(Arc::new(Mutex::new(context)))),
+            Err(e) => Err(hyper::Error::Ssl(Box::new(e))),
+        }
+    }
+}
+
+// To implement SSL tickets and have faster connections to the same remote server:
+// - implement Drop for TlsStream -> it should store the context into a cache.
+// - update wrap_client to use TlsStream cache
+//
+// This is similar to what hyper does for keep alive connections: hyper/src/client/pool.rs
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    use hyper::client::Pool;
+    use hyper::net::{HttpListener, HttpsConnector, HttpsListener, NetworkListener};
+    use hyper::status::StatusCode;
+    use mbedtls::pk::Pk;
+    use mbedtls::ssl::Config;
+    use mbedtls::ssl::config::{Endpoint, Preset, Transport, AuthMode, Version, UseSessionTickets, Renegotiation};
+    use mbedtls::ssl::context::HandshakeContext;
+    use mbedtls::x509::{Certificate, VerifyError};
+    use std::sync::Arc;
+    use mbedtls::ssl::CipherSuite::*;
+    use std::io::Write;
+    use mbedtls::ssl::TicketContext;
+    
+    #[cfg(not(target_env = "sgx"))]
+    use mbedtls::set_global_debug_threshold;
+    
+    #[cfg(not(target_env = "sgx"))]
+    use mbedtls::rng::{OsEntropy, CtrDrbg};
+
+    #[cfg(target_env = "sgx")]
+    use mbedtls::rng::{Rdrand};
+
+    #[cfg(not(target_env = "sgx"))]
+    pub fn rng_new() -> Arc<CtrDrbg> {
+        let entropy = Arc::new(OsEntropy::new());
+        let rng = Arc::new(CtrDrbg::new(entropy, None).unwrap());
+        rng
+    }
+
+    #[cfg(target_env = "sgx")]
+    pub fn rng_new() -> Arc<Rdrand> {
+        Arc::new(Rdrand)
+    }
+    
+    #[test]
+    fn test_simple_request() {
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+        config.set_authmode(AuthMode::None);
+        config.set_rng(rng_new());
+        config.set_min_version(Version::Tls1_2).unwrap();
+
+        let ssl = MbedSSLClient::new(Arc::new(config), false);
+        let connector = HttpsConnector::new(ssl);
+        let client = hyper::Client::with_connector(Pool::with_connector(Default::default(), connector));
+
+        let response = client.get("https://www.google.com/").send().unwrap();
+
+        assert_eq!(response.status, hyper::status::StatusCode::Ok);
+    }
+
+
+    #[test]
+    fn test_multiple_request() {
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+        config.set_rng(rng_new());
+        config.set_authmode(AuthMode::None);
+        config.set_min_version(Version::Tls1_2).unwrap();
+        
+        // Immutable from this point on
+        let ssl = MbedSSLClient::new(Arc::new(config), false);
+
+        let client1 = hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl.clone())));
+        let response = client1.get("https://www.google.com/").send().unwrap();
+        assert_eq!(response.status, hyper::status::StatusCode::Ok);
+
+        let client2 = hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl.clone())));
+        let response = client2.get("https://www.google.com/").send().unwrap();
+        assert_eq!(response.status, hyper::status::StatusCode::Ok);
+
+        let client3 = hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl.clone())));
+        let response = client3.get("https://www.google.com/").send().unwrap();
+        assert_eq!(response.status, hyper::status::StatusCode::Ok);
+    }
+
+    #[test]
+    fn test_hyper_multithread() {
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+        config.set_authmode(AuthMode::None);
+        config.set_rng(rng_new());
+        config.set_min_version(Version::Tls1_2).unwrap();
+        
+        let ssl = MbedSSLClient::new(Arc::new(config), false);
+        let client = Arc::new(hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl.clone()))));
+
+        let clone1 = client.clone();
+        let clone2 = client.clone();
+        let t1 = std::thread::spawn(move || {
+            let response = clone1.get("https://google.com").send().unwrap();
+            assert_eq!(response.status, hyper::status::StatusCode::Ok);
+        });
+        
+        let t2 = std::thread::spawn(move || {
+            clone2.post("https://google.com").body("foo=bar").send().unwrap();
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    }
+
+
+    #[test]
+    fn test_verify() {
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+        config.set_authmode(AuthMode::Required);
+        config.set_rng(rng_new());
+        config.set_min_version(Version::Tls1_2).unwrap();
+
+        let verify_callback = |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+            *verify_flags = VerifyError::CERT_OTHER;
+            Ok(())
+        };
+        config.set_verify_callback(verify_callback);
+
+        // This is mostly as an example - how to debug mbedtls
+        let dbg_callback = |level: i32, file: Cow<'_, str>, line: i32, message: Cow<'_, str>| {
+            println!("{} {}:{} {}", level, file, line, message);
+        };
+        config.set_dbg_callback(dbg_callback);
+
+        #[cfg(not(target_env = "sgx"))]
+        unsafe { set_global_debug_threshold(1); }
+        
+        config.set_ca_list(Arc::new(Certificate::from_pem_multiple(ROOT_CA_CERT).unwrap()), None);
+        
+        let ssl = MbedSSLClient::new(Arc::new(config), false);
+        let connector = HttpsConnector::new(ssl.clone());
+        let client = Arc::new(hyper::Client::with_connector(Pool::with_connector(Default::default(), connector)));
+
+        match client.get("https://google.com").send() {
+            Err(hyper::Error::Ssl(_)) => (),
+            _ => assert!(false),
+        };
+    }
+
+    
+    #[test]
+    fn test_hyper_server() {
+        std::env::set_var("RUST_BACKTRACE", "full");
+
+        let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+
+        config.set_rng(rng_new());
+        config.set_authmode(AuthMode::None);
+        config.set_min_version(Version::Tls1_2).unwrap();
+
+        let cert = Arc::new(Certificate::from_pem_multiple(PEM_CERT).unwrap());
+        let key = Arc::new(Pk::from_private_key(PEM_KEY, None).unwrap());
+        config.push_cert(cert, key).unwrap();
+        
+        let ssl = MbedSSLServer { rc_config: Arc::new(config) };
+
+        // Random port is intentional
+        let mut listener = HttpListener::new("127.0.0.1:0").unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let server = hyper::Server::new(HttpsListener::with_listener(listener, ssl));
+
+        let mut handler = server.handle_threads(move |mut _req: hyper::server::Request, mut res: hyper::server::Response| {
+            *res.status_mut() = StatusCode::MethodNotAllowed;
+        }, 3).unwrap();
+
+        std::thread::sleep(core::time::Duration::from_millis(10));
+        
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+        config.set_authmode(AuthMode::Required);
+        config.set_rng(rng_new());
+        config.set_min_version(Version::Tls1_2).unwrap();
+        config.set_ca_list(Arc::new(Certificate::from_pem_multiple(ROOT_CA_CERT).unwrap()), None);
+        
+        let ssl = MbedSSLClient::new(Arc::new(config), false);
+        let client = Arc::new(hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl.clone()))));
+
+        let client1 = client.clone();
+
+        // If this fails due to EWOULDBLOCK it means not enough threads were created.
+        let t1 = std::thread::Builder::new().spawn(move || {
+            let response = client1.post(&format!("https://{}/path", local_addr)).body("foo=bar").send();
+            println!("{:?}", response);
+        }).unwrap();
+
+        t1.join().unwrap();
+        handler.close().unwrap();
+    }
+
+    #[test]
+    fn test_sni_hyper_server() {
+        std::env::set_var("RUST_BACKTRACE", "full");
+
+        // This is mostly as an example - how to debug mbedtls
+        let dbg_callback = |level: i32, file: Cow<'_, str>, line: i32, message: Cow<'_, str>| {
+            println!("{} {}:{} {}", level, file, line, message);
+        };
+
+        // Enable as needed for debug
+        //set_global_debug_threshold(4);
+
+        let rng = rng_new();
+        
+        let (local_addr, server) = {
+            let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+
+            config.set_rng(rng.clone());
+            config.set_min_version(Version::Tls1_2).unwrap();
+            config.set_dbg_callback(dbg_callback.clone());
+
+            let cert = Arc::new(Certificate::from_pem_multiple(PEM_CERT).unwrap());
+            let key = Arc::new(Pk::from_private_key(PEM_KEY, None).unwrap());
+
+            let cipher_suites : Vec<i32> = vec![RsaWithAes128GcmSha256.into(), DheRsaWithAes128GcmSha256.into(), PskWithAes128GcmSha256.into(), DhePskWithAes128GcmSha256.into(), RsaPskWithAes128GcmSha256.into(), 0];
+
+            config.set_ciphersuites(Arc::new(cipher_suites));
+            
+            let sni_callback = move |ctx: &mut HandshakeContext, name: &[u8]| -> Result<(), mbedtls::Error> {
+                let name = std::str::from_utf8(name).unwrap();
+                if name == "mbedtls.example" {
+                    ctx.set_authmode(AuthMode::None).unwrap();
+                    ctx.push_cert(cert.clone(), key.clone()).unwrap();
+                    Ok(())
+                } else {
+                    return Err(mbedtls::Error::SslNoClientCertificate);
+                }
+            };
+
+            config.set_sni_callback(sni_callback);                                    
+
+            let tctx = TicketContext::new(rng.clone(), mbedtls::cipher::raw::CipherType::Aes128Gcm, 300).unwrap();
+            config.set_session_tickets_callback(Arc::new(tctx));
+
+            let ssl = MbedSSLServer { rc_config: Arc::new(config) };
+
+            // Random port is intentional
+            let mut listener = HttpListener::new("127.0.0.1:0").unwrap();
+
+            (listener.local_addr().unwrap(), hyper::Server::new(HttpsListener::with_listener(listener, ssl)))
+        };
+
+        let mut handler = server.handle_threads(move |mut _req: hyper::server::Request, mut res: hyper::server::Response| {
+            *res.status_mut() = StatusCode::MethodNotAllowed;
+        }, 3).unwrap();
+
+        std::thread::sleep(core::time::Duration::from_millis(10));
+        
+        let client = {
+            let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+
+            config.set_authmode(AuthMode::Required);
+            config.set_rng(rng.clone());
+            config.set_min_version(Version::Tls1_2).unwrap();
+            config.set_ca_list(Arc::new(Certificate::from_pem_multiple(ROOT_CA_CERT).unwrap()), None);
+
+            config.set_dbg_callback(dbg_callback.clone());
+            
+            config.set_session_tickets(UseSessionTickets::Enabled);
+            config.set_renegotiation(Renegotiation::Enabled);
+            
+            let ssl = MbedSSLClient::new_with_sni(Arc::new(config), true, Some("mbedtls.example".to_string()));
+            Arc::new(hyper::Client::with_connector(Pool::with_connector(Default::default(), HttpsConnector::new(ssl))))
+        };
+        
+        {
+            let response = client.post(&format!("https://{}/path", local_addr)).body("foo=bar").send().unwrap();
+            println!("Response: {}", response.status);
+            assert_eq!(response.status, StatusCode::MethodNotAllowed);
+        }
+        {
+            let response = client.post(&format!("https://{}/path", local_addr)).body("foo=bar").send().unwrap();
+            println!("Response: {}", response.status);
+            assert_eq!(response.status, StatusCode::MethodNotAllowed);
+        }
+        {
+            let response = client.post(&format!("https://{}/path", local_addr)).body("foo=bar").send().unwrap();
+            println!("Response: {}", response.status);
+            assert_eq!(response.status, StatusCode::MethodNotAllowed);
+        }
+
+        handler.close().unwrap();
+        std::io::stdout().flush().unwrap();
+    }
+
+
+// Signed by ROOT_CA below
+    pub const PEM_CERT: &'static [u8] = b"-----BEGIN CERTIFICATE-----
+MIIEGzCCAgOgAwIBAgIKElgwWDKDQhBIOTANBgkqhkiG9w0BAQsFADARMQ8wDQYD
+VQQDEwZSb290Q0EwIBcNMjAwNTA4MDkxNDMwWhgPMjEwMDA0MTkwOTE0MzBaMBox
+GDAWBgNVBAMMD21iZWR0bHMuZXhhbXBsZTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAN/SZjoB4zxaOxgtCjC6c88Y8twUUtNoNJu+D2X1vjoEEmeh0CCA
+x6fvyDbZE7kad5pTVHWdiaepodWzTf4GcuGKa0qP0jwitDuqBoqraDxYT9saQd4I
+rh8tPanoDQO2V6iewJT59EFxwC6pry+EWPox1UuKzd66x5a+yTq4d7ybkgBjoico
++0I4m+4BxZNPmZDSdIZpgfMANGvTZCLt/x4gypqotHH//8sssucJJgMwD+YybYis
+wtRCt+Atw2YUQe0JhLs8nMTRQXqREBpz250hITpNsior4PhNsjiMElEFqx0ZmT84
+tQW6lpJ5Yz297xAeUXrdVl+DrvvdhfrqJJ8CAwEAAaNqMGgwHQYDVR0OBBYEFJvl
+m+3MJ2eYR9dGydOY0QNRRMaAMDkGA1UdIwQyMDCAFIkuNd0n1URsu71cJCyBnQwO
+MsqLoRWkEzARMQ8wDQYDVQQDEwZSb290Q0GCAQEwDAYDVR0TAQH/BAIwADANBgkq
+hkiG9w0BAQsFAAOCAgEAGbkSdZL5BC46GTGSR09lEh+cZ2o4fP6uSbkyT4xEPRWx
+fNMLZeEJPVzZkar5tVDnpBb3gAoArHIn6ePPiTssYUD/3yN7ZL6YFn4Bg0VBig8e
+ZWzQT6BiAmXKRY7JtDdgnhggxfo1x1bwW0r3qz/BYeC1cdqbC9CRmTPFNIKFhZyY
+fC1BQ49dI/prfiBlgGO/bIDZfzMNC9b5b7g5aKVQH1e1ViGkRKL4l6tIKp/pL7Nx
+1e1H/f2cl33rm+kTvkH5H02Z+Fg2tVnx2xPxMIkpGOnhtrh5H48xT1oxqcZ/ySmp
+W7xiCt4QAW7DafRLwhsMhKSxcBxHEl4mRTX2pz5BV5yyq/rTGDRFQAlzBUEteLh3
+fCPsdYOQEQMdPUzx3VAieaHSbR424kcd5Iw3uMBCk2NzyLxbIWKA4Q+9XFIacEdh
+TFO2Z/pvkTWMOo1yKzC8NM26QT/o0USgtHBIc2F8FlGEYBLZXvqtOeKJ5mneyLR/
+jnAr18OJv+/DPPSv4qB6LpF+CAQFm0pZisqZdwsMBRgWQ3wml/A+lOLmiajNB3gk
+XfzmCVga7Kik6cjP0ExV7rRvvQ9akWgsMLYJm28Ck6k3Nl3AsfiAGf5kFj5VlBrd
+Ecs4CTdh5ZsL2pDU+QmWsqRNdN+Kz1IVX7fLvR48MgpKZhK+d97/P37e1kEtXoo=
+-----END CERTIFICATE-----\0";
+
+    pub const PEM_KEY: &'static [u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDf0mY6AeM8WjsY
+LQowunPPGPLcFFLTaDSbvg9l9b46BBJnodAggMen78g22RO5GneaU1R1nYmnqaHV
+s03+BnLhimtKj9I8IrQ7qgaKq2g8WE/bGkHeCK4fLT2p6A0DtleonsCU+fRBccAu
+qa8vhFj6MdVLis3euseWvsk6uHe8m5IAY6InKPtCOJvuAcWTT5mQ0nSGaYHzADRr
+02Qi7f8eIMqaqLRx///LLLLnCSYDMA/mMm2IrMLUQrfgLcNmFEHtCYS7PJzE0UF6
+kRAac9udISE6TbIqK+D4TbI4jBJRBasdGZk/OLUFupaSeWM9ve8QHlF63VZfg677
+3YX66iSfAgMBAAECggEAL/Pq9Picj7yhNo/HxCLeVvt4ZNBx4ltMEiYJNIYO6G0g
+6FURuzT8Ea3czmt5v0m9YDIEQWKsMGC2jItq5UbKbCn0zLe9iibBSJsn5aPNpEgj
+a8TXYdOoQoO112YhC6+QXk8M4Z4fx7mwPA8cumh3i7sLgLDPZK3Nvy1G/a6x8JVZ
+g3W1Oyrbn29z1XANTAj2Q0NrdTogKUgNOLYRWB9SeONCnWQmxtzx3jlUIGSn5J9T
+RBQo5ZIhRqOOe8Td3coU+OJ+Z2g7XETTlU3hYmi70/PeXaRxq3k9sX95LtnjgduK
+r2H0KNxyhCmC8cdXL5ogBfnnLColW4Ya1/vyN7sAIQKBgQDwPYJcz3636j8xh1Pt
+U4kxfA4ozqDOXK6jnl6ujhYfwhAghEEFqV2yWYkQbLkkQu2ewRuQxNYLCT+O6WBH
+DF8uoYBtbdH47MLM+TuLUnglHEC1qwwaO62Eb+2cn5f1i5Z/mLQOG3uxlnSPbIC5
+2mEpKmWqdFJAGwOF3/rbVr+88QKBgQDugSqpXgIg4RR3rRzUZog/ReieoG+cf2WO
+rHfmIXBSACktfoQMlrgO/sD2zq1sjQXSUNbQCzMV7kIrLrb+Y7xtZljFJj3wSG/k
+LQBJy1qk7uVfoFfndmYgrkb7+aNkMR0KrqEZPuS3bmXcD2BUzzgYsD9LoC5nD55U
+EAnKGRE6jwKBgQCmtpiLnXZbXJQj47xrGig/jc4ppVJUQl7yrkkYKwPRYBNe7UhO
+DH038gg6vKgyMLvDClD9woqit/VCUFN+mmhG7M45ohcu/eYk5ePbSAyV/CgvqZZJ
+chZ0rFOg9+M1A3wZ6bcxfwL0dutGSE6AKrp4HbLVeclGMTjdo1Pq+CUwkQKBgQDU
+MWEGTFgybm4qR38lzY8cVBMwxeZm4sU1GWaW/VsT6Ya5Lh1HofRhiu+c5aZPtGvg
+gQGNGNm7gj2mc6plS9DBuFP0GyDyHVBHPm5KOT0NDmpOGLb8fE9Cdis7VQ+0PSns
+bg9wCY+tTvAayCdZbP8on+3AV+PQ14lyms5K2uCEKwKBgQCrpoMycTrB2KOczWNp
+kZouBK4tU5rGjBj3/0p+wHszyCOtiX5sdBT66eRHYY/t9YcOTWA8w3OO/8sj4X4d
+nMsuXM/jD/NWW9JD9+vPUQz4db5evhQBNIkOG4FIRnSh15pDIcEeLxEamNV82fRS
+26jlsLNCILTT9RsfswR3U+1GuA==
+-----END PRIVATE KEY-----\0";
+
+pub const ROOT_CA_CERT: &'static [u8] = b"-----BEGIN CERTIFICATE-----
+MIIE4jCCAsqgAwIBAgIBATANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZSb290
+Q0EwHhcNMTkwOTA1MTg0NTMyWhcNMjEwMzA1MTg0NTI2WjARMQ8wDQYDVQQDEwZS
+b290Q0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQD6AOBz7HbIi8w3
+Wjjk16oglHRQcICTkvgfl6gbGuSjOoVHmOAn2EWT9AuXtcyNcVFyk90h0dsadqkJ
+Enrk3BkTJQmtGW0u5UvcI+famYjZDvYQpGcgXBFmrH7/g/BN4v5VvdrXxUVy6Uyv
+Ql60yG7JxlMY8K2OMV13bOpABXhnG/zNr1hCPLQWu52Mn3M1nudFBZff7tZz4dBo
+YoMeXkIWQ3t2wypD3WunlQcuGxNOCcXONZRDzeUidh/Yv/4tTggZe8KAnEngKb86
+KwKAhVjinGIN2C+ISpKsDurDxhExA2Na6+EbtLEgkI9AeoBz6tIjt/yv/inil+Du
+fEDSmG+P97oY1GNcZMkftjjJd0u57YWz0Ck5bfHdgploh/1VHGdoC677MDWJOb31
+O3mGdpTiBHP2Gh6Xwm8NuZc+tQSPVr/GaYg7slLBl/7GWU9QGjr9DGj/qYozD8tT
+cazIHFh9zDP4XC+a+D+3lMA5EMfvVmDmr2QZJoiKBrxbNXXZ0QQcc+Wr9jFBBx/i
+BRlpnxr+EDG+Q7nFnbG6x1DkvKhc1KDGBhq/HDb5bBVSr7Pjl2FMNh8HVX64mDbA
+7clQJHa1rIjB+HxtZB5DNKQbRobyrWgkTpi5XHPhMw966zrhBWgOdAh+PSeq9FEf
+Y0w328/EBWGqIg3rRMOvDAQpbojNdwIDAQABo0UwQzAOBgNVHQ8BAf8EBAMCAQYw
+EgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUiS413SfVRGy7vVwkLIGdDA4y
+yoswDQYJKoZIhvcNAQELBQADggIBAHcRzQhesOTpFG4KINJyzZf7a5lrc8kayTaL
+lzSXW1pEl3/OFiMvOayjDq+yVAJB+5j3WZu8AOTFuZ4pBjz2I1hdIt5F2asqnVN3
+8ymuC7t4gNAQGhWJldnsL58iTYGlxFciiT/8QSHJJjYRkKxyhF08Oj3Zbs13J4xc
+ENLmwCZMFait+qm7aX3idnUa1XMGO26ioQOi0uEVqu9N4p62OQKd/76vmnaqmIAw
+5s47DaaUi7DeiBguLZrNzfZcJTAHNM5VxCjsXW4PieN6mJhQSar40794n7HLHxtG
+Xc5UdxT3nLclEAviDJFubA1N/szWtu4vdfehdAKCXkIjwoUEVEOpPYEeYr27JFlP
+kaxezxswwxY2UD0MZq21FhO7SpVQdmmvfoJvjQwIsiyoa9UNzC6mTqsJPjln+2mK
+p6WHzX+E6GeA7Ng6CyvJsHRsqbQdJ0OXHm4GIG2Z05r4AgBtvI6hkhSfAotBt3Xi
+lo5BEO6SbUnPYo03zD4x/76c4j/uZLYxy2n+Qrlm2KTQIUu7KEsKdUnLAxjWYePH
+VxcYz0/9Z5H4OzhW4J1Qd6OBW0dqETLlMJauPX5DV/slyYQQasPStEJGgiDiKG+B
+Jpjv6PefPTqZawP6gPoGmhF4UyMRWZ+NgqLft1uXTHhrHdnrZFag1oPLjxWFs5hx
+pElsC4v+
+-----END CERTIFICATE-----\0";
+}

--- a/mbedtls/tests/ssl_conf_verify.rs
+++ b/mbedtls/tests/ssl_conf_verify.rs
@@ -16,13 +16,14 @@ use mbedtls::pk::Pk;
 use mbedtls::rng::CtrDrbg;
 use mbedtls::ssl::config::{Endpoint, Preset, Transport};
 use mbedtls::ssl::{Config, Context};
-use mbedtls::x509::{Certificate, LinkedCertificate, VerifyError};
+use mbedtls::x509::{Certificate, VerifyError};
 use mbedtls::Error;
 use mbedtls::Result as TlsResult;
 
 mod support;
 use support::entropy::entropy_new;
 use support::keys;
+use std::sync::Arc;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum Test {
@@ -30,27 +31,31 @@ enum Test {
     CallbackError,
 }
 
-fn client(mut conn: TcpStream, test: Test) -> TlsResult<()> {
-    let mut entropy = entropy_new();
-    let mut rng = CtrDrbg::new(&mut entropy, None)?;
-    let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
-    let verify_callback =
-        &mut |_: &mut LinkedCertificate, _, verify_flags: &mut VerifyError| match test {
+fn client(conn: TcpStream, test: Test) -> TlsResult<()> {
+    let entropy = entropy_new();
+    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT)?);
+
+    let verify_test = test.clone();
+    let verify_callback = move |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+        match verify_test {
             Test::CallbackSetVerifyFlags => {
                 *verify_flags |= VerifyError::CERT_OTHER;
                 Ok(())
             }
             Test::CallbackError => Err(Error::Asn1InvalidData),
-        };
+        }
+    };
+    
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
-    config.set_rng(Some(&mut rng));
+    config.set_rng(rng);
     config.set_verify_callback(verify_callback);
-    config.set_ca_list(Some(&mut *cert), None);
-    let mut ctx = Context::new(&config)?;
+    config.set_ca_list(cert, None);
+    let mut ctx = Context::new(Arc::new(config));
 
     match (
         test,
-        ctx.establish(&mut conn, None)
+        ctx.establish(conn, None)
             .err()
             .expect("should have failed"),
     ) {
@@ -67,17 +72,17 @@ fn client(mut conn: TcpStream, test: Test) -> TlsResult<()> {
     Ok(())
 }
 
-fn server(mut conn: TcpStream) -> TlsResult<()> {
-    let mut entropy = entropy_new();
-    let mut rng = CtrDrbg::new(&mut entropy, None)?;
-    let mut cert = Certificate::from_pem(keys::PEM_CERT)?;
-    let mut key = Pk::from_private_key(keys::PEM_KEY, None)?;
+fn server(conn: TcpStream) -> TlsResult<()> {
+    let entropy = entropy_new();
+    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT)?);
+    let key = Arc::new(Pk::from_private_key(keys::PEM_KEY, None)?);
     let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
-    config.set_rng(Some(&mut rng));
-    config.push_cert(&mut *cert, &mut key)?;
-    let mut ctx = Context::new(&config)?;
+    config.set_rng(rng);
+    config.push_cert(cert, key)?;
+    let mut ctx = Context::new(Arc::new(config));
 
-    let _ = ctx.establish(&mut conn, None);
+    let _ = ctx.establish(conn, None);
     Ok(())
 }
 

--- a/mbedtls/tests/support/entropy.rs
+++ b/mbedtls/tests/support/entropy.rs
@@ -7,7 +7,7 @@
  * according to those terms. */
 
 #[cfg(all(feature = "std", not(feature = "rdrand")))]
-pub fn entropy_new<'a>() -> crate::mbedtls::rng::OsEntropy<'a> {
+pub fn entropy_new() -> crate::mbedtls::rng::OsEntropy {
     crate::mbedtls::rng::OsEntropy::new()
 }
 

--- a/mbedtls/valgrind_unittests.sh
+++ b/mbedtls/valgrind_unittests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# This is to quickly run unit tests before delivery.
+# Output is verbose on purpose, there must be no memory errors before reviews/merges.
+#
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --num-callers=100 --track-origins=yes --leak-check=full --track-fds=yes --time-stamp=yes --malloc-fill=fd --free-fill=fd" cargo test --features=default,pthread


### PR DESCRIPTION
Moving from referene counting allows simpler move to native-tls / hyper.

Arc Changes:
- Each Config/Context/... will hold Arcs towards items it holds pointers to.
- This forces objects to live as long as needed, once no longer used they get destroyed by reference counting.

This allows passing the objects to multiple threads without worrying about lifetime.
I've also added notes why classes are Sync where used. Let me know if I missed any classes.

Usage example of an intermediate mbed-hyper integration is at: 
- https://github.com/fortanix/rust-mbedtls/tree/acruceru/wip-mbed-hyper-v2/mbedtls-hyper/examples/integrations

There I added a crate to wrap hyper - similar to native-tls. (that will be moved to native-tls layer soon)
That crate can be considered an integration test that I will raise a separate PR for.


Edit:

Changes after initial review:
-    Added forward_mbedtls_calloc / forward_mbedtls_free functions so we can pass certificates to and from mbedtls without allocator mismatches/corruptions.
-    Switched to MbedtlsList<Certificate> and Certificate. A MbedtlsBox is pending for this PR as well.
-    Fixed most comments.

Still pending:
-    Update define! macros
-    Add MbedtlsBox<Certificate>


Fixes https://github.com/fortanix/rust-mbedtls/issues/1
Partial progress on https://github.com/fortanix/rust-mbedtls/issues/3
Fixes https://github.com/fortanix/rust-mbedtls/issues/4
Fixes https://github.com/fortanix/rust-mbedtls/issues/8
Partially addresses https://github.com/fortanix/rust-mbedtls/issues/9