### PR TITLE
Replace crate `core_io` with `core2` to support more rust toolchain versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,12 +197,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core_io"
-version = "0.1.20210325"
+name = "core2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f8932064288cc79feb4d343a399d353a6f6f001e586ece47fe518a9e8507df"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
- "rustc_version",
+ "memchr",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "chrono",
- "core_io",
+ "core2",
  "hex",
  "hyper",
  "libc",
@@ -627,25 +627,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "serde"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
 bitflags = "1"
-core_io = { version = "0.1", features = ["collections"], optional = true }
+core2 = { version = "0.4.0", default-features = false, optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
@@ -57,7 +57,7 @@ cc = "1.0"
 default = ["std", "aesni", "time", "padlock"]
 std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
 debug = ["mbedtls-sys-auto/debug"]
-no_std_deps = ["core_io", "spin"]
+no_std_deps = ["core2", "spin"]
 force_aesni_support = ["mbedtls-sys-auto/custom_has_support", "mbedtls-sys-auto/aes_alt", "aesni"]
 mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -89,10 +89,10 @@ pub unsafe fn cstr_to_slice<'a>(ptr: *const c_char) -> &'a [u8] {
 }
 
 #[cfg(not(feature = "std"))]
-use core_io::{Error as IoError, ErrorKind as IoErrorKind};
+use core2::io::{Error as IoError, ErrorKind as IoErrorKind};
 #[cfg(feature = "std")]
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 pub fn error_to_io_error(e: Error) -> IoError {
-    IoError::new(IoErrorKind::Other, e.to_string())
+    IoError::new(IoErrorKind::Other, e.as_str())
 }

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -15,7 +15,7 @@ use {
 };
 
 #[cfg(not(feature = "std"))]
-use core_io::{Read, Write, Result as IoResult};
+use core2::io::{Read, Write, Result as IoResult};
 
 
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
@@ -416,7 +416,7 @@ mod tests {
     use std::io::{Read,Write, Result as IoResult};
 
     #[cfg(not(feature = "std"))]
-    use core_io::{Read, Write, Result as IoResult};
+    use core2::io::{Read, Write, Result as IoResult};
 
     use crate::ssl::context::{HandshakeContext, Context};
     use crate::tests::TestTrait;


### PR DESCRIPTION
`core_io` has not been updated for a long time, the latest rust version it supports is 2021-03-25.
To support more rust toolchain versions, we can use `core2` instead which does not depend on specific nightly versions.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>