### PR TITLE
Clean up features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,12 @@ rust:
    - beta
    - nightly
    - nightly-2019-07-01
-   - nightly-2019-10-28
 env:
   global:
     - RUST_BACKTRACE=1
     # Pinned to this particular nightly version because of core_io. This can be
     # re-pinned whenever core_io is updated to the latest nightly.
     - CORE_IO_NIGHTLY=nightly-2019-07-01
-    - SGX_NIGHTLY=nightly-2019-10-28
     - LLVM_CONFIG_PATH=llvm-config-3.8
 script:
   - ./ct.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,11 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "chrono"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +251,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,12 +294,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mbedtls"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_io 0.1.20190701 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -312,7 +323,9 @@ name = "mbedtls-sys-auto"
 version = "2.24.0"
 dependencies = [
  "bindgen 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -763,6 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clang-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19911f7964ce61a02d382adee8400f919d0fedd53c5441e3d6a9858ba73e249e"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
@@ -780,6 +794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"

--- a/README.md
+++ b/README.md
@@ -18,23 +18,24 @@ This crate depends on the mbedtls-sys-auto crate, see below for build details.
 This is a list of the Cargo features available for mbedtls. Features in
 **bold** are enabled by default.
 
-* **aesni** Enable support for the AES-NI instructions.
-* *core_io* On no_std, you must enable this feature. It will supply the I/O
-            Read and Write traits.
+* **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
+            enabled automatically.
+* *debug* Enable debug printing to stdout. You need to configure the debug
+          threshold at runtime.
 * *force_aesni_support* MbedTLS normally uses runtime detection of AES-NI
                         support. With this feature, always use AES-NI. This
                         will result in undefined instruction exceptions on
-                        unsupported processors.
-* **legacy_protocols** Enable support for SSLv3, TLSv1.0 and TLSv1.1
+                        unsupported processors. On SGX, this feature is
+                        enabled automatically.
+* *legacy_protocols* Enable support for SSLv3, TLSv1.0 and TLSv1.1
+* *no_std_deps* On no_std, you must enable this feature. It enables optional
+                dependencies needed on no_std. If the `std` feature is enabled,
+                this feature is ignored.
 * **padlock** Enable support for VIA padlock.
 * *pkcs12* Enable code to parse PKCS12 files using yasna
 * *pkcs12_rc2* Enable use of RC2 crate to decrypt RC2-encrypted PKCS12 files
-* *pthread* Enable mutex synchronization using pthreads.
-* *rdrand* Enable the RDRAND random number generator.
-* *rust_threading* Enable mutex synchronization using the `std::sync::Mutex`.
-                   spin_threading takes precedence over rust_threading.
-* *spin_threading* Enable mutex synchronization using the spin crate.
-* *sgx* Enables features recommended for x86\_64-fortanix-unknown-sgx target.
+* *rdrand* Enable the RDRAND random number generator. On SGX, this feature is
+           enabled automatically.
 * **std** If this feature is not enabled, this crate is a no_std crate. (An
           allocator is *required*) The necessary C functions to make MbedTLS
           work without libc will be provided.
@@ -76,35 +77,44 @@ The build script will perform the following steps:
 This is a list of the Cargo features available for mbedtls-sys. Features in
 **bold** are enabled by default.
 
-* **aesni** Enable support for the AES-NI instructions.
+* **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
+            enabled automatically.
 * *aes_alt* Allow an alternative implementation of AES, replacing the
   T-tables code.
 * *custom_has_support* Override runtime feature detection. In a dependent
                        crate, you must define the functions
                        `mbedtls_aesni_has_support` and
                        `mbedtls_padlock_has_support` following the MbedTLS
-                       function signatures.
+                       function signatures. On SGX, this feature is enabled
+                       automatically.
 * *custom_printf* Provide a custom printf implementation. printf is only used
                   for the self tests. In a dependent crate, you must define the
                   `mbedtls_printf` function with the standard printf signature.
-* *custom_threading* Provide a custom threading implementation. In a dependent
-                     crate, you must define the functions `mbedtls_mutex_init`,
-                     `mbedtls_mutex_free`, `mbedtls_mutex_lock`, and
-                     `mbedtls_mutex_unlock` following the MbedTLS function
-                     signatures.
+* **debug** Enable debug callbacks.
 * *havege* Enable the Hardware Volatile Entropy Gathering and Expansion
            (HAVEGE) algorithm.
 * **legacy_protocols** Enable support for SSLv3, TLSv1.0 and TLSv1.1
 * **padlock** Enable support for VIA padlock.
 * *pkcs11* Enable PKCS#11 support. This requires pkcs11-helper to be installed.
-* **pthread** Enable threading support using pthreads.
 * **std** If this feature is not enabled, this crate is a no_std crate. In a
           no_std configuration without libc, you need to provide your own
-          versions of the following standard C functions: calloc/free, and
-          strstr/strlen/strncpy/strncmp/strcmp/snprintf, and
-          memmove/memcpy/memcmp/memset, and rand/printf. For printf, you can
-          optionally use the `custom_printf` feature.
-* **time** Enable time support.
+          versions of the following standard C functions: `calloc()`/`free()`,
+          and `strstr()`/`strlen()`/`strncpy()`/`strncmp()`/`strcmp()`/
+          `snprintf()`, and `memmove()`/`memcpy()`/`memcmp()`/`memset()`, and
+          `rand()`/`printf()`. For `printf()`, you can optionally use the
+          `custom_printf` feature. `rand()` is only needed for the selftests.
+          On UNIX platforms, this also enables networking, filesystems and OS
+          entropy.
+* **threading** Enable threading support. On `cfg(unix)` platforms, this uses
+                pthreads. On other platforms, you need to provide a custom
+                threading implementation. In a dependent crate, you must define
+                the functions `mbedtls_mutex_init()`, `mbedtls_mutex_free()`,
+                `mbedtls_mutex_lock()`, and `mbedtls_mutex_unlock()` following
+                the  MbedTLS function signatures.
+* **time** Enable time support. On `cfg(unix)` platforms, this uses `libc`. On
+           other platforms, you need to provide your own implementations of
+           `mbedtls_platform_gmtime_r(const long long*, struct tm*)` and
+           `mbedtls_time(long long*)`.
 * *trusted_cert_callback* Enable trusted certificate callback support.
 * **zlib** Enable zlib support.
 

--- a/ct.sh
+++ b/ct.sh
@@ -13,21 +13,17 @@ if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [
     rustup default $TRAVIS_RUST_VERSION
     # make sure that explicitly providing the default target works
     cargo test --target x86_64-unknown-linux-gnu
-    cargo test --features spin_threading
-    cargo test --features rust_threading
     cargo test --features zlib
     cargo test --features pkcs12
     cargo test --features pkcs12_rc2
     cargo test --features force_aesni_support
-    cargo test --features default,pthread
+
+    rustup target add --toolchain $TRAVIS_RUST_VERSION x86_64-fortanix-unknown-sgx
+    cargo +$TRAVIS_RUST_VERSION test --no-run --target=x86_64-fortanix-unknown-sgx
 
 elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand,time,custom_time,custom_gmtime_r
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand
-
-elif [ $TRAVIS_RUST_VERSION = $SGX_NIGHTLY ]; then
-    rustup target add --toolchain $SGX_NIGHTLY x86_64-fortanix-unknown-sgx
-    cargo +$SGX_NIGHTLY test --no-run --target=x86_64-fortanix-unknown-sgx --features=sgx --no-default-features
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand,time
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand
 
 else
     echo "Unknown version $TRAVIS_RUST_VERSION"

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -4,7 +4,6 @@ version = "2.24.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0/GPL-2.0+"
-#edition = "2018"
 description = """
 Rust bindings for MbedTLS.
 
@@ -18,12 +17,16 @@ links = "mbedtls"
 name = "mbedtls_sys"
 
 [dependencies]
-libc = { version = "0.2.0", optional = true }
+cfg-if = "1.0.0"
 libz-sys = { version = "1.0.0", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2.0" }
 
 [build-dependencies]
 bindgen = "0.19.0"
 cmake = "0.1.17"
+lazy_static = "1.4"
 
 [features]
 # If you use mbedtls-sys in a no_std configuration, you need to provide your
@@ -33,15 +36,12 @@ cmake = "0.1.17"
 # * strstr/strlen/strncpy/strncmp/strcmp/snprintf
 # * memmove/memcpy/memcmp/memset
 # * rand/printf (used only for self tests. optionally use custom_printf)
-default = ["std", "zlib", "time", "pthread", "aesni", "padlock", "legacy_protocols"]
-std = []
+default = ["std", "debug", "threading", "zlib", "time", "aesni", "padlock", "legacy_protocols"]
+std = ["debug"] # deprecated automatic enabling of debug, can be removed on major version bump
+debug = []
 custom_printf = []
-custom_time = ["custom_gmtime_r", "time"]
-custom_gmtime_r = ["time"]
 custom_has_support = []
 aes_alt = []
-custom_threading = ["threading"]
-pthread = ["libc","threading"]
 threading = []
 time = []
 havege = ["time"]
@@ -52,3 +52,8 @@ padlock = []
 legacy_protocols = []
 mpi_force_c_code = []
 trusted_cert_callback = []
+# deprecated features, these don't do anything anymore, can be removed on major version bump
+custom_threading = ["threading"]
+pthread = ["threading"]
+custom_time = ["time"]
+custom_gmtime_r = ["time"]

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -8,7 +8,7 @@
 
 use cmake;
 
-use crate::have_feature;
+use crate::features::FEATURES;
 
 impl super::BuildConfig {
     pub fn cmake(&self) {
@@ -20,11 +20,7 @@ impl super::BuildConfig {
         .define("ENABLE_PROGRAMS", "OFF")
         .define("ENABLE_TESTING", "OFF")
         .build_target("lib");
-        if !have_feature("std")
-            || ::std::env::var("TARGET")
-                .map(|s| (s == "x86_64-unknown-none-gnu") || (s == "x86_64-fortanix-unknown-sgx"))
-                == Ok(true)
-        {
+        if FEATURES.have_platform_component("c_compiler", "freestanding") {
             cmk.cflag("-fno-builtin")
                 .cflag("-D_FORTIFY_SOURCE=0")
                 .cflag("-fno-stack-protector");

--- a/mbedtls-sys/build/config.rs
+++ b/mbedtls-sys/build/config.rs
@@ -409,20 +409,11 @@ pub const FEATURE_DEFINES: &'static [(&'static str, CDefine)] = &[
     ("time",                  ("MBEDTLS_HAVE_TIME",                         Defined)),
     ("time",                  ("MBEDTLS_HAVE_TIME_DATE",                    Defined)),
     ("time",                  ("MBEDTLS_TIMING_C",                          Defined)),
-    ("custom_time",           ("MBEDTLS_PLATFORM_TIME_MACRO",               DefinedAs("mbedtls_time"))),
-    ("custom_time",           ("MBEDTLS_PLATFORM_TIME_TYPE_MACRO",          DefinedAs("long long"))),
-    ("custom_gmtime_r",       ("MBEDTLS_PLATFORM_GMTIME_R_ALT",             Defined)),
     ("havege",                ("MBEDTLS_HAVEGE_C",                          Defined)),
     ("threading",             ("MBEDTLS_THREADING_C",                       Defined)),
-    ("pthread",               ("MBEDTLS_THREADING_PTHREAD",                 Defined)),
-    ("custom_threading",      ("MBEDTLS_THREADING_IMPL",                    Defined)),
     ("pkcs11",                ("MBEDTLS_PKCS11_C",                          Defined)),
     ("zlib",                  ("MBEDTLS_ZLIB_SUPPORT",                      Defined)),
-    ("std",                   ("MBEDTLS_NET_C",                             Defined)),
-    ("std",                   ("MBEDTLS_FS_IO",                             Defined)),
-    ("std",                   ("MBEDTLS_NO_PLATFORM_ENTROPY",               Undefined)),
-    ("std",                   ("MBEDTLS_DEBUG_C",                           Defined)),
-    ("std",                   ("MBEDTLS_ENTROPY_C",                         Defined)),
+    ("debug",                 ("MBEDTLS_DEBUG_C",                           Defined)),
     ("custom_printf",         ("MBEDTLS_PLATFORM_C",                        Defined)),
     ("custom_printf",         ("MBEDTLS_PLATFORM_PRINTF_MACRO",             DefinedAs("mbedtls_printf"))),
     ("aesni",                 ("MBEDTLS_AESNI_C",                           Defined)),
@@ -437,6 +428,19 @@ pub const FEATURE_DEFINES: &'static [(&'static str, CDefine)] = &[
     ("aes_alt",               ("MBEDTLS_AES_DECRYPT_ALT",                   Defined)),
     ("mpi_force_c_code",      ("MBEDTLS_MPI_FORCE_C_CODE",                  Defined)),
     ("trusted_cert_callback", ("MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK", Defined)),
+];
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+pub const PLATFORM_DEFINES: &'static [(&'static str, &'static str, CDefine)] = &[
+    ("time",      "custom",   ("MBEDTLS_PLATFORM_TIME_MACRO",               DefinedAs("mbedtls_time"))),
+    ("time",      "custom",   ("MBEDTLS_PLATFORM_TIME_TYPE_MACRO",          DefinedAs("long long"))),
+    ("time",      "custom",   ("MBEDTLS_PLATFORM_GMTIME_R_ALT",             Defined)),
+    ("threading", "pthread",  ("MBEDTLS_THREADING_PTHREAD",                 Defined)),
+    ("threading", "custom",   ("MBEDTLS_THREADING_IMPL",                    Defined)),
+    ("std",       "net",      ("MBEDTLS_NET_C",                             Defined)),
+    ("std",       "fs",       ("MBEDTLS_FS_IO",                             Defined)),
+    ("std",       "entropy",  ("MBEDTLS_NO_PLATFORM_ENTROPY",               Undefined)),
+    ("std",       "entropy",  ("MBEDTLS_ENTROPY_C",                         Defined)),
 ];
 
 pub const SUFFIX: &'static str = r#"

--- a/mbedtls-sys/build/features.rs
+++ b/mbedtls-sys/build/features.rs
@@ -1,0 +1,95 @@
+use std::collections::{HashMap, HashSet};
+use std::env;
+
+pub struct Features {
+    platform_components: HashMap<&'static str, HashSet<&'static str>>,
+    automatic_features: HashSet<&'static str>,
+}
+
+lazy_static! {
+    pub static ref FEATURES: Features = {
+        let mut ret = Features {
+            platform_components: HashMap::new(),
+            automatic_features: HashSet::new(),
+        };
+
+        ret.init();
+
+        ret
+    };
+}
+
+impl Features {
+    fn init(&mut self) {
+        if env_have_target_cfg("env", "sgx") {
+            self.automatic_features.insert("custom_has_support");
+            self.automatic_features.insert("aes_alt");
+            self.automatic_features.insert("aesni");
+        }
+        self.automatic_features.insert("c_compiler");
+
+        if !self.have_feature("std") ||
+            env_have_target_cfg("env", "sgx") ||
+            env_have_target_cfg("os", "none") {
+            self.with_feature("c_compiler").unwrap().insert("freestanding");
+        }
+        if let Some(components) = self.with_feature("threading") {
+            if env_have_target_cfg("family", "unix") {
+                components.insert("pthread");
+            } else {
+                components.insert("custom");
+            }
+        }
+        if let Some(components) = self.with_feature("std") {
+            if env_have_target_cfg("family", "unix") {
+                components.insert("net");
+                components.insert("fs");
+                components.insert("entropy");
+            }
+        }
+        if let Some(components) = self.with_feature("time") {
+            if env_have_target_cfg("family", "unix") {
+                components.insert("libc");
+            } else {
+                components.insert("custom");
+            }
+        }
+
+        for (feature, components) in &self.platform_components {
+            for component in components {
+                println!(r#"cargo:rustc-cfg={}_component="{}""#, feature, component);
+            }
+        }
+        println!("cargo:platform-components={}",
+            self.platform_components.iter().flat_map(|(feature, components)| {
+                components.iter().map(move |component| format!(r#"{}_component={}"#, feature, component))
+            } ).collect::<Vec<_>>().join(",")
+        );
+    }
+
+    fn with_feature(&mut self, feature: &'static str) -> Option<&mut HashSet<&'static str>> {
+        if self.have_feature(feature) {
+            Some(self.platform_components.entry(feature).or_insert_with(HashSet::new))
+        } else {
+            None
+        }
+    }
+
+    pub fn have_platform_component(&self, feature: &'static str, component: &'static str) -> bool {
+        self.platform_components.get(feature).map_or(false, |feat| feat.contains(component))
+    }
+
+    pub fn have_feature(&self, feature: &'static str) -> bool {
+        self.automatic_features.contains(feature) || env_have_feature(feature)
+    }
+}
+
+fn env_have_target_cfg(var: &'static str, value: &'static str) -> bool {
+    let env = format!("CARGO_CFG_TARGET_{}", var).to_uppercase().replace("-", "_");
+    env::var_os(env).map_or(false, |s| s == value)
+}
+
+fn env_have_feature(feature: &'static str) -> bool {
+    let env = format!("CARGO_FEATURE_{}", feature).to_uppercase().replace("-", "_");
+    env::var_os(env).is_some()
+}

--- a/mbedtls-sys/build/headers.rs
+++ b/mbedtls-sys/build/headers.rs
@@ -6,7 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-use crate::have_feature;
+use crate::features::FEATURES;
 
 /* This list has been generated from a include/mbedtls/ directory as follows:
  *
@@ -106,7 +106,7 @@ pub const ORDERED: &'static [(Option<&'static str>, &'static str)] = &[
 
 pub fn enabled_ordered() -> Box<dyn Iterator<Item = &'static str>> {
     Box::new(ORDERED.iter().filter_map(|&(feat, h)| {
-        if feat.map(have_feature).unwrap_or(true) {
+        if feat.map_or(true, |feat| FEATURES.have_feature(feat)) {
             Some(h)
         } else {
             None

--- a/mbedtls-sys/src/lib.rs
+++ b/mbedtls-sys/src/lib.rs
@@ -10,6 +10,9 @@
 #[cfg(feature = "std")]
 extern crate core;
 
+#[macro_use]
+extern crate cfg_if;
+
 pub mod types;
 include!(concat!(env!("OUT_DIR"), "/mod-bindings.rs"));
 
@@ -19,9 +22,3 @@ pub use bindings::*;
    https://github.com/rust-lang-nursery/rust-bindgen/issues/231
 */
 pub const ECDSA_MAX_LEN : u32 = 141;
-
-#[cfg(all(feature = "time", not(feature = "custom_time"), not(feature = "libc")))]
-impl _ERROR_MUST_ENABLE_EITHER_CUSTOM_TIME_OR_LIBC_ for _TIME_FEATURE_ {}
-
-#[cfg(all(feature = "time", not(feature = "custom_gmtime_r"), not(feature = "libc")))]
-impl _ERROR_MUST_ENABLE_EITHER_CUSTOM_GMTIME_R_OR_LIBC_ for _TIME_FEATURE_ {}

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls"
-version = "0.6.1"
+version = "0.8.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
@@ -19,7 +19,6 @@ keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
 bitflags = "1"
-chrono = { version = "0.4", optional = true }
 core_io = { version = "0.1", features = ["collections"], optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
@@ -28,14 +27,16 @@ byteorder = "1.0.0"
 yasna = { version = "0.2", optional = true }
 block-modes = { version = "0.3", optional = true }
 rc2 = { version = "0.3", optional = true }
+cfg-if = "1.0.0"
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.1.0"
+chrono = "0.4"
 
 [dependencies.mbedtls-sys-auto]
 version = "2.18.5"
 default-features = false
-features = ["custom_printf", "trusted_cert_callback"]
+features = ["custom_printf", "trusted_cert_callback", "threading"]
 path = "../mbedtls-sys"
 
 [dev-dependencies]
@@ -51,78 +52,40 @@ cc = "1.0"
 
 [features]
 # Features are documented in the README
-default = ["std", "aesni", "time", "padlock", "legacy_protocols", "use_libc"]
+default = ["std", "aesni", "time", "padlock"]
 std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
-threading = []
-pthread = ["threading","std","mbedtls-sys-auto/pthread"]
-spin_threading = ["threading","spin","mbedtls-sys-auto/custom_threading"]
-sgx = ["std", "rust_threading", "rdrand", "force_aesni_support"]
-rust_threading = ["threading", "mbedtls-sys-auto/custom_threading", "std"]
-force_aesni_support = ["mbedtls-sys-auto/custom_has_support","mbedtls-sys-auto/aes_alt","aesni"]
+debug = ["mbedtls-sys-auto/debug"]
+no_std_deps = ["core_io", "spin"]
+force_aesni_support = ["mbedtls-sys-auto/custom_has_support", "mbedtls-sys-auto/aes_alt", "aesni"]
 mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []
-use_libc = ["mbedtls-sys-auto/libc"]
-custom_gmtime_r = ["mbedtls-sys-auto/custom_gmtime_r", "chrono"]
-custom_time = ["mbedtls-sys-auto/custom_time", "chrono"]
 aesni = ["mbedtls-sys-auto/aesni"]
 zlib = ["mbedtls-sys-auto/zlib"]
 time = ["mbedtls-sys-auto/time"]
 padlock = ["mbedtls-sys-auto/padlock"]
-legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "block-modes"]
 
 [[example]]
 name = "client"
-path = "examples/client.rs"
 required-features = ["std"]
 
 [[example]]
 name = "server"
-path = "examples/server.rs"
 required-features = ["std"]
 
 [[test]]
 name = "client_server"
-path = "tests/client_server.rs"
 required-features = ["std"]
 
 [[test]]
-name = "ec"
-path = "tests/ec.rs"
-
-[[test]]
-name = "pbkdf"
-path = "tests/pbkdf.rs"
-
-[[test]]
-name = "mbedtls_self_tests"
-path = "tests/mbedtls_self_tests.rs"
-
-[[test]]
-name = "bignum"
-path = "tests/bignum.rs"
-
-[[test]]
-name = "rsa"
-path = "tests/rsa.rs"
-
-[[test]]
-name = "save_restore"
-path = "tests/save_restore.rs"
-
-[[test]]
 name = "ssl_conf_ca_cb"
-path = "tests/ssl_conf_ca_cb.rs"
 required-features = ["std"]
 
 [[test]]
 name = "ssl_conf_verify"
-path = "tests/ssl_conf_verify.rs"
 required-features = ["std"]
-
 
 [[test]]
 name = "hyper"
-path = "tests/hyper.rs"
-required-features = ["std", "threading"]
+required-features = ["std"]

--- a/mbedtls/build.rs
+++ b/mbedtls/build.rs
@@ -6,24 +6,28 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate cc;
-
+use std::collections::{HashMap, HashSet};
 use std::env;
 
 fn main() {
+    let env_components = env::var("DEP_MBEDTLS_PLATFORM_COMPONENTS").unwrap();
+    let mut sys_platform_components = HashMap::<_, HashSet<_>>::new();
+    for mut kv in env_components.split(",").map(|component| component.splitn(2, "=")) {
+        let k = kv.next().unwrap();
+        let v = kv.next().unwrap();
+        sys_platform_components.entry(k).or_insert_with(Default::default).insert(v);
+        println!(r#"cargo:rustc-cfg=sys_{}="{}""#, k, v);
+    }
+
     let mut b = cc::Build::new();
-    b.include(env::var_os("DEP_MBEDTLS_INCLUDE").expect("Links was not properly set in mbedtls-sys package, missing DEP_MBEDTLS_INCLUDE"));
-    let config_file = format!("\"{}\"", env::var_os("DEP_MBEDTLS_CONFIG_H").expect("Links was not properly set in mbedtls-sys package, missing DEP_MBEDTLS_CONFIG_H").to_str().unwrap());
+    b.include(env::var_os("DEP_MBEDTLS_INCLUDE").unwrap());
+    let config_file = format!(r#""{}""#, env::var("DEP_MBEDTLS_CONFIG_H").unwrap());
     b.define("MBEDTLS_CONFIG_FILE",
              Some(config_file.as_str()));
     
     b.file("src/mbedtls_malloc.c");
     b.file("src/rust_printf.c");
-    if env::var_os("CARGO_FEATURE_STD").is_none()
-        || ::std::env::var("TARGET")
-	    .map(|s| (s == "x86_64-unknown-none-gnu") || (s == "x86_64-fortanix-unknown-sgx"))
-	    == Ok(true)
-    {
+    if sys_platform_components.get("c_compiler").map_or(false, |comps| comps.contains("freestanding")) {
         b.flag("-U_FORTIFY_SOURCE")
             .define("_FORTIFY_SOURCE", Some("0"))
             .flag("-ffreestanding");

--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -6,6 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use std::io::{self, stdin, stdout, Write};

--- a/mbedtls/examples/server.rs
+++ b/mbedtls/examples/server.rs
@@ -6,6 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use std::io::{BufRead, BufReader, Write};

--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -453,6 +453,8 @@ mod tests {
         assert!(secp256r1 == copy); //can't use assert_eq as EcGroup doesn't impl Debug
     }
 
+    // FIXME: very slow on SGX https://github.com/fortanix/rust-mbedtls/issues/134
+    #[cfg_attr(target_env = "sgx", ignore)]
     #[test]
     fn test_ec_compressed_points() {
         let groups = [

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -227,7 +227,6 @@ define!(
 //
 // - Only used when creating/freeing - which is safe by design: ecdsa_alloc_wrap, ecdsa_free_wrap
 //
-#[cfg(feature = "threading")]
 unsafe impl Sync for Pk {}
 
 impl Pk {

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -19,11 +19,6 @@ use crate::alloc_prelude::*;
 
 use core::result::Result as StdResult;
 
-#[cfg(feature = "pkcs12_rc2")]
-extern crate block_modes;
-#[cfg(feature = "pkcs12_rc2")]
-extern crate rc2;
-
 use core::fmt;
 
 #[cfg(feature = "std")]

--- a/mbedtls/src/rng/ctr_drbg.rs
+++ b/mbedtls/src/rng/ctr_drbg.rs
@@ -44,7 +44,6 @@ define!(
 // That is avoided by having any users of the callback hold an 'Arc' to this class.
 // Rust will then ensure that a mutable reference cannot be aquired if more then 1 Arc exists to the same class.
 //
-#[cfg(feature = "threading")]
 unsafe impl Sync for CtrDrbg {}
 
 #[allow(dead_code)]

--- a/mbedtls/src/rng/hmac_drbg.rs
+++ b/mbedtls/src/rng/hmac_drbg.rs
@@ -30,7 +30,6 @@ define!(
     impl<'a> Into<ptr> {}
 );
 
-#[cfg(feature = "threading")]
 unsafe impl Sync for HmacDrbg {}
 
 impl HmacDrbg {

--- a/mbedtls/src/rng/mod.rs
+++ b/mbedtls/src/rng/mod.rs
@@ -8,19 +8,19 @@
 
 pub mod ctr_drbg;
 pub mod hmac_drbg;
-#[cfg(all(feature = "std", not(target_env = "sgx")))]
+#[cfg(sys_std_component = "entropy")]
 pub mod os_entropy;
-#[cfg(feature = "rdrand")]
+#[cfg(any(feature = "rdrand", target_env = "sgx"))]
 mod rdrand;
 
 #[doc(inline)]
 pub use self::ctr_drbg::CtrDrbg;
 #[doc(inline)]
 pub use self::hmac_drbg::HmacDrbg;
-#[cfg(all(feature = "std", not(target_env = "sgx")))]
+#[cfg(sys_std_component = "entropy")]
 #[doc(inline)]
 pub use self::os_entropy::OsEntropy;
-#[cfg(feature = "rdrand")]
+#[cfg(any(feature = "rdrand", target_env = "sgx"))]
 pub use self::rdrand::{Entropy as Rdseed, Nrbg as Rdrand};
 
 use crate::error::{Result, IntoResult};

--- a/mbedtls/src/rng/os_entropy.rs
+++ b/mbedtls/src/rng/os_entropy.rs
@@ -36,7 +36,6 @@ define!(
 // That is avoided by having any users of the callback hold an 'Arc' to this class.
 // Rust will then ensure that a mutable reference cannot be aquired if more then 1 Arc exists to the same class.
 //
-#[cfg(feature = "threading")]
 unsafe impl Sync for OsEntropy {}
 
 #[allow(dead_code)]

--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -135,7 +135,6 @@ define!(
     impl<'a> Into<ptr> {}
 );
 
-#[cfg(feature = "threading")]
 unsafe impl Sync for Config {}
 
 impl Config {

--- a/mbedtls/src/ssl/ticket.rs
+++ b/mbedtls/src/ssl/ticket.rs
@@ -19,29 +19,7 @@ use crate::cipher::raw::CipherType;
 use crate::error::{IntoResult, Result};
 use crate::rng::RngCallback;
 
-
-#[cfg(not(feature = "threading"))]
-pub trait TicketCallback {
-    unsafe extern "C" fn call_write(
-        p_ticket: *mut c_void,
-        session: *const ssl_session,
-        start: *mut c_uchar,
-        end: *const c_uchar,
-        tlen: *mut size_t,
-        lifetime: *mut u32,
-    ) -> c_int where Self: Sized;
-    unsafe extern "C" fn call_parse(
-        p_ticket: *mut c_void,
-        session: *mut ssl_session,
-        buf: *mut c_uchar,
-        len: size_t,
-    ) -> c_int where Self: Sized;
-
-    fn data_ptr(&self) -> *mut c_void;
-}
-
-#[cfg(feature = "threading")]
-pub trait TicketCallback : Sync {
+pub trait TicketCallback: Sync {
     unsafe extern "C" fn call_write(
         p_ticket: *mut c_void,
         session: *const ssl_session,
@@ -73,7 +51,6 @@ define!(
     impl<'a> Into<ptr> {}
 );
 
-#[cfg(feature = "threading")]
 unsafe impl Sync for TicketContext {}
 
 impl TicketContext {

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -464,10 +464,8 @@ impl<'a> Builder<'a> {
 // x509write_crt_set_subject_key_identifier
 //
 
-#[cfg(feature = "threading")]
 unsafe impl Send for MbedtlsBox<Certificate> {}
 
-#[cfg(feature = "threading")]
 unsafe impl Sync for MbedtlsBox<Certificate> {}
 
 impl MbedtlsBox<Certificate> {
@@ -528,10 +526,8 @@ impl<'a> UnsafeFrom<*mut *mut x509_crt> for &'a mut Option<MbedtlsBox<Certificat
     }
 }
 
-#[cfg(feature = "threading")]
 unsafe impl Send for MbedtlsList<Certificate> {}
 
-#[cfg(feature = "threading")]
 unsafe impl Sync for MbedtlsList<Certificate> {}
 
 impl MbedtlsList<Certificate> {

--- a/mbedtls/tests/bignum.rs
+++ b/mbedtls/tests/bignum.rs
@@ -6,8 +6,6 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate mbedtls;
-
 use mbedtls::bignum::{Mpi, Sign};
 
 #[cfg(feature = "std")]

--- a/mbedtls/tests/client_server.rs
+++ b/mbedtls/tests/client_server.rs
@@ -8,6 +8,7 @@
 
 #![cfg(not(target_env = "sgx"))]
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use std::io::{Read, Write};

--- a/mbedtls/tests/ec.rs
+++ b/mbedtls/tests/ec.rs
@@ -6,6 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use mbedtls::hash::Md;

--- a/mbedtls/tests/hyper.rs
+++ b/mbedtls/tests/hyper.rs
@@ -174,9 +174,6 @@ mod tests {
     use mbedtls::ssl::TicketContext;
     
     #[cfg(not(target_env = "sgx"))]
-    use mbedtls::set_global_debug_threshold;
-    
-    #[cfg(not(target_env = "sgx"))]
     use mbedtls::rng::{OsEntropy, CtrDrbg};
 
     #[cfg(target_env = "sgx")]
@@ -283,9 +280,6 @@ mod tests {
         };
         config.set_dbg_callback(dbg_callback);
 
-        #[cfg(not(target_env = "sgx"))]
-        unsafe { set_global_debug_threshold(1); }
-        
         config.set_ca_list(Arc::new(Certificate::from_pem_multiple(ROOT_CA_CERT).unwrap()), None);
         
         let ssl = MbedSSLClient::new(Arc::new(config), false);
@@ -357,9 +351,6 @@ mod tests {
         let dbg_callback = |level: i32, file: Cow<'_, str>, line: i32, message: Cow<'_, str>| {
             println!("{} {}:{} {}", level, file, line, message);
         };
-
-        // Enable as needed for debug
-        //set_global_debug_threshold(4);
 
         let rng = rng_new();
         

--- a/mbedtls/tests/pbkdf.rs
+++ b/mbedtls/tests/pbkdf.rs
@@ -6,8 +6,6 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate mbedtls;
-
 use mbedtls::hash::Type as MdType;
 use mbedtls::hash::{pbkdf2_hmac, pbkdf_pkcs12};
 

--- a/mbedtls/tests/rsa.rs
+++ b/mbedtls/tests/rsa.rs
@@ -6,6 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use mbedtls::hash::Type::Sha256;

--- a/mbedtls/tests/save_restore.rs
+++ b/mbedtls/tests/save_restore.rs
@@ -6,11 +6,6 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate mbedtls;
-extern crate mbedtls_sys;
-extern crate serde_cbor;
-// extern crate rustc_serialize;
-
 use mbedtls::cipher;
 use mbedtls::cipher::raw::{CipherId, CipherMode, CipherPadding};
 use mbedtls::cipher::{Cipher, Decryption, Encryption, Fresh, Authenticated, Traditional};

--- a/mbedtls/tests/ssl_conf_ca_cb.rs
+++ b/mbedtls/tests/ssl_conf_ca_cb.rs
@@ -7,6 +7,8 @@
  * according to those terms. */
 
 #![allow(dead_code)]
+
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use std::net::TcpStream;

--- a/mbedtls/tests/ssl_conf_verify.rs
+++ b/mbedtls/tests/ssl_conf_verify.rs
@@ -8,6 +8,7 @@
 
 #![allow(dead_code)]
 
+// needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
 use std::net::TcpStream;

--- a/mbedtls/tests/support/entropy.rs
+++ b/mbedtls/tests/support/entropy.rs
@@ -6,17 +6,18 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-#[cfg(all(feature = "std", not(feature = "rdrand")))]
-pub fn entropy_new() -> crate::mbedtls::rng::OsEntropy {
-    crate::mbedtls::rng::OsEntropy::new()
-}
-
-#[cfg(feature = "rdrand")]
-pub fn entropy_new() -> crate::mbedtls::rng::Rdseed {
-    crate::mbedtls::rng::Rdseed
-}
-
-#[cfg(all(not(feature = "std"), not(feature = "rdrand")))]
-pub fn entropy_new() -> _UNABLE_TO_RUN_TEST_WITHOUT_ENTROPY_SOURCE_ {
-    panic!("Unable to run test without entropy source")
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "rdrand", target_env = "sgx"))] {
+        pub fn entropy_new() -> crate::mbedtls::rng::Rdseed {
+            crate::mbedtls::rng::Rdseed
+        }
+    } else if #[cfg(feature = "std")] {
+        pub fn entropy_new() -> crate::mbedtls::rng::OsEntropy {
+            crate::mbedtls::rng::OsEntropy::new()
+        }
+    } else {
+        pub fn entropy_new() -> ! {
+            panic!("Unable to run test without entropy source")
+        }
+    }
 }

--- a/mbedtls/tests/support/mod.rs
+++ b/mbedtls/tests/support/mod.rs
@@ -9,6 +9,6 @@
 #![allow(dead_code)]
 pub mod entropy;
 pub mod keys;
-#[cfg(all(feature = "std", not(target_env = "sgx")))]
+#[cfg(sys_std_component = "net")]
 pub mod net;
 pub mod rand;

--- a/mbedtls/tests/support/net.rs
+++ b/mbedtls/tests/support/net.rs
@@ -6,8 +6,6 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate libc;
-
 use std::io::{Error as IoError, Result as IoResult};
 use std::net::TcpStream;
 use std::os::unix::io::FromRawFd;

--- a/mbedtls/tests/support/rand.rs
+++ b/mbedtls/tests/support/rand.rs
@@ -6,14 +6,10 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-extern crate core;
-extern crate mbedtls_sys;
-extern crate rand;
+use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
+use mbedtls_sys::types::size_t;
 
-use self::mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
-use self::mbedtls_sys::types::size_t;
-
-use self::rand::{Rng, XorShiftRng};
+use rand::{Rng, XorShiftRng};
 
 /// Not cryptographically secure!!! Use for testing only!!!
 pub struct TestRandom(XorShiftRng);
@@ -22,7 +18,7 @@ impl crate::mbedtls::rng::RngCallbackMut for TestRandom {
     unsafe extern "C" fn call_mut(p_rng: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         (*(p_rng as *mut TestRandom))
             .0
-            .fill_bytes(self::core::slice::from_raw_parts_mut(data, len));
+            .fill_bytes(core::slice::from_raw_parts_mut(data, len));
         0
     }
 
@@ -35,7 +31,7 @@ impl crate::mbedtls::rng::RngCallback for TestRandom {
     unsafe extern "C" fn call(p_rng: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         (*(p_rng as *mut TestRandom))
             .0
-            .fill_bytes(self::core::slice::from_raw_parts_mut(data, len));
+            .fill_bytes(core::slice::from_raw_parts_mut(data, len));
         0
     }
 


### PR DESCRIPTION
Features are now split into two categories: cargo features and
platform features. Platform features are dependent on the
compilation target and automatically selected when needed. This
removes the (broken) mechanism of selecting backend implementations
based on cargo features. Enabled platform features are passed from
`mbedtls-sys` to dependent crates so they can change their
implementation as needed.

As part of this change, it's no longer possible to build the
`mbedtls` crate without threading support. Support may be added
again in the future if there's a need for it. The `mbedtls-sys`
crate can still be built without threading support.

The changes to `mbedtls-sys` are intended to not be a breaking
change (except for the removal of the libc feature, which had
not been explicitly advertised to users).

Also some cleanup related to Rust 2018 edition.