### PR TITLE
Add sysroot support for GNU based toolchains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,31 @@ addons:
     - clang-3.9
     - clang-11
     - cmake
+    - qemu-user
 rust:
    - stable
    - beta
    - nightly
    - nightly-2021-03-25
 env:
+  jobs:
+    # Matrix build of 3 targets against the above rust toolchain releases
+    - TARGET=aarch64-unknown-linux-musl
+    - TARGET=x86_64-fortanix-unknown-sgx
+    - TARGET=x86_64-unknown-linux-gnu ZLIB_INSTALLED=true AES_NI_SUPPORT=true
   global:
     - RUST_BACKTRACE=1
     # Pinned to this particular nightly version because of core_io. This can be
     # re-pinned whenever core_io is updated to the latest nightly.
     - CORE_IO_NIGHTLY=nightly-2021-03-25
     - LLVM_CONFIG_PATH=llvm-config-3.9
+
+before_script:
+  - if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
+      cd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
+      tar -xvzf aarch64-linux-musl-cross.tgz;
+      cd $TRAVIS_BUILD_DIR;
+    fi
+
 script:
   - ./ct.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,28 +23,23 @@ addons:
     - qemu-user
 rust:
    - stable
-   - beta
-   - nightly
-   - nightly-2021-03-25
 env:
   jobs:
-    # Matrix build of 3 targets against the above rust toolchain releases
+    # Matrix build of 3 targets against Rust stable
+    - TARGET=x86_64-unknown-linux-gnu ZLIB_INSTALLED=true AES_NI_SUPPORT=true
     - TARGET=aarch64-unknown-linux-musl
     - TARGET=x86_64-fortanix-unknown-sgx
-    - TARGET=x86_64-unknown-linux-gnu ZLIB_INSTALLED=true AES_NI_SUPPORT=true
   global:
     - RUST_BACKTRACE=1
     # Pinned to this particular nightly version because of core_io. This can be
     # re-pinned whenever core_io is updated to the latest nightly.
     - CORE_IO_NIGHTLY=nightly-2021-03-25
     - LLVM_CONFIG_PATH=llvm-config-3.9
-
-before_script:
-  - if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
-      cd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
-      tar -xvzf aarch64-linux-musl-cross.tgz;
-      cd $TRAVIS_BUILD_DIR;
-    fi
-
+jobs:
+  include:
+    # Test additional Rust toolchains on x86_64
+    - rust: beta
+    - rust: nightly
+    - rust: nightly-2021-03-25
 script:
   - ./ct.sh

--- a/ct.sh
+++ b/ct.sh
@@ -10,9 +10,9 @@ if [ -z $TRAVIS_RUST_VERSION ]; then
 fi
 
 if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
-  cd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
+  pushd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
   tar -xzf aarch64-linux-musl-cross.tgz;
-  cd $TRAVIS_BUILD_DIR;
+  popd;
 fi
 
 export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"

--- a/ct.sh
+++ b/ct.sh
@@ -38,12 +38,12 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --features dsa --target $TARGET
 
         # If zlib is installed, test the zlib feature
-        if [ -n $ZLIB_INSTALLED ]; then
+        if [ -n "$ZLIB_INSTALLED" ]; then
             cargo test --features zlib --target $TARGET
         fi
 
         # If AES-NI is supported, test the feature
-        if [ -n $AES_NI_SUPPORT ]; then
+        if [ -n "$AES_NI_SUPPORT" ]; then
             cargo test --features force_aesni_support --target $TARGET
         fi
     else

--- a/ct.sh
+++ b/ct.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 cd "$(dirname "$0")"
 
@@ -11,24 +11,42 @@ fi
 
 export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
 export CC_x86_64_fortanix_unknown_sgx=clang-11
+export CC_aarch64_unknown_linux_musl=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER=qemu-aarch64
 
-if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [ $TRAVIS_RUST_VERSION = "nightly" ]; then
+# Temporary workaround for MbedTLS 2.26.0 https://github.com/ARMmbed/mbedtls/pull/4237
+export CFLAGS_aarch64_unknown_linux_musl="-Wformat-truncation"
+
+if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" ] || [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+    # Install the rust toolchain
     rustup default $TRAVIS_RUST_VERSION
-    # make sure that explicitly providing the default target works
-    cargo test --target x86_64-unknown-linux-gnu
-    cargo test --features zlib
-    cargo test --features pkcs12
-    cargo test --features pkcs12_rc2
-    cargo test --features force_aesni_support
-    cargo test --features dsa
+    rustup target add --toolchain $TRAVIS_RUST_VERSION $TARGET
 
