### PR TITLE
[v0.7] Remove pining of indirect dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,8 +344,6 @@ dependencies = [
  "matches",
  "mbedtls-sys-auto",
  "num-bigint",
- "proc-macro2",
- "quote",
  "rand",
  "rc2",
  "rs-libc",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ This is a list of the Cargo features available for mbedtls. Features in
             enabled automatically.
 * *core_io* On no_std, you must enable this feature. It will supply the I/O
             Read and Write traits.
+            **Note**: You need to add following into `Cargo.toml` to correctly compile
+            code with old toolchain (`nightly-2021-03-25`) that support `core-io` feature
+    ```toml
+    proc-macro2 = { version = ">=1.0.24, <1.0.40" }
+    quote = { version = "=1.0.10" }
+    ```
 * *debug* Enable debug printing to stdout. You need to configure the debug
           threshold at runtime.
 * dsa Enable support for DSA signatures

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -31,6 +31,10 @@ bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 tokio = { version = "1.16.1", optional = true }
+# Note: following two lines of pinning is necessary when you want to use `core-io` feature
+# proc-macro2 = { version = ">=1.0.24, <1.0.40" }
+# quote = { version = "=1.0.10" }
+
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.1.0"
@@ -74,6 +78,7 @@ legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
+# Note: you need to uncomment two dependencies above to ensure correct compilation
 core-io = ["core_io"]
 async = ["std", "threading", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
 async-rt = [ "async", "tokio/rt"]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -31,8 +31,6 @@ bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 tokio = { version = "1.16.1", optional = true }
-proc-macro2 = { version = ">=1.0.24, <1.0.40", optional = true }
-quote = { version = "=1.0.10", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.1.0"
@@ -76,7 +74,7 @@ legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
-core-io = ["core_io", "proc-macro2", "quote"]
+core-io = ["core_io"]
 async = ["std", "threading", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
 async-rt = [ "async", "tokio/rt"]
 


### PR DESCRIPTION
Because  `core_io` still depends on `nightly-20210325`, pining the  indirect dependencies of `core_io` makes this crate incompatible with a lot of crates which is on `stable` or `nightly` channel.

This PR remove the explicitly pining of  indirect dependencies to resolve above problem and keep `lock` file unchanged so the tests & CI could still pass