### PR TITLE
Remove core_io dependency and add alternative interface for no_std environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,15 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core_io"
-version = "0.1.20210325"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f8932064288cc79feb4d343a399d353a6f6f001e586ece47fe518a9e8507df"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,7 +368,6 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "chrono",
- "core_io",
  "hex",
  "hyper",
  "libc",
@@ -627,25 +617,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "serde"

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -26,6 +26,18 @@ impl super::BuildConfig {
             cmk.define("CMAKE_C_COMPILER_FORCED", "TRUE");
         }
 
+        let target = std::env::var("TARGET").expect("TARGET environment variable should be set in build scripts");
+        // thumbv6m-none-eabi, thumbv7em-none-eabi, thumbv7em-none-eabihf, thumbv7m-none-eabi
+        // probably use arm-none-eabi-gcc which can cause the cmake compiler test to fail.
+        if target.starts_with("thumbv") && target.contains("none-eabi") {
+            // When building on Linux, -rdynamic flag is added automatically. Changing the
+            // CMAKE_SYSTEM_NAME to Generic avoids this.
+            cmk.define("CMAKE_SYSTEM_NAME", "Generic");
+            // The compiler test requires _exit which is not available. By just trying to compile
+            // a library, we can fix it.
+            cmk.define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY");
+        }
+
         let mut dst = cmk.build();
 
         dst.push("build");

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -22,7 +22,7 @@ bitflags = "1"
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
-byteorder = "1.0.0"
+byteorder = { version = "1.0.0", default-features = false }
 yasna = { version = "0.2", optional = true, features = ["num-bigint", "bit-vec"] }
 num-bigint = { version = "0.2", optional = true }
 bit-vec = { version = "0.5", optional = true }

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -19,7 +19,6 @@ keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
 
 [dependencies]
 bitflags = "1"
-core_io = { version = "0.1", features = ["collections"], optional = true }
 spin = { version = "0.4.0", default-features = false, optional = true }
 serde = { version = "1.0.7", default-features = false }
 serde_derive = "1.0.7"
@@ -57,7 +56,7 @@ cc = "1.0"
 default = ["std", "aesni", "time", "padlock"]
 std = ["mbedtls-sys-auto/std", "serde/std", "yasna"]
 debug = ["mbedtls-sys-auto/debug"]
-no_std_deps = ["core_io", "spin", "serde/alloc"]
+no_std_deps = ["spin", "serde/alloc"]
 force_aesni_support = ["mbedtls-sys-auto/custom_has_support", "mbedtls-sys-auto/aes_alt", "aesni"]
 mpi_force_c_code = ["mbedtls-sys-auto/mpi_force_c_code"]
 rdrand = []

