### PR TITLE
Context<S>, generic over IO

### DIFF
--- a/mbedtls-sys/vendor/library/ssl_tls.c
+++ b/mbedtls-sys/vendor/library/ssl_tls.c
@@ -3330,6 +3330,7 @@ static void ssl_calc_finished_tls_sha384(
      * However, to avoid stringop-overflow warning in gcc, we have to cast
      * mbedtls_sha512_finish_ret().
      */
+    // this still emits the warning on clang...
     finish_sha384_t finish = (finish_sha384_t)mbedtls_sha512_finish_ret;
     finish( &sha512, padbuf );
 

--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -33,7 +33,9 @@ fn result_main(addr: &str) -> TlsResult<()> {
     config.set_ca_list(cert, None);
     let mut ctx = Context::new(Arc::new(config));
 
+    println!("connecting..");
     let conn = TcpStream::connect(addr).unwrap();
+    println!("establishing SSL connection...");
     ctx.establish(conn, None)?;
 
     let mut line = String::new();

--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -320,6 +320,7 @@ impl Config {
             // - We can pointer cast to it to allow storing additional objects.
             //
             let cb = &mut *(closure as *mut F);
+            // TODO is this cast still safe?
             let context = UnsafeFrom::from(ctx).unwrap();
             
             let mut ctx = HandshakeContext::init(context);

--- a/mbedtls/src/wrapper_macros.rs
+++ b/mbedtls/src/wrapper_macros.rs
@@ -179,7 +179,9 @@ macro_rules! define_struct {
         );
 
         as_item!(
-        unsafe impl<$($g)*> Send for $name<$($g)*> {}
+        unsafe impl<$($g)*> Send for $name<$($g)*> 
+        where $($g: Send)*
+        {}
         );
     };
 


### PR DESCRIPTION
This is a MVP implementation of my proposal in https://github.com/fortanix/rust-mbedtls/issues/3#issuecomment-983703952.

* Update wrapper macros to support generic arg(s), not just lifetimes
* Make Context generic over the underlying IO

This does seem to work with my (not yet published) PR in `rust-native-tls`, and I can run some examples.

## Notes

* I think the `Context<S>` implementation is sound, but `HandshakeContext` I am a lot more unsure of. Particularly the `UnsafeFrom` cast in the Sni Callback.
  * I think it works right now because `HandshakeContext` doesn't use the io field, but its definitely not correct.
  * Making  `HandshakeContext` generic is probably the correct way to do it, but doing that also adds a lot of complications with the callbacks.
* I think the wrapper macros can be refactored to not duplicate everything for generics (I just chose the easiest option to get something working.)

I welcome any feedback :)