### PR TITLE
Md: Implement Clone

### DIFF
--- a/mbedtls/src/hash/mod.rs
+++ b/mbedtls/src/hash/mod.rs
@@ -172,6 +172,18 @@ impl Md {
     }
 }
 
+impl Clone for Md {
+    fn clone(&self) -> Self {
+        fn copy_md(md: &Md) -> Result<Md> {
+            let md_type = unsafe { md_get_type(md.inner.md_info) };
+            let mut m = Md::new(md_type.into())?;
+            unsafe { md_clone(&mut m.inner, &md.inner) }.into_result()?;
+            Ok(m)
+        }
+        copy_md(self).expect("Md::copy success")
+    }
+}
+
 pub fn pbkdf2_hmac(
     md: Type,
     password: &[u8],


### PR DESCRIPTION
This is required in scenarios where a running transcript is added to the hash, and intermittently checkpointed by taking the digest so far.

The clone implementation is kept inline with other clone implementations in the repo: https://github.com/fortanix/rust-mbedtls/blob/master/mbedtls/src/ecp/mod.rs#L27