--- a/mbedtls/examples/client_dtls.rs
+++ b/mbedtls/examples/client_dtls.rs
@@ -40,10 +40,10 @@ fn result_main(addr: &str) -> TlsResult<()> {
 
     let mut line = String::new();
     stdin().read_line(&mut line).unwrap();
-    ctx.write(line.as_bytes()).unwrap();
+    ctx.send(line.as_bytes()).unwrap();
     let mut resp = Vec::with_capacity(100);
-    ctx.read(&mut resp).unwrap();
-    if let Ok(s) = std::str::from_utf8(&resp) {
+    let len = ctx.recv(&mut resp).unwrap();
+    if let Ok(s) = std::str::from_utf8(&resp[..len]) {
         println!("{}", s);
     } else {
         eprintln!("Invalid UTF-8 received");

--- a/mbedtls/examples/client_dtls.rs
+++ b/mbedtls/examples/client_dtls.rs
@@ -9,7 +9,7 @@
 // needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
-use std::io::{self, stdin, stdout, Write};
+use std::io::stdin;
 use std::net::UdpSocket;
 use std::sync::Arc;
 
@@ -40,8 +40,14 @@ fn result_main(addr: &str) -> TlsResult<()> {
 
     let mut line = String::new();
     stdin().read_line(&mut line).unwrap();
-    ctx.write_all(line.as_bytes()).unwrap();
-    io::copy(&mut ctx, &mut stdout()).unwrap();
+    ctx.write(line.as_bytes()).unwrap();
+    let mut resp = Vec::with_capacity(100);
+    ctx.read(&mut resp).unwrap();
+    if let Ok(s) = std::str::from_utf8(&resp) {
+        println!("{}", s);
+    } else {
+        eprintln!("Invalid UTF-8 received");
+    }
     Ok(())
 }
 

--- a/mbedtls/src/cipher/raw/serde.rs
+++ b/mbedtls/src/cipher/raw/serde.rs
@@ -341,20 +341,20 @@ unsafe impl BytesSerde for gcm_context {}
 
 // If the C API changes, the serde implementation needs to be reviewed for correctness.
 
-unsafe fn _check_cipher_context_t_size(ctx: cipher_context_t) -> [u8; 96] {
+unsafe fn _check_cipher_context_t_size(ctx: cipher_context_t) -> [u8; size_of::<cipher_context_t>()] {
     ::core::mem::transmute(ctx)
 }
 
-unsafe fn _check_aes_context_size(ctx: aes_context) -> [u8; 288] {
+unsafe fn _check_aes_context_size(ctx: aes_context) -> [u8; size_of::<aes_context>()] {
     ::core::mem::transmute(ctx)
 }
 
-unsafe fn _check_des_context_size(ctx: des_context) -> [u8; 128] {
+unsafe fn _check_des_context_size(ctx: des_context) -> [u8; size_of::<des_context>()] {
     ::core::mem::transmute(ctx)
 }
 
-unsafe fn _check_des3_context_size(ctx: des3_context) -> [u8; 384] {
+unsafe fn _check_des3_context_size(ctx: des3_context) -> [u8; size_of::<des3_context>()] {
     ::core::mem::transmute(ctx)
 }
 
-unsafe fn _check_gcm_context_size(ctx: gcm_context) -> [u8; 424] { ::core::mem::transmute(ctx) }
+unsafe fn _check_gcm_context_size(ctx: gcm_context) -> [u8; size_of::<gcm_context>()] { ::core::mem::transmute(ctx) }

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -88,11 +88,10 @@ pub unsafe fn cstr_to_slice<'a>(ptr: *const c_char) -> &'a [u8] {
     ::core::slice::from_raw_parts(ptr as *const _, strlen(ptr))
 }
 
-#[cfg(not(feature = "std"))]
-use core_io::{Error as IoError, ErrorKind as IoErrorKind};
 #[cfg(feature = "std")]
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
+#[cfg(feature = "std")]
 pub fn error_to_io_error(e: Error) -> IoError {
     IoError::new(IoErrorKind::Other, e.to_string())
 }

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -486,13 +486,13 @@ impl<T> Context<T> {
 }
 
 impl<T: IoCallback> Context<T> {
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+    pub fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
         unsafe {
             ssl_read(self.into(), buf.as_mut_ptr(), buf.len()).into_result().map(|r| r as usize)
         }
     }
 
-    pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
+    pub fn send(&mut self, buf: &[u8]) -> Result<usize> {
         unsafe {
             ssl_write(self.into(), buf.as_ptr(), buf.len()).into_result().map(|w| w as usize)
         }
@@ -515,7 +515,7 @@ impl<T> Drop for Context<T> {
 /// for `Context<TcpStream>`, i.e. TLS connections but not for DTLS connections.
 impl<T: IoCallback + Read> Read for Context<T> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        match self.read(buf) {
+        match self.recv(buf) {
             Err(Error::SslPeerCloseNotify) => Ok(0),
             Err(e) => Err(crate::private::error_to_io_error(e)),
             Ok(i) => Ok(i),
@@ -530,7 +530,7 @@ impl<T: IoCallback + Read> Read for Context<T> {
 /// for `Context<TcpStream>`, i.e. TLS connections but not for DTLS connections.
 impl<T: IoCallback + Write> Write for Context<T> {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
-        match self.write(buf) {
+        match self.send(buf) {
             Err(Error::SslPeerCloseNotify) => Ok(0),
             Err(e) => Err(crate::private::error_to_io_error(e)),
             Ok(i) => Ok(i),

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -14,10 +14,6 @@ use {
     std::sync::Arc,
 };
 
-#[cfg(not(feature = "std"))]
-use core_io::{Read, Write, Result as IoResult};
-
-
 use mbedtls_sys::types::raw_types::{c_int, c_uchar, c_void};
 use mbedtls_sys::types::size_t;
 use mbedtls_sys::*;
@@ -37,6 +33,7 @@ pub trait IoCallback {
     fn data_ptr(&mut self) -> *mut c_void;
 }
 
+#[cfg(feature = "std")]
 impl<IO: Read + Write> IoCallback for IO {
     unsafe extern "C" fn call_recv(user_data: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
         let len = if len > (c_int::max_value() as size_t) {
@@ -488,6 +485,20 @@ impl<T> Context<T> {
     }
 }
 
+impl<T: IoCallback> Context<T> {
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        unsafe {
+            ssl_read(self.into(), buf.as_mut_ptr(), buf.len()).into_result().map(|r| r as usize)
+        }
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        unsafe {
+            ssl_write(self.into(), buf.as_ptr(), buf.len()).into_result().map(|w| w as usize)
+        }
+    }
+}
+
 impl<T> Drop for Context<T> {
     fn drop(&mut self) {
         unsafe {
@@ -497,9 +508,10 @@ impl<T> Drop for Context<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: IoCallback> Read for Context<T> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        match unsafe { ssl_read(self.into(), buf.as_mut_ptr(), buf.len()).into_result() } {
+        match self.read(buf) {
             Err(Error::SslPeerCloseNotify) => Ok(0),
             Err(e) => Err(crate::private::error_to_io_error(e)),
             Ok(i) => Ok(i as usize),
@@ -507,9 +519,10 @@ impl<T: IoCallback> Read for Context<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: IoCallback> Write for Context<T> {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
-        match unsafe { ssl_write(self.into(), buf.as_ptr(), buf.len()).into_result() } {
+        match self.write(buf) {
             Err(Error::SslPeerCloseNotify) => Ok(0),
             Err(e) => Err(crate::private::error_to_io_error(e)),
             Ok(i) => Ok(i as usize),
@@ -520,6 +533,7 @@ impl<T: IoCallback> Write for Context<T> {
         Ok(())
     }
 }
+
 //
 // Class exists only during SNI callback that is configured from Config.
 // SNI Callback must provide input whose lifetime exceeds the SNI closure to avoid memory corruptions.

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -625,9 +625,6 @@ mod tests {
     #[cfg(feature = "std")]
     use std::io::{Read,Write, Result as IoResult};
 
-    #[cfg(not(feature = "std"))]
-    use core_io::{Read, Write, Result as IoResult};
-
     use crate::ssl::context::{HandshakeContext, Context};
     use crate::tests::TestTrait;
     
@@ -640,12 +637,14 @@ mod tests {
         _buffer: core::ptr::NonNull<u8>,
     }
 
+    #[cfg(feature = "std")]
     impl Read for NonSendStream {
         fn read(&mut self, _: &mut [u8]) -> IoResult<usize> {
             unimplemented!()
         }
     }
     
+    #[cfg(feature = "std")]
     impl Write for NonSendStream {
         fn write(&mut self, _: &[u8]) -> IoResult<usize> {
             unimplemented!()
@@ -660,12 +659,14 @@ mod tests {
         _buffer: u8,
     }
 
+    #[cfg(feature = "std")]
     impl Read for SendStream {
         fn read(&mut self, _: &mut [u8]) -> IoResult<usize> {
             unimplemented!()
         }
     }
     
+    #[cfg(feature = "std")]
     impl Write for SendStream {
         fn write(&mut self, _: &[u8]) -> IoResult<usize> {
             unimplemented!()

--- a/mbedtls/tests/client_server.rs
+++ b/mbedtls/tests/client_server.rs
@@ -11,7 +11,6 @@
 // needed to have common code for `mod support` in unit and integrations tests
 extern crate mbedtls;
 
-use std::io::{Read, Write};
 use std::net::TcpStream;
 
 use mbedtls::pk::Pk;
@@ -118,9 +117,10 @@ fn client(
     };
 
     let ciphersuite = ctx.ciphersuite().unwrap();
-    ctx.write_all(format!("Client2Server {:4x}", ciphersuite).as_bytes()).unwrap();
+    let buf = format!("Client2Server {:4x}", ciphersuite);
+    assert_eq!(ctx.send(buf.as_bytes()).unwrap(), buf.len());
     let mut buf = [0u8; 13 + 4 + 1];
-    ctx.read_exact(&mut buf).unwrap();
+    assert_eq!(ctx.recv(&mut buf).unwrap(), buf.len());
     assert_eq!(&buf, format!("Server2Client {:4x}", ciphersuite).as_bytes());
     Ok(())
 }
@@ -189,9 +189,10 @@ fn server(
     };
 
     let ciphersuite = ctx.ciphersuite().unwrap();
-    ctx.write_all(format!("Server2Client {:4x}", ciphersuite).as_bytes()).unwrap();
+    let buf = format!("Server2Client {:4x}", ciphersuite);
+    assert_eq!(ctx.send(buf.as_bytes()).unwrap(), buf.len());
     let mut buf = [0u8; 13 + 1 + 4];
-    ctx.read_exact(&mut buf).unwrap();
+    assert_eq!(ctx.recv(&mut buf).unwrap(), buf.len());
 
     assert_eq!(&buf, format!("Client2Server {:4x}", ciphersuite).as_bytes());
     Ok(())


### PR DESCRIPTION
As already stated in https://github.com/fortanix/rust-mbedtls/pull/210, `core_io` "has not been updated for a long time, the latest rust version it supports is 2021-03-25." Since `no_std` usage of `rust-mbedtls` currently depends on `core_io`, this is a major barrier when adopting `rust-mbedtls` in `no_std` environments.

As opposed to https://github.com/fortanix/rust-mbedtls/pull/210, I propose to remove any `std::io` replacement altogether because we need a different interface (non `io::Write`, non `io::Read`) for DTLS anyways. So this interface can be used for TLS in `no_std` environments, too, which removes the necessity to have a `std::io` replacement at all. If you think the benefits are worth the effort, a `std::io` replacement could be added optionally with a feature. I have not had a detailed look at `core2` but I found working with `core_io` very limiting, so maybe `core2` could be a better option.

When working on these changes, I have also fixed some other minor issues with `no_std` usage. Specifically, this should also fix https://github.com/fortanix/rust-mbedtls/issues/208 (making https://github.com/fortanix/rust-mbedtls/pull/209 obsolete) while bringing `rust-mbedtls` to 32 bit targets (specifically the ARM `thumb...` targets commonly found on MCUs).

With the changes presented in this PR, I was finally able to successfully use `rust-mbedtls` on an STM32L452CCUx MCU.