### PR TITLE
Some changes needed to interact with rust-native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,21 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
+name = "block-cipher"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "block-modes"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
+checksum = "538b66bc25a51ce985544067a9c3e17d426447f468c495dd6cb00040e5953692"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "block-padding",
 ]
 
@@ -226,11 +226,12 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -570,11 +571,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rc2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039209d71774c9b2ae967ffb66b73ed253b3c384c198ec0d620fdd5369c78e5e"
+checksum = "225ef99d4ccbef9f4d25247a905c6d3d9e06a904be1d98d279fb6af6e9458c8c"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 
@@ -791,9 +792,9 @@ checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicase"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -27,8 +27,8 @@ byteorder = "1.0.0"
 yasna = { version = "0.2", optional = true, features = ["num-bigint", "bit-vec"] }
 num-bigint = { version = "0.2", optional = true }
 bit-vec = { version = "0.5", optional = true }
-block-modes = { version = "0.3", optional = true }
-rc2 = { version = "0.3", optional = true }
+block-modes = { version = "0.4", optional = true }
+rc2 = { version = "0.4", optional = true }
 cfg-if = "1.0.0"
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
@@ -68,6 +68,7 @@ padlock = ["mbedtls-sys-auto/padlock"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "block-modes"]
+legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 
 [[example]]
 name = "client"

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -98,7 +98,15 @@ impl Certificate {
     /// Input must be NULL-terminated
     pub fn from_pem(pem: &[u8]) -> Result<MbedtlsBox<Certificate>> {
         let mut cert = MbedtlsBox::<Certificate>::init()?;
-        unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+
+        // Mbedtls from_pem needs a trailing NULL byte, only handles c type strings.
+        if !pem.last().map(|c| *c == 0).unwrap_or(false)  {
+            let mut pem = pem.to_vec();
+            pem.push(0);
+            unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+        } else {
+            unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+        }
         
         if !(*cert).inner.next.is_null() {
             // Use from_pem_multiple for parsing multiple certificates in a pem.
@@ -111,7 +119,15 @@ impl Certificate {
     /// Input must be NULL-terminated
     pub fn from_pem_multiple(pem: &[u8]) -> Result<MbedtlsList<Certificate>> {
         let mut cert = MbedtlsBox::<Certificate>::init()?;
-        unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+
+        // Mbedtls from_pem needs a trailing NULL byte, only handles c type strings.
+        if !pem.last().map(|c| *c == 0).unwrap_or(false)  {
+            let mut pem = pem.to_vec();
+            pem.push(0);
+            unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+        } else {
+            unsafe { x509_crt_parse((&mut (*cert)).into(), pem.as_ptr(), pem.len()) }.into_result()?;
+        }
 
         let mut list = MbedtlsList::<Certificate>::new();
         list.push(cert);


### PR DESCRIPTION
Update PKCS for newer RC2 since the version used was yanked.

Improved APLN NullTerminatedList to take a ref to Vec<String> as well.

Tokio integration requires proper WouldBlock IO Error.

handshake needs to be pub to be called from tokio-native-tls.

from_pem is annoying in that it needs last byte 0, added code to detect improper pems and fix them.