### PR TITLE
Silence compiler warnings from bindgen tests

### DIFF
--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -135,7 +135,7 @@ impl super::BuildConfig {
             .prepend_enum_name(false)
             .translate_enum_integer_types(true)
             .rustfmt_bindings(false)
-            .raw_line("#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals, invalid_value)]")
+            .raw_line("#![allow(dead_code, deref_nullptr, non_snake_case, non_camel_case_types, non_upper_case_globals, invalid_value)]")
             .generate()
             .expect("bindgen error")
             .to_string();


### PR DESCRIPTION
Compiling `rust-mbedtls` results in 627 warnings similar to:
```
    assert_eq!(                                                                                                                                                                                                                                                                                                             
        unsafe { &(*(::core::ptr::null::<arc4_context>())).y as *const _ as usize },                                                                                                                                                                                                                                        
        4usize,                                                                                                                                                                                                                                                                                                             
        concat!(                                                                                                                                                                                                                                                                                                            
            "Offset of field: ",                                                                                                                                                                                                                                                                                            
            stringify!(arc4_context),                                                                                                                                                                                                                                                                                       
            "::",                                                                                                                                                                                                                                                                                                           
            stringify!(y)                                                                                                                                                                                                                                                                                                   
        )                                                                                                                                                                                                                                                                                                                   
    );
```
all of these warnings come from `bindgen` tests and check whether a specific field of a struct has the expected size. The null pointer is only used to specify the field it wants to verify. The null pointer is never dereferenced at runtime. Still, having so many warnings in a crypto library is scary and annoying. This PR silences warnings of null pointer dereferences, but only for `bindgen` code and in debug mode.