### PR TITLE
Change license fields to SPDX-compliant license expression avoiding deprecated 'GPL-2.0+'

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "mbedtls-sys-auto"
 version = "2.28.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Rust bindings for MbedTLS.
 

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Idiomatic Rust wrapper for MbedTLS, allowing you to use MbedTLS with only safe
 code while being able to use such great Rust features like error handling and


### PR DESCRIPTION
The `/` operator is not specified by SPDX and [deprecated in Cargo.toml](https://doc.rust-lang.org/cargo/reference/manifest.html#slash). The usage of `GPL-2.0+` to denote `GPL-2.0-or-later` is [deprecated by SPDX](https://spdx.org/licenses/).

Changing this in `Cargo.toml` fixes usage with automatic tooling.