### PR TITLE
Fix wrong cert used in examples/client.rs

### DIFF
--- a/mbedtls/examples/client.rs
+++ b/mbedtls/examples/client.rs
@@ -27,7 +27,7 @@ use support::keys;
 fn result_main(addr: &str) -> TlsResult<()> {
     let entropy = Arc::new(entropy_new());
     let rng = Arc::new(CtrDrbg::new(entropy, None)?);
-    let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT.as_bytes())?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes())?);
     let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
     config.set_rng(rng);
     config.set_ca_list(cert, None);


### PR DESCRIPTION
I got this error when trying to run the `examples/client.rs`

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: X509CertVerifyFailed', mbedtls/examples/client.rs:54:6
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/result.rs:1113:23
   4: client::main
             at ./mbedtls/examples/client.rs:49:5
   5: core::ops::function::FnOnce::call_once
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs:507:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I found that it's because of using the wrong cert in `examples/client.rs`

Fix with:
```diff
-   let cert = Arc::new(Certificate::from_pem_multiple(keys::PEM_CERT.as_bytes())?);
+   let cert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes())?);
```

Same as #123 

