### PR TITLE
Clean up `v0.7` branch dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,11 +471,11 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -706,6 +706,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +381,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +410,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -434,18 +471,18 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -644,7 +681,24 @@ version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
  "pin-project-lite",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/ct.sh
+++ b/ct.sh
@@ -42,8 +42,8 @@ if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [
     fi
 
 elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand,time,custom_time,custom_gmtime_r
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core_io,rdrand
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core-io,rdrand,time,custom_time,custom_gmtime_r
+    cargo +$CORE_IO_NIGHTLY test --no-default-features --features core-io,rdrand
 else
     echo "Unknown version $TRAVIS_RUST_VERSION"
     exit 1

--- a/ct.sh
+++ b/ct.sh
@@ -26,7 +26,7 @@ if [ $TRAVIS_RUST_VERSION = "stable" ] || [ $TRAVIS_RUST_VERSION = "beta" ] || [
         cargo test --features rust_threading --target $TARGET
         cargo test --features custom_time,custom_gmtime_r --target $TARGET
         # test the async support
-        cargo test --test async_session --features=std,threading,tokio/full --target $TARGET
+        cargo test --test async_session --features=async-rt --target $TARGET
 
         # If zlib is installed, test the zlib feature
         if [ -n "$ZLIB_INSTALLED" ]; then

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -31,8 +31,8 @@ bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 tokio = { version = "1.16.1", optional = true }
-proc-macro2 = "=1.0.24"
-quote = "=1.0.9"
+proc-macro2 = { version = "=1.0.27", optional = true }
+quote = { version = "=1.0.10", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.1.0"
@@ -76,6 +76,7 @@ legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
+core-io = ["core_io", "proc-macro2", "quote"]
 async = ["std", "threading", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
 async-rt = [ "async", "tokio/rt"]
 

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -31,7 +31,7 @@ bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 tokio = { version = "1.16.1", optional = true }
-proc-macro2 = { version = "=1.0.27", optional = true }
+proc-macro2 = { version = ">=1.0.24, <1.0.40", optional = true }
 quote = { version = "=1.0.10", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -76,6 +76,8 @@ legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
+async = ["std", "threading", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
+async-rt = [ "async", "tokio/rt"]
 
 [[example]]
 name = "client"
@@ -95,7 +97,7 @@ required-features = ["std"]
 [[test]]
 name = "async_session"
 path = "tests/async_session.rs"
-required-features = ["std", "threading", "tokio", "tokio/net", "tokio/io-util", "tokio/macros", "tokio/rt"]
+required-features = ["async-rt"]
 
 [[test]]
 name = "client_server"

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -10,7 +10,7 @@
 #![allow(unused_doc_comments)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(all(not(feature = "std"), not(feature = "core_io")))]
+#[cfg(all(not(feature = "std"), not(feature = "core-io")))]
 const ERROR: _MUST_USE_EITHER_STD_OR_CORE_IO_ = ();
 
 #[cfg(not(feature = "std"))]

--- a/mbedtls/src/ssl/async_session.rs
+++ b/mbedtls/src/ssl/async_session.rs
@@ -6,7 +6,7 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
-#![cfg(all(feature = "std", feature = "tokio"))]
+#![cfg(all(feature = "std", feature = "async"))]
 
 use std::cell::Cell;
 use std::future::Future;

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -379,7 +379,7 @@ impl<'a> Drop for MidHandshake<'a> {
     }
 }
 
-#[cfg(all(feature = "std", feature = "tokio"))]
+#[cfg(all(feature = "std", feature = "async"))]
 impl<'a> Session<'a> {
     // This is unsafe because if it returns something other than Ok or
     // WouldBlock, then it's the caller's responsibility to ensure the session

--- a/mbedtls/src/ssl/mod.rs
+++ b/mbedtls/src/ssl/mod.rs
@@ -12,7 +12,7 @@ pub mod config;
 pub mod context;
 pub mod ticket;
 
-#[cfg(all(feature = "std", feature = "tokio"))]
+#[cfg(all(feature = "std", feature = "async"))]
 #[doc(inline)]
 pub use self::async_session::{AsyncSession, IoAdapter};
 #[doc(inline)]

--- a/mbedtls/tests/support/net.rs
+++ b/mbedtls/tests/support/net.rs
@@ -12,7 +12,7 @@ use std::io::{Error as IoError, Result as IoResult};
 use std::net::TcpStream;
 use std::os::unix::io::FromRawFd;
 
-#[cfg(feature = "tokio")]
+#[cfg(feature = "async")]
 use tokio::net;
 
 pub fn create_tcp_pair() -> IoResult<(TcpStream, TcpStream)> {
@@ -32,7 +32,7 @@ pub fn create_tcp_pair() -> IoResult<(TcpStream, TcpStream)> {
     }
 }
 
-#[cfg(feature = "tokio")]
+#[cfg(feature = "async")]
 pub fn create_tcp_pair_async() -> IoResult<(net::TcpStream, net::TcpStream)> {
     let (c, s) = create_tcp_pair()?;
     c.set_nonblocking(true)?;


### PR DESCRIPTION
Changes:

1. add `async` and `async-rt` feature and put all `tokio` dependencies behind it
2. add `core-io` feature, put all related dependencies with pinned version behind it