### PR TITLE
Add serde support for the ARIA cipher

### DIFF
--- a/mbedtls/src/cipher/raw/serde.rs
+++ b/mbedtls/src/cipher/raw/serde.rs
@@ -44,6 +44,7 @@ pub struct SavedRawCipher {
 #[derive(Serialize, Deserialize)]
 enum AlgorithmContext {
     Aes(Bytes<aes_context>),
+    Aria(Bytes<aria_context>),
     Des(Bytes<des_context>),
     Des3(Bytes<des3_context>),
     Gcm {
@@ -94,6 +95,12 @@ unsafe fn serialize_raw_cipher(mut cipher_context: cipher_context_t)
             let mut aes_context = *(cipher_context.cipher_ctx as *const aes_context);
             aes_context.rk = ::core::ptr::null_mut();
             AlgorithmContext::Aes(Bytes(aes_context))
+        }
+        (CIPHER_ID_ARIA, MODE_CBC)
+        | (CIPHER_ID_ARIA, MODE_CTR)
+        | (CIPHER_ID_ARIA, MODE_CFB)
+        | (CIPHER_ID_ARIA, MODE_ECB) => {
+            AlgorithmContext::Aria(Bytes(*(cipher_context.cipher_ctx as *const aria_context)))
         }
         (CIPHER_ID_DES, MODE_CBC)
         | (CIPHER_ID_DES, MODE_CTR)
@@ -211,6 +218,9 @@ unsafe fn deserialize_raw_cipher(raw: SavedRawCipher, padding: raw::CipherPaddin
             // mbedtls_aes_context in the mbedTLS source).
             (*ret_aes_ctx).rk = &mut (*ret_aes_ctx).buf[0];
         }
+        (CIPHER_ID_ARIA, AlgorithmContext::Aria(Bytes(aria_ctx))) => {
+            *(cipher_context.cipher_ctx as *mut aria_context) = aria_ctx
+        }
         (CIPHER_ID_DES, AlgorithmContext::Des(Bytes(des_ctx))) => {
             *(cipher_context.cipher_ctx as *mut des_context) = des_ctx
         }
@@ -324,6 +334,7 @@ impl<'de, T: BytesSerde> Deserialize<'de> for Bytes<T> {
 
 unsafe impl BytesSerde for cipher_context_t {}
 unsafe impl BytesSerde for aes_context {}
+unsafe impl BytesSerde for aria_context {}
 unsafe impl BytesSerde for des_context {}
 unsafe impl BytesSerde for des3_context {}
 unsafe impl BytesSerde for gcm_context {}


### PR DESCRIPTION
This PR adds serde support for the Aria cipher. This is needed to use the `update` API. This is a follow-up of #187.