### PR TITLE
Re-introduce libc “feature” for mbedtls-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mbedtls-sys-auto 2.25.0",
+ "mbedtls-sys-auto 2.25.1",
  "num-bigint 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.25.0"
+version = "2.25.1"
 dependencies = [
  "bindgen 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.25.0"
+version = "2.25.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0/GPL-2.0+"
@@ -19,6 +19,9 @@ name = "mbedtls_sys"
 [dependencies]
 cfg-if = "1.0.0"
 libz-sys = { version = "1.0.0", optional = true }
+# deprecated dependency, this don't do anything anymore, but still needed to
+# provide the `libc` feature, can be removed on major version bump
+libc = { version = "0.2.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.0" }


### PR DESCRIPTION
Well it turns out that we immediately ran into what I called [“intended to not be a breaking change, except libc”](https://github.com/fortanix/rust-mbedtls/pull/135)