-    rustup target add --toolchain $TRAVIS_RUST_VERSION x86_64-fortanix-unknown-sgx
-    cargo +$TRAVIS_RUST_VERSION test --no-run --target=x86_64-fortanix-unknown-sgx
+    # The SGX target cannot be run under test like a ELF binary
+    if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then 
+        # make sure that explicitly providing the default target works
+        cargo test --target $TARGET
+        cargo test --features pkcs12 --target $TARGET
+        cargo test --features pkcs12_rc2 --target $TARGET
+        cargo test --features dsa --target $TARGET
+
+        # If zlib is installed, test the zlib feature
+        if [[ -v "${ZLIB_INSTALLED}" ]]; then
+            cargo test --features zlib --target $TARGET
+        fi
+
+        # If AES-NI is supported, test the feature
+        if [[ -v "${AES_NI_SUPPORT}" ]]; then
+            cargo test --features force_aesni_support --target $TARGET
+        fi
+    else
+        cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET
+    fi
 
 elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
     cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand,time
     cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand
-
 else
     echo "Unknown version $TRAVIS_RUST_VERSION"
     exit 1

--- a/ct.sh
+++ b/ct.sh
@@ -9,6 +9,12 @@ if [ -z $TRAVIS_RUST_VERSION ]; then
     exit 1
 fi
 
+if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
+  cd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
+  tar -xzf aarch64-linux-musl-cross.tgz;
+  cd $TRAVIS_BUILD_DIR;
+fi
+
 export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
 export CC_x86_64_fortanix_unknown_sgx=clang-11
 export CC_aarch64_unknown_linux_musl=/tmp/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
@@ -32,12 +38,12 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --features dsa --target $TARGET
 
         # If zlib is installed, test the zlib feature
-        if [[ -v "${ZLIB_INSTALLED}" ]]; then
+        if [ -n $ZLIB_INSTALLED ]; then
             cargo test --features zlib --target $TARGET
         fi
 
         # If AES-NI is supported, test the feature
-        if [[ -v "${AES_NI_SUPPORT}" ]]; then
+        if [ -n $AES_NI_SUPPORT ]; then
             cargo test --features force_aesni_support --target $TARGET
         fi
     else

--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -103,22 +103,6 @@ impl BuildConfig {
             cflags.push("-fno-stack-protector".into());
         }
 
-        // Determine the sysroot for this compiler so that bindgen
-        // uses the correct headers
-        let compiler = cc::Build::new().get_compiler();
-        let output = compiler.to_command().args(&["--print-sysroot"]).output();
-        match (output, compiler.is_like_gnu()) {
-            (Ok(sysroot), true) => {
-                let path = std::str::from_utf8(&sysroot.stdout).expect("Malformed sysroot");
-                let trimmed_path = path
-                    .strip_suffix("\r\n")
-                    .or(path.strip_suffix("\n"))
-                    .unwrap_or(&path);
-                cflags.push(format!("--sysroot={}", trimmed_path));
-            }
-            _ => {}
-        };
-
         BuildConfig {
             config_h,
             out_dir,

--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -103,6 +103,24 @@ impl BuildConfig {
             cflags.push("-fno-stack-protector".into());
         }
 
+        // Determine the sysroot for this compiler so that bindgen
+        // uses the correct headers
+        let compiler = cc::Build::new().get_compiler();
+        match compiler.is_like_gnu() {
+            true => {
+                let output = compiler.to_command().args(&["--print-sysroot"]).output().unwrap();
+                let output = std::str::from_utf8(&output.stdout).unwrap();
+                let res = output
+                    .strip_suffix("\r\n")
+                    .or(output.strip_suffix("\n"))
+                    .unwrap_or(&output);
+                let mut val = "--sysroot=".to_string();
+                val.push_str(&res);
+                cflags.push(val)
+            },
+            false => {}
+        };
+
         BuildConfig {
             config_h,
             out_dir,

--- a/mbedtls/src/bignum/mod.rs
+++ b/mbedtls/src/bignum/mod.rs
@@ -173,7 +173,7 @@ impl Mpi {
             mpi_write_string(
                 &self.inner,
                 radix,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr() as *mut _,
                 buf.len(),
                 &mut olen,
             )

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -131,7 +131,7 @@ const CUSTOM_PK_INFO: pk_info_t = {
         sign_func: None,
         verify_func: None,
         get_bitlen: None,
-        name: b"\0" as *const u8 as *const i8,
+        name: b"\0" as *const u8 as *const _,
         ctx_alloc_func: Some(alloc_custom_pk_ctx),
         ctx_free_func: Some(free_custom_pk_ctx),
     }


### PR DESCRIPTION
This PR adds sysroot detection for GNU based toolchains for targets like `aarch64-unknown-linux-musl`. This prevents bindgen from using incorrect headers when generating bindings. 

For instance when using cross, the aarch64 musl sysroot is installed in /usr/local/aarch64-linux-musl/ but bindgen/clang will attempt to look for headers in /usr/include unless `--sysroot` is provided.