### PR TITLE
Pin aarch64-linux-musl-cross compiler

### DIFF
--- a/aarch64-linux-musl-cross.tgz.sha1sum
+++ b/aarch64-linux-musl-cross.tgz.sha1sum
@@ -1,0 +1,1 @@
+09a79097e0e53c5c61ba3ed217f095c8aa1686ea  /tmp/aarch64-linux-musl-cross.tgz

--- a/ct.sh
+++ b/ct.sh
@@ -10,9 +10,9 @@ if [ -z $TRAVIS_RUST_VERSION ]; then
 fi
 
 if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
-  pushd /tmp && wget https://musl.cc/aarch64-linux-musl-cross.tgz;
-  tar -xzf aarch64-linux-musl-cross.tgz;
-  popd;
+  wget https://more.musl.cc/10-20210301/x86_64-linux-musl/aarch64-linux-musl-cross.tgz -O /tmp/aarch64-linux-musl-cross.tgz
+  sha1sum -c ../aarch64-linux-musl-cross.tgz.sha1sum
+  tar -xf /tmp/aarch64-linux-musl-cross.tgz -C /tmp;
 fi
 
 export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"


### PR DESCRIPTION
Compiling for aarch64-unknown-linux-musl target failed with:
```
  /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/library/ssl_tls.c: In function â€˜ssl_calc_finished_tls_sha384â€™:
  /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/library/ssl_tls.c:3334:5: error: â€˜mbedtls_sha512_finish_retâ€™ accessing 64 bytes in a region of size 48 [-Werror=stringop-overflow=]
   3334 |     finish( &sha512, padbuf );
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~
  /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/library/ssl_tls.c:3334:5: note: referencing argument 2 of type â€˜unsigned char *â€™
  In file included from /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/include/mbedtls/ssl_internal.h:51,
                   from /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/library/ssl_tls.c:41:
  /home/travis/build/fortanix/rust-mbedtls/mbedtls-sys/vendor/include/mbedtls/sha512.h:144:5: note: in a call to function â€˜mbedtls_sha512_finish_retâ€™
    144 | int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
        |     ^~~~~~~~~~~~~~~~~~~~~~~~~
  cc1: all warnings being treated as errors
  make[3]: *** [library/CMakeFiles/mbedtls.dir/build.make:183: library/CMakeFiles/mbedtls.dir/ssl_tls.c.o] Error 1
  make[2]: *** [CMakeFiles/Makefile2:227: library/CMakeFiles/mbedtls.dir/all] Error 2
  make[1]: *** [CMakeFiles/Makefile2:263: library/CMakeFiles/lib.dir/rule] Error 2
  make: *** [Makefile:219: lib] Error 2
```

This is caused by:
```
   typedef int (*finish_sha384_t)(mbedtls_sha512_context*, unsigned char*);
...
    /*                                                                                                                                                                                                                                                                                                       
     * For SHA-384, we can save 16 bytes by keeping padbuf 48 bytes long.       
     * However, to avoid stringop-overflow warning in gcc, we have to cast                                                                                    
     * mbedtls_sha512_finish_ret().                                                                                                                                                                                                                                                                                   
     */                                                                                                                                                                                                                                                                                                                     
    finish_sha384_t finish = (finish_sha384_t)mbedtls_sha512_finish_ret;                                                                                                                                                                                                                                                    
    finish( &sha512, padbuf );
```
This work around no longer works for newer versions of the `aarch64-linux-musl-gcc` compiler. The compiler is pinned to an older version where this workaround still works