### PR TITLE
Export mbedtls sys items, prepare for windows compiling

### DIFF
--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -119,8 +119,10 @@ mod alloc_prelude {
     pub(crate) use alloc::vec::Vec;
 }
 
-#[cfg(all(feature="time", any(feature="custom_gmtime_r", feature="custom_time")))]
-use mbedtls_sys::types::{time_t, tm};
+#[cfg(all(feature = "time", any(feature = "custom_gmtime_r", feature = "custom_time")))]
+use mbedtls_sys::types::time_t;
+#[cfg(all(feature = "time", feature = "custom_gmtime_r"))]
+use mbedtls_sys::types::tm;
 
 #[cfg(any(feature = "custom_gmtime_r", feature = "custom_time"))]
 extern crate chrono;

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -40,10 +40,10 @@ extern crate rs_libc;
 #[macro_use]
 mod wrapper_macros;
 
-#[cfg(feature="pkcs12_rc2")]
-extern crate rc2;
-#[cfg(feature="pkcs12_rc2")]
+#[cfg(feature = "pkcs12_rc2")]
 extern crate cbc;
+#[cfg(feature = "pkcs12_rc2")]
+extern crate rc2;
 
 // ==============
 //      API

--- a/mbedtls/src/pk/mod.rs
+++ b/mbedtls/src/pk/mod.rs
@@ -10,6 +10,7 @@
 use crate::alloc_prelude::*;
 use mbedtls_sys::*;
 
+pub use mbedtls_sys::ecp_group_id;
 use mbedtls_sys::types::raw_types::c_void;
 
 use core::ptr;
@@ -39,9 +40,9 @@ pub use self::ec::{EcGroupId, ECDSA_MAX_LEN};
 pub use crate::ecp::EcGroup;
 
 // SHA-256("Fortanix")[:4]
-const CUSTOM_PK_TYPE: pk_type_t = 0x8b205408 as pk_type_t;
+const CUSTOM_PK_TYPE: pk_type_t = 0x8b205408_u32 as pk_type_t;
 
-const RAW_RSA_DECRYPT : i32 = 1040451858;
+const RAW_RSA_DECRYPT: i32 = 1040451858;
 
 define!(
     #[c_ty(pk_type_t)]
@@ -114,7 +115,7 @@ unsafe extern "C" fn free_custom_pk_ctx(p: *mut c_void) {
     let _ = Box::from_raw(p as *mut CustomPkContext);
 }
 
-extern "C" fn custom_pk_can_do(_t: u32) -> i32 {
+extern "C" fn custom_pk_can_do(_t: pk_type_t) -> i32 {
     0
 }
 

--- a/mbedtls/src/rust_printf.c
+++ b/mbedtls/src/rust_printf.c
@@ -8,6 +8,12 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#ifdef _WIN32
+#define alloca _alloca
+#include <malloc.h>
+#else
+#include <alloca.h>
+#endif
 
 extern void mbedtls_log(const char* msg);
 
@@ -22,7 +28,7 @@ extern int mbedtls_printf(const char *fmt, ...) {
        return -1;
 
     n++;
-    char p[n];
+    char *p = alloca(n);
 
     va_start(ap,fmt);
     n=vsnprintf(p,n,fmt,ap);


### PR DESCRIPTION
Windows should now compile with mbedtls (mbedtls sys should still be updated)

Exported some mbedtls sys items to be used in other crates (this way no other crates should ever need to include mbedtls sys)