### PR TITLE
Changes to `chrono` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
 ]
 
 [[package]]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -33,7 +33,8 @@ cfg-if = "1.0.0"
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.2.0"
-chrono = "0.4"
+# if `chrono` is desired to be upgraded, features = ["std"] needs to be added
+chrono = { version = "=0.4.9", default-features = false }
 
 [dependencies.mbedtls-sys-auto]
 version = "2.25.0"

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -141,7 +141,9 @@ cfg_if::cfg_if! {
         #[doc(hidden)]
         #[no_mangle]
         pub unsafe extern "C" fn mbedtls_time(tp: *mut time_t) -> time_t {
-            let timestamp = chrono::Utc::now().timestamp() as time_t;
+            let now =
+                std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).expect("system time before Unix epoch");
+            let timestamp = now.as_secs() as time_t;
             if !tp.is_null() {
                 *tp = timestamp;
             }


### PR DESCRIPTION
This PR avoids using the default features in `chrono`, as the only usage of the `clock` feature was `Utc::now()` which can be replaced with a call to `SystemTime::now()`. 

Due to the checked in `Cargo.lock`, `chrono` is locked to 0.4.9, however if/when this is changed, a `features=["std"]` needs to be added in the `Cargo.toml`, in the meantime I've locked the dependency to 0.4.9 in the `Cargo.toml`. 