### PR TITLE
Update to rs-libc 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "cc"
-version = "1.0.45"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cexpr"
@@ -613,9 +613,9 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rs-libc"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a671d6c4696a49b78e0a271c99bc58bc1a17a64893a3684a1ba1a944b26ca9"
+checksum = "b434763aff74b924c33af0ce3a3791c7c5ff8fb431773061dde30447e2fb77f0"
 dependencies = [
  "cc",
 ]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -32,7 +32,7 @@ rc2 = { version = "0.3", optional = true }
 cfg-if = "1.0.0"
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-rs-libc = "0.1.0"
+rs-libc = "0.2.2"
 chrono = "0.4"
 
 [dependencies.mbedtls-sys-auto]


### PR DESCRIPTION
Bump `rs-libc` dependency to  `0.2.2` which includes a fix for build reproducibility.