### PR TITLE
Adding `Certificate::verify_with_callback` function

### DIFF
--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -340,7 +340,7 @@ impl Config {
         F: VerifyCallback + 'static,
     {
         self.verify_callback = Some(Arc::new(cb));
-        unsafe { ssl_conf_verify(self.into(), Some(x509::verify_callback::<F>), &**self.verify_callback.as_mut().unwrap() as *const _ as *mut c_void) }
+        unsafe { ssl_conf_verify(self.into(), Some(x509::verify_callback::<F>), &**self.verify_callback.as_ref().unwrap() as *const _ as *mut c_void) }
     }
 
     pub fn set_ca_callback<F>(&mut self, cb: F)

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -225,12 +225,12 @@ impl Certificate {
         chain: &MbedtlsList<Certificate>,
         trust_ca: &MbedtlsList<Certificate>,
         err_info: Option<&mut String>,
-        mut cb: Option<F>,
+        cb: Option<F>,
     ) -> Result<()>
     where
         F: VerifyCallback + 'static,
     {
-        let (f_vrfy, p_vrfy): (Option<unsafe extern "C" fn(_, _, _, _) -> _>, _) = if let Some(cb) = cb.as_mut() {
+        let (f_vrfy, p_vrfy): (Option<unsafe extern "C" fn(_, _, _, _) -> _>, _) = if let Some(cb) = cb.as_ref() {
             (Some(x509::verify_callback::<F>),
             cb as *const _ as *mut c_void)
         } else {

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -225,14 +225,14 @@ impl Certificate {
         chain: &MbedtlsList<Certificate>,
         trust_ca: &MbedtlsList<Certificate>,
         err_info: Option<&mut String>,
-        cb: Option<F>,
+        mut cb: Option<F>,
     ) -> Result<()>
     where
         F: VerifyCallback + 'static,
     {
-        let (f_vrfy, p_vrfy): (Option<unsafe extern "C" fn(_, _, _, _) -> _>, _) = if let Some(cb) = cb {
+        let (f_vrfy, p_vrfy): (Option<unsafe extern "C" fn(_, _, _, _) -> _>, _) = if let Some(cb) = cb.as_mut() {
             (Some(x509::verify_callback::<F>),
-            &cb as *const _ as *mut c_void)
+            cb as *const _ as *mut c_void)
         } else {
             (None, ::core::ptr::null_mut())
         };
@@ -269,8 +269,7 @@ impl Certificate {
         trust_ca: &MbedtlsList<Certificate>,
         err_info: Option<&mut String>,
     ) -> Result<()> {
-        let none: Option<Box<dyn VerifyCallback + 'static>> = None;
-        Self::verify_ex(chain, trust_ca, err_info, none)
+        Self::verify_ex(chain, trust_ca, err_info, None::<&dyn VerifyCallback>)
     }
 
     pub fn verify_with_callback<F>(

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -11,7 +11,7 @@ use core::iter::FromIterator;
 use core::ptr::NonNull;
 
 use mbedtls_sys::*;
-use mbedtls_sys::types::raw_types::c_char;
+use mbedtls_sys::types::raw_types::*;
 
 use crate::alloc::{List as MbedtlsList, Box as MbedtlsBox};
 #[cfg(not(feature = "std"))]
@@ -22,6 +22,7 @@ use crate::pk::Pk;
 use crate::private::UnsafeFrom;
 use crate::rng::Random;
 use crate::x509::Time;
+use crate::x509::VerifyError;
 
 extern "C" {
     pub(crate) fn forward_mbedtls_calloc(n: mbedtls_sys::types::size_t, size: mbedtls_sys::types::size_t) -> *mut mbedtls_sys::types::raw_types::c_void;
@@ -253,6 +254,44 @@ impl Certificate {
         }
         result.map(|_| ())
     }
+
+    pub fn verify_callback<F>(
+        chain: &MbedtlsList<Certificate>,
+        trust_ca: &MbedtlsList<Certificate>,
+        err_info: Option<&mut String>,
+        cb: F,
+    ) -> Result<()>
+    where
+        F: VerifyCallback + 'static,
+    {
+        let mut flags = 0;
+        let result = unsafe {
+            x509_crt_verify(
+                chain.inner_ffi_mut(),
+                trust_ca.inner_ffi_mut(),
+                ::core::ptr::null_mut(),
+                ::core::ptr::null(),
+                &mut flags,
+                Some(verify_callback::<F>),
+                &cb as *const _ as *mut c_void,
+            )
+        }
+        .into_result();
+
+        if result.is_err() {
+            if let Some(err_info) = err_info {
+                let verify_info = crate::private::alloc_string_repeat(|buf, size| unsafe {
+                    let prefix = "\0";
+                    x509_crt_verify_info(buf, size, prefix.as_ptr() as *const _, flags)
+                });
+                if let Ok(error_str) = verify_info {
+                    *err_info = error_str;
+                }
+            }
+        }
+        result.map(|_| ())
+    }
+
 }
 
 // TODO
@@ -719,6 +758,38 @@ impl Extend<MbedtlsBox::<Certificate>> for MbedtlsList<Certificate> {
     }
 }
 
+pub(crate) unsafe extern "C" fn verify_callback<F>(
+    closure: *mut c_void,
+    crt: *mut x509_crt,
+    depth: c_int,
+    flags: *mut u32,
+) -> c_int
+where
+    F: VerifyCallback + 'static,
+{
+    if crt.is_null() || closure.is_null() || flags.is_null() {
+        return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA;
+    }
+
+    let cb = &mut *(closure as *mut F);
+    let crt: &mut Certificate = UnsafeFrom::from(crt).expect("valid certificate");
+
+    let mut verify_error = match VerifyError::from_bits(*flags) {
+        Some(ve) => ve,
+        // This can only happen if mbedtls is setting flags in VerifyError that are
+        // missing from our definition.
+        None => return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA,
+    };
+
+    let res = cb(crt, depth, &mut verify_error);
+    *flags = verify_error.bits();
+    match res {
+        Ok(()) => 0,
+        Err(e) => e.to_int(),
+    }
+}
+
+callback!(VerifyCallback: Fn(&Certificate, i32, &mut VerifyError) -> Result<()>);
 
 #[cfg(test)]
 mod tests {
@@ -995,7 +1066,21 @@ cYp0bH/RcPTC0Z+ZaqSWMtfxRrk63MJQF9EXpDCdvQRcTMD9D85DJrMKn8aumq0M
 
             // try again after fixing the chain
             chain.push(c_int2.clone());
-            Certificate::verify(&chain, &mut c_root, None).unwrap();
+
+
+            let mut err_str = String::new();
+
+            let verify_callback = |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+                verify_flags.remove(VerifyError::CERT_EXPIRED);
+                Ok(())
+            };
+
+            let res = Certificate::verify_callback(&chain, &mut c_root, Some(&mut err_str), verify_callback);
+
+            match res {
+                Ok(()) => (),
+                Err(e) => assert!(false, "Failed to verify, error: {}, err_str: {}", e, err_str),
+            };
         }
 
         {
@@ -1004,7 +1089,18 @@ cYp0bH/RcPTC0Z+ZaqSWMtfxRrk63MJQF9EXpDCdvQRcTMD9D85DJrMKn8aumq0M
             chain.push(c_int1.clone());
             chain.push(c_int2.clone());
 
-            Certificate::verify(&chain, &mut c_root, None).unwrap();
+            let verify_callback = |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+                verify_flags.remove(VerifyError::CERT_EXPIRED);
+                Ok(())
+            };
+
+            let mut err_str = String::new();
+            let res = Certificate::verify_callback(&chain, &mut c_root, Some(&mut err_str), verify_callback);
+
+            match res {
+                Ok(()) => (),
+                Err(e) => assert!(false, "Failed to verify, error: {}, err_str: {}", e, err_str),
+            };
         }
     }
 

--- a/mbedtls/src/x509/mod.rs
+++ b/mbedtls/src/x509/mod.rs
@@ -134,7 +134,7 @@ where
         return ::mbedtls_sys::ERR_X509_BAD_INPUT_DATA;
     }
 
-    let cb = &mut *(closure as *mut F);
+    let cb = &*(closure as *const F);
     let crt: &mut Certificate = UnsafeFrom::from(crt).expect("valid certificate");
 
     let mut verify_error = match VerifyError::from_bits(*flags) {


### PR DESCRIPTION
For [Nitro attestation verification](https://github.com/fortanix/rust-sgx/pull/376/) we need some features introduced by @AdrianCX on the `acruceru/port-async-support` branch. For the rust-sgx repo, we want to avoid relying on a separate branch for rust-mbedtls. With this PR two features are added to master:
* serialization and deserialization of signatures
* Certificate verification with a callback function