### PR TITLE
Remove `core_io` related CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,10 @@ env:
     - TARGET=x86_64-fortanix-unknown-sgx
   global:
     - RUST_BACKTRACE=1
-    # Pinned to this particular nightly version because of core_io. This can be
-    # re-pinned whenever core_io is updated to the latest nightly.
-    - CORE_IO_NIGHTLY=nightly-2021-03-25
 jobs:
   include:
     # Test additional Rust toolchains on x86_64
     - rust: beta
     - rust: nightly
-    - rust: nightly-2021-03-25
 script:
   - ./ct.sh

--- a/ct.sh
+++ b/ct.sh
@@ -47,9 +47,6 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET
     fi
 
-elif [ $TRAVIS_RUST_VERSION = $CORE_IO_NIGHTLY ]; then
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand,time
-    cargo +$CORE_IO_NIGHTLY test --no-default-features --features no_std_deps,rdrand
 else
     echo "Unknown version $TRAVIS_RUST_VERSION"
     exit 1

--- a/ct.sh
+++ b/ct.sh
@@ -44,9 +44,11 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
             cargo test --features force_aesni_support --target $TARGET
         fi
 
-        # no_std tests
-        cargo test --no-default-features --features no_std_deps,rdrand,time --target $TARGET
-        cargo test --no-default-features --features no_std_deps,rdrand --target $TARGET
+        # no_std tests only be able to run on x86 platform
+        if [ "$TARGET" == "x86_64-fortanix-unknown-sgx" ]; then
+            cargo test --no-default-features --features no_std_deps,rdrand,time --target $TARGET
+            cargo test --no-default-features --features no_std_deps,rdrand --target $TARGET
+        fi
     else
         cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET
     fi

--- a/ct.sh
+++ b/ct.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         fi
 
         # no_std tests only be able to run on x86 platform
-        if [ "$TARGET" == "x86_64-fortanix-unknown-sgx" ]; then
+        if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
             cargo test --no-default-features --features no_std_deps,rdrand,time --target $TARGET
             cargo test --no-default-features --features no_std_deps,rdrand --target $TARGET
         fi

--- a/ct.sh
+++ b/ct.sh
@@ -43,6 +43,10 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         if [ -n "$AES_NI_SUPPORT" ]; then
             cargo test --features force_aesni_support --target $TARGET
         fi
+
+        # no_std tests
+        cargo test --no-default-features --features no_std_deps,rdrand,time --target $TARGET
+        cargo test --no-default-features --features no_std_deps,rdrand --target $TARGET
     else
         cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET
     fi

--- a/ct.sh
+++ b/ct.sh
@@ -44,7 +44,7 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
             cargo test --features force_aesni_support --target $TARGET
         fi
 
-        # no_std tests only be able to run on x86 platform
+        # no_std tests only are able to run on x86 platform
         if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
             cargo test --no-default-features --features no_std_deps,rdrand,time --target $TARGET
             cargo test --no-default-features --features no_std_deps,rdrand --target $TARGET


### PR DESCRIPTION
Since `core_io` (which originally depends on specific version of rust toolchain: `nightly-2021-03-25`) have been removed in source code, so we need to update CI to remove unnecessary CI & tests