### PR TITLE
Fix checks on curve parameters

### DIFF
--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -96,13 +96,13 @@ impl EcGroup {
         let zero = Mpi::new(0)?;
 
         // basic bounds checking
-        if &a <= &zero
+        if &a < &zero
             || &a >= &p
-            || &b <= &zero
+            || &b < &zero
             || &b >= &p
-            || &g_x <= &zero
+            || &g_x < &zero
             || &g_x >= &p
-            || &g_y <= &zero
+            || &g_y < &zero
             || &g_y >= &p
             || &order <= &zero
         {

--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -79,6 +79,13 @@ impl EcGroup {
         Ok(ret)
     }
 
+    /// Enables the use of custom curves.
+    ///
+    /// HAZMAT: This function DOES NOT perform a full check on parameters
+    /// against all known attacks. The caller MUST make sure that parameters are
+    /// trusted. Failing to comply with this requirement may result in the use
+    /// of INSECURE curves. Prefer [EcGroup::new] with known curves listed in
+    /// [EcGroupId].
     pub fn from_parameters(
         p: Mpi,
         a: Mpi,

--- a/mbedtls/src/ecp/mod.rs
+++ b/mbedtls/src/ecp/mod.rs
@@ -79,7 +79,7 @@ impl EcGroup {
         Ok(ret)
     }
 
-    /// Enables the use of custom curves.
+    /// Initialize an EcGroup with custom group parameters.
     ///
     /// HAZMAT: This function DOES NOT perform a full check on parameters
     /// against all known attacks. The caller MUST make sure that parameters are

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -264,7 +264,7 @@ impl<T> Context<T> {
     
     /// Return the 16-bit ciphersuite identifier.
     /// All assigned ciphersuites are listed by the IANA in
-    /// https://www.iana.org/assignments/tls-parameters/tls-parameters.txt
+    /// <https://www.iana.org/assignments/tls-parameters/tls-parameters.txt>
     pub fn ciphersuite(&self) -> Result<u16> {
         if self.handle().session.is_null() {
             return Err(Error::SslBadInputData);


### PR DESCRIPTION
On instantiating a curve by parameters, the code checks that all
field elements are non-zero in 𝔽ₚ. This is not necessary, and forbids
useful curves such as e.g. the Barreto-Naehrig pairing-friendly curves,
of the form y² = x³ + 257 (e.g. `a = 0`), and secp256k1 (used in Bitcoin, but can be instantiated by name).