### PR TITLE
Add async IO &  async support for TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +58,12 @@ name = "autocfg"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -96,6 +124,12 @@ name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cbc"
@@ -220,6 +254,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "futures"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+
+[[package]]
+name = "futures-task"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+
+[[package]]
+name = "futures-util"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,9 +445,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libloading"
@@ -374,8 +497,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
+ "async-stream",
  "bit-vec",
  "bitflags",
  "byteorder",
@@ -383,6 +507,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "chrono",
+ "futures",
  "hex",
  "hyper",
  "libc",
@@ -390,6 +515,7 @@ dependencies = [
  "mbedtls-selftest",
  "mbedtls-sys-auto",
  "num-bigint",
+ "pin-project-lite",
  "rand",
  "rc2",
  "rs-libc",
@@ -397,6 +523,8 @@ dependencies = [
  "serde_cbor",
  "serde_derive",
  "spin",
+ "tokio",
+ "tracing",
  "yasna",
 ]
 
@@ -440,6 +568,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log 0.4.8",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,12 +600,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343b3df15c945a59e72aae31e89a7cfc9e11850e96d4fde6fed5e3c7c8d9c887"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.6",
  "num-integer",
  "num-traits",
 ]
@@ -466,7 +625,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.6",
  "num-traits",
 ]
 
@@ -476,7 +635,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.6",
 ]
 
 [[package]]
@@ -491,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "peeking_take_while"
@@ -506,6 +665,18 @@ name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -684,6 +855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +949,65 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "traitobject"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is a list of the Cargo features available for mbedtls. Features in
           work without libc will be provided.
 * **time** Enable time support in mbedtls-sys.
 * *zlib* Enable zlib support in mbedtls-sys.
+* *async-rt* Enable async support for SSL.
 
 PRs adding new features are encouraged.
 

--- a/ct.sh
+++ b/ct.sh
@@ -33,10 +33,14 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --features pkcs12 --target $TARGET
         cargo test --features pkcs12_rc2 --target $TARGET
         cargo test --features dsa --target $TARGET
-
+        cargo test --test async_session --features=async-rt --target $TARGET
+        cargo test --test async_session --features=async-rt,legacy_protocols --target $TARGET
+        
         # If zlib is installed, test the zlib feature
         if [ -n "$ZLIB_INSTALLED" ]; then
             cargo test --features zlib --target $TARGET
+            cargo test --test async_session --features=async-rt,zlib --target $TARGET
+            cargo test --test async_session --features=async-rt,zlib,legacy_protocols --target $TARGET
         fi
 
         # If AES-NI is supported, test the feature

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
@@ -29,6 +29,7 @@ bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 cfg-if = "1.0.0"
+tokio = { version = "1.16.1", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.2.0"
@@ -51,6 +52,10 @@ serde_cbor = "0.6"
 hex = "0.3"
 matches = "0.1.8"
 hyper = { version = "0.10.16", default-features = false }
+async-stream = "0.3.0"
+futures = "0.3"
+tracing = "0.1"
+pin-project-lite = "0.2"
 
 [build-dependencies]
 cc = "1.0"
@@ -72,6 +77,8 @@ dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
+async = ["std", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
+async-rt = ["async", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
 
 [[example]]
 name = "client"
@@ -104,3 +111,9 @@ required-features = ["std"]
 [[test]]
 name = "hyper"
 required-features = ["std"]
+
+
+[[test]]
+name = "async_session"
+path = "tests/async_session.rs"
+required-features = ["async-rt"]

--- a/mbedtls/src/ssl/async_io.rs
+++ b/mbedtls/src/ssl/async_io.rs
@@ -1,0 +1,171 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or
+ * https://www.gnu.org/licenses/gpl-2.0.html> or the Apache License, Version
+ * 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, at your
+ * option. This file may not be copied, modified, or distributed except
+ * according to those terms. */
+
+#![cfg(all(feature = "std", feature = "async"))]
+
+use crate::{
+    error::{Error, Result},
+    ssl::{
+        context::Context,
+        io::{IoCallback, IoCallbackUnsafe},
+    },
+};
+use std::{
+    future::Future,
+    io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult},
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// Marker type for an IO implementation that implements both
+/// `tokio::io::AsyncRead` and `tokio::io::AsyncWrite`.
+pub enum AsyncStream {}
+
+// TODO: Add enum `AnyAsyncIo` as marker type for an IO implementation that
+// doesn't implement `tokio::io::AsyncRead` and `tokio::io::AsyncWrite`.
+
+// TODO: Add `AsyncIo` trait for async IO that that doesn't implement
+// `tokio::io::AsyncRead` and `tokio::io::AsyncWrite`. For example:
+//     pub trait AsyncIo {
+//        async fn recv(&mut self, buf: &mut [u8]) -> Result<usize>;
+//         async fn send(&mut self, buf: &[u8]) -> Result<usize>;
+//     }
+// Could implement by using `async-trait` crate or
+// #![feature(async_fn_in_trait)] or Associated Types
+
+impl<'a, 'b, 'c, IO: AsyncRead + AsyncWrite + std::marker::Unpin + 'static> IoCallback<AsyncStream>
+    for (&'a mut TaskContext<'b>, &'c mut IO)
+{
+    fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let mut buf = ReadBuf::new(buf);
+        let io = Pin::new(&mut self.1);
+        match io.poll_read(self.0, &mut buf) {
+            Poll::Ready(Ok(())) => Ok(buf.filled().len()),
+            Poll::Ready(Err(_)) => Err(Error::NetRecvFailed),
+            Poll::Pending => Err(Error::SslWantRead),
+        }
+    }
+
+    fn send(&mut self, buf: &[u8]) -> Result<usize> {
+        let io = Pin::new(&mut self.1);
+        match io.poll_write(self.0, buf) {
+            Poll::Ready(Err(_)) => Err(Error::NetSendFailed),
+            Poll::Ready(Ok(n)) => Ok(n),
+            Poll::Pending => Err(Error::SslWantWrite),
+        }
+    }
+}
+
+impl<T: Unpin + AsyncRead + AsyncWrite + 'static> Context<T> {
+    pub async fn establish_async<IoType>(&mut self, io: T, hostname: Option<&str>) -> Result<()>
+    where
+        for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut T): IoCallbackUnsafe<IoType>,
+    {
+        struct HandshakeFuture<'a, T>(&'a mut Context<T>);
+        impl<T> Future for HandshakeFuture<'_, T>
+        where
+            for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut T): IoCallbackUnsafe<AsyncStream>,
+        {
+            type Output = Result<()>;
+            fn poll(mut self: Pin<&mut Self>, ctx: &mut TaskContext) -> std::task::Poll<Self::Output> {
+                self.0
+                    .with_bio_async(ctx, |ssl_ctx| match ssl_ctx.handshake() {
+                        Err(Error::SslWantRead) | Err(Error::SslWantWrite) => Poll::Pending,
+                        Err(e) => Poll::Ready(Err(e)),
+                        Ok(()) => Poll::Ready(Ok(())),
+                    })
+                    .unwrap_or(Poll::Ready(Err(Error::NetSendFailed)))
+            }
+        }
+
+        self.prepare_handshake(io, hostname)?;
+
+        HandshakeFuture(self).await
+    }
+}
+
+impl<T: AsyncRead> AsyncRead for Context<T>
+where
+    for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut T): IoCallbackUnsafe<AsyncStream>,
+{
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>, buf: &mut ReadBuf<'_>) -> Poll<IoResult<()>> {
+        if self.handle().session.is_null() {
+            return Poll::Ready(Err(IoError::new(IoErrorKind::Other, "stream has been shutdown")));
+        }
+
+        self.with_bio_async(cx, |ssl_ctx| match ssl_ctx.recv(buf.initialize_unfilled()) {
+            Err(Error::SslPeerCloseNotify) => Poll::Ready(Ok(())),
+            Err(Error::SslWantRead) => Poll::Pending,
+            Err(e) => Poll::Ready(Err(crate::private::error_to_io_error(e))),
+            Ok(i) => {
+                buf.advance(i);
+                Poll::Ready(Ok(()))
+            }
+        })
+        .unwrap_or_else(|| Poll::Ready(Err(crate::private::error_to_io_error(Error::NetRecvFailed))))
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for Context<T>
+where
+    for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut T): IoCallbackUnsafe<AsyncStream>,
+{
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>, buf: &[u8]) -> Poll<IoResult<usize>> {
+        if self.handle().session.is_null() {
+            return Poll::Ready(Err(IoError::new(IoErrorKind::Other, "stream has been shutdown")));
+        }
+
+        self
+            .with_bio_async(cx, |ssl_ctx| match ssl_ctx.async_write(buf) {
+                Err(Error::SslPeerCloseNotify) => Poll::Ready(Ok(0)),
+                Err(Error::SslWantWrite) => Poll::Pending,
+                Err(e) => Poll::Ready(Err(crate::private::error_to_io_error(e))),
+                Ok(i) => Poll::Ready(Ok(i)),
+            })
+            .unwrap_or_else(|| Poll::Ready(Err(crate::private::error_to_io_error(Error::NetSendFailed))))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<IoResult<()>> {
+        if self.handle().session.is_null() {
+            return Poll::Ready(Err(IoError::new(IoErrorKind::Other, "stream has been shutdown")));
+        }
+
+        match self
+            .with_bio_async(cx, Context::flush_output)
+            .unwrap_or(Err(Error::NetSendFailed))
+        {
+            Err(Error::SslWantWrite) => Poll::Pending,
+            Err(e) => Poll::Ready(Err(crate::private::error_to_io_error(e))),
+            Ok(()) => Poll::Ready(Ok(())),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<IoResult<()>> {
+        if self.handle().session.is_null() {
+            return Poll::Ready(Err(IoError::new(IoErrorKind::Other, "stream has been shutdown")));
+        }
+
+        match self
+            .with_bio_async(cx, Context::close_notify)
+            .unwrap_or(Err(Error::NetSendFailed))
+        {
+            Err(Error::SslWantRead) | Err(Error::SslWantWrite) => Poll::Pending,
+            Err(e) => {
+                self.drop_io();
+                Poll::Ready(Err(crate::private::error_to_io_error(e)))
+            }
+            Ok(()) => {
+                self.drop_io();
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+}
+
+// TODO: AsyncIo impl for tokio::net::UdpSocket

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -16,7 +16,7 @@ use mbedtls_sys::*;
 
 #[cfg(not(feature = "std"))]
 use crate::alloc_prelude::*;
-use crate::alloc::{List as MbedtlsList};
+use crate::alloc::List as MbedtlsList;
 use crate::error::{Error, Result, IntoResult};
 use crate::pk::Pk;
 use crate::private::UnsafeFrom;
@@ -172,35 +172,101 @@ impl<T> Context<T> {
     }
 }
 
+/// # Safety
+/// `io` must live as long as `ctx` or the next time bio is set/cleared.
+unsafe fn set_bio_raw<IoType, T: IoCallbackUnsafe<IoType>>(ctx: *mut ssl_context, io: &mut T) {
+    ssl_set_bio(
+        ctx,
+        io as *mut T as *mut c_void,
+        Some(T::call_send),
+        Some(T::call_recv),
+        None,
+    );
+}
+
+/// This function provides a way to apply async context to bio before running 
+/// any logic.
+/// Note: `bio` is a concept in common TLS implementation which refers to basic IO.
+/// openssl and mbedtls both use this concept.
+/// Ref: https://stackoverflow.com/questions/51672133/what-are-openssl-bios-how-do-they-work-how-are-bios-used-in-openssl
+#[cfg(all(feature = "std", feature = "async"))]
+impl<T> Context<T>  {
+    pub(super) fn with_bio_async<'cx, R, IoType>(&mut self, cx: &mut std::task::Context<'cx>, f: impl FnOnce(&mut Self) -> R) -> Option<R> where for<'c> (&'c mut std::task::Context<'cx>, &'c mut T): IoCallbackUnsafe<IoType> {
+        let ret;
+
+        struct BioGuard<'a, T> {
+            context: &'a mut Context<T>,
+        }
+        
+        impl<'a, T> Drop for BioGuard<'a, T> {
+            fn drop(&mut self) {
+                self.context.clear_bio();
+            }
+        }
+        // SAFETY: In the call to `set_bio_raw`, `user_data` must live as long
+        // as `ctx`, or until the bio is cleared from `ctx`. The bio is cleared
+        // at the end of this block ensured by the drop guard: [`BioGuard`]
+        unsafe {
+            // Points to `self.inner`, so safe to borrow at the same time as `self.io`
+            let ctx = self.into();
+            let mut user_data = (cx, &mut**self.io.as_mut()?);
+            set_bio_raw(ctx, &mut user_data);
+
+            let guard = BioGuard { context: self };
+
+            ret = f(guard.context);
+        }
+
+        Some(ret)
+    }
+
+    // This function is created to handle the odd behavior of `mbedtls_ssl_write()`
+    // Please check this https://github.com/Mbed-TLS/mbedtls/issues/4183 to learn more about how `mbedtls_ssl_write()` works in c-mbedtls 2.28
+    // This function ultimately ensure the semantics:
+    // Returned value `Ok(n)` always means n bytes of data has been sent into c-mbedtls's buffer (some of them might be sent out through underlying IO)
+    pub(super) fn async_write(&mut self, buf: &[u8]) -> Result<usize> {
+        while self.handle().out_left > 0 {
+            self.flush_output()?;
+        }
+        // when calling `send()` here, already ensured that `ssl_context.out_left` == 0
+        match self.send(buf) {
+            // Although got `Error::SslWantWrite` means underlying IO is blocked, but some of `buf` is still saved into c-mbedtls's
+            // buffer, so we need to return size of bytes that has been buffered.
+            // Since we know before this call `out_left` was 0, all buffer (with in the MBEDTLS_SSL_OUT_CONTENT_LEN part) is buffered
+            Err(Error::SslWantWrite) => Ok(std::cmp::min(unsafe { ssl_get_max_out_record_payload((&*self).into()).into_result()? as usize }, buf.len())),
+            res => res,
+        }
+    }
+}
+
 impl<T> Context<T> {
     /// Establish a TLS session on the given `io`.
     ///
-    /// Upon succesful return, the context can be communicated with using the
+    /// Upon successful return, the context can be communicated with using the
     /// `std::io::Read` and `std::io::Write` traits if `io` implements those as
     /// well, and using the `mbedtls::ssl::io::Io` trait otherwise.
     pub fn establish<IoType>(&mut self, io: T, hostname: Option<&str>) -> Result<()> where T: IoCallbackUnsafe<IoType> {
+        // SAFETY: In the call to `set_bio_raw`, `self.io` must live as long as
+        // `self`, or until the bio is cleared from `ctx`. It lives as long as
+        // `self` since it is stored in self and never cleared.
         unsafe {
-            let mut io = Box::new(io);
+            self.prepare_handshake(io, hostname)?;
+            set_bio_raw(self.into(), &mut**self.io.as_mut().unwrap());
+        }
+        self.handshake()
+    }
+
+    pub(super) fn prepare_handshake(&mut self, io: T, hostname: Option<&str>) -> Result<()> {
+        unsafe {
             ssl_session_reset(self.into()).into_result()?;
             self.set_hostname(hostname)?;
             if let Some(client_id) = self.client_transport_id.take() {
                 self.set_client_transport_id(&client_id)?;
             }
-
-            let ptr = &mut *io as *mut _ as *mut c_void;
-            ssl_set_bio(
-                self.into(),
-                ptr,
-                Some(T::call_send),
-                Some(T::call_recv),
-                None,
-            );
-
-            self.io = Some(io);
+            self.io = Some(Box::new(io));
             self.inner.reset_handshake();
+            Ok(())
         }
-
-        self.handshake()
     }
 }
 
@@ -212,7 +278,7 @@ impl<T> Context<T> {
     ///
     /// This should only be used directly if the handshake could not be completed successfully in
     /// `establish`, i.e.:
-    /// - If using nonblocking operation and `establish` failed with [`Error::SslWantRead`] or
+    /// - If using non-blocking operation and `establish` failed with [`Error::SslWantRead`] or
     /// [`Error::SslWantWrite`]
     /// - If running a DTLS server and it answers the first `ClientHello` (without cookie) with a
     /// `HelloVerifyRequest`, i.e. `establish` failed with [`Error::SslHelloVerifyRequired`]
@@ -246,9 +312,16 @@ impl<T> Context<T> {
     }
 
     fn inner_handshake(&mut self) -> Result<()> {
+        self.flush_output()?;
         unsafe {
-            ssl_flush_output(self.into()).into_result()?;
             ssl_handshake(self.into()).into_result_discard()
+        }
+    }
+
+    pub(super) fn flush_output(&mut self) -> Result<()> {
+        unsafe {
+            // non-negative return value just means `ssl_flush_output` is succeed
+            ssl_flush_output(self.into()).into_result_discard()
         }
     }
 
@@ -284,15 +357,32 @@ impl<T> Context<T> {
     pub fn config(&self) -> &Arc<Config> {
         &self.config
     }
-    
-    pub fn close(&mut self) {
+
+    pub(super) fn close_notify(&mut self) -> Result<()> {
         unsafe {
-            ssl_close_notify(self.into());
+            ssl_close_notify(self.into()).into_result().map(|_| ())
+        }
+    }
+
+    pub fn close(&mut self) {
+        let _ = self.close_notify();
+        self.drop_io();
+    }
+
+    pub(super) fn clear_bio(&mut self) {
+        // It is safe to set the bio to null using the `ssl_set_bio` function. If the bio
+        // is null, mbedtls can handle this case and will return an error if you attempt
+        // to continue using SSL after calling this function.
+        unsafe {
             ssl_set_bio(self.into(), ::core::ptr::null_mut(), None, None, None);
-            self.io = None;
         }
     }
     
+    pub(super) fn drop_io(&mut self) {
+        self.clear_bio();
+        self.io = None;
+    }
+
     pub fn io(&self) -> Option<&T> {
         self.io.as_ref().map(|v| &**v)
     }
@@ -425,7 +515,7 @@ impl<T> Drop for Context<T> {
 //
 // Class exists only during SNI callback that is configured from Config.
 // SNI Callback must provide input whose lifetime exceeds the SNI closure to avoid memory corruptions.
-// That can be achieved easily by storing certificate chains/crls inside the closure for the lifetime of the closure.
+// That can be achieved easily by storing certificate chains/CRLs inside the closure for the lifetime of the closure.
 //
 // That is due to SNI being held by an Arc inside Config.
 // Config lives longer then Context. Context lives longer then Handshake.
@@ -509,7 +599,7 @@ mod tests {
     use crate::tests::TestTrait;
     
     #[test]
-    fn handshakecontext_sync() {
+    fn handshake_context_sync() {
         assert!(!TestTrait::<dyn Sync, HandshakeContext>::new().impls_trait(), "HandshakeContext must be !Sync");
     }
 

--- a/mbedtls/src/ssl/io.rs
+++ b/mbedtls/src/ssl/io.rs
@@ -132,7 +132,7 @@ impl<IO: Read + Write> IoCallback<Stream> for IO {
 }
 
 #[cfg(feature = "std")]
-/// A `UdpSocket` on which `connect` was succesfully called.
+/// A `UdpSocket` on which `connect` was successfully called.
 ///
 /// Construct this type using `ConnectedUdpSocket::connect`.
 pub struct ConnectedUdpSocket {

--- a/mbedtls/src/ssl/mod.rs
+++ b/mbedtls/src/ssl/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod context;
 pub mod cookie;
 pub mod io;
+pub mod async_io;
 pub mod ticket;
 
 #[doc(inline)]

--- a/mbedtls/tests/async_session.rs
+++ b/mbedtls/tests/async_session.rs
@@ -1,0 +1,555 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * Licensed under the GNU General Public License, version 2 <LICENSE-GPL or
+ * https://www.gnu.org/licenses/gpl-2.0.html> or the Apache License, Version
+ * 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0>, at your
+ * option. This file may not be copied, modified, or distributed except
+ * according to those terms. */
+
+#![cfg(not(target_env = "sgx"))]
+extern crate mbedtls;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use mbedtls::pk::Pk;
+use mbedtls::rng::CtrDrbg;
+use mbedtls::ssl::config::{Endpoint, Preset, Transport};
+use mbedtls::ssl::{Config, Context, Version};
+use mbedtls::x509::{Certificate, VerifyError};
+use mbedtls::Error;
+use mbedtls::Result as TlsResult;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+mod support;
+use support::entropy::entropy_new;
+use support::keys;
+use tokio::net::TcpStream;
+
+// TODO: Add unified interface for TCP and UDP like `TransportType` in
+// `client_server.rs`
+
+async fn client(conn: TcpStream, min_version: Version, max_version: Version, exp_version: Option<Version>) -> TlsResult<()> {
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None)?);
+    let cacert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes())?);
+    let expected_flags = VerifyError::empty();
+    #[cfg(feature = "time")]
+    let expected_flags = expected_flags | VerifyError::CERT_EXPIRED;
+    {
+        let verify_callback = move |crt: &Certificate, depth: i32, verify_flags: &mut VerifyError| {
+            match (crt.subject().unwrap().as_str(), depth, &verify_flags) {
+                ("CN=RootCA", 1, _) => (),
+                (keys::EXPIRED_CERT_SUBJECT, 0, flags) => assert_eq!(**flags, expected_flags),
+                _ => assert!(false),
+            };
+
+            verify_flags.remove(VerifyError::CERT_EXPIRED); //we check the flags at the end,
+                                                            //so removing this flag here prevents the connections from failing with
+                                                            // VerifyError
+            Ok(())
+        };
+        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+        config.set_rng(rng);
+        config.set_verify_callback(verify_callback);
+        config.set_ca_list(cacert, None);
+        config.set_min_version(min_version)?;
+        config.set_max_version(max_version)?;
+        let mut ctx = Context::new(Arc::new(config));
+
+        match ctx.establish_async(conn, None).await {
+            Ok(()) => {
+                assert_eq!(ctx.version(), exp_version.unwrap());
+            }
+            Err(e) => {
+                match e {
+                    Error::SslBadHsProtocolVersion => {
+                        assert!(exp_version.is_none())
+                    }
+                    Error::SslFatalAlertMessage => {}
+                    e => panic!("Unexpected error {}", e),
+                };
+                return Ok(());
+            }
+        };
+
+        let ciphersuite = ctx.ciphersuite().unwrap();
+        ctx.write_all(format!("Client2Server {:4x}", ciphersuite).as_bytes())
+            .await
+            .unwrap();
+        let mut buf = [0u8; 13 + 4 + 1];
+        ctx.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, format!("Server2Client {:4x}", ciphersuite).as_bytes());
+    } // drop verify_callback, releasing borrow of verify_args
+    Ok(())
+}
+
+async fn server(conn: TcpStream, min_version: Version, max_version: Version, exp_version: Option<Version>) -> TlsResult<()> {
+    let entropy = entropy_new();
+    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::EXPIRED_CERT.as_bytes())?);
+    let key = Arc::new(Pk::from_private_key(keys::EXPIRED_KEY.as_bytes(), None)?);
+    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+    config.set_rng(rng);
+    config.set_min_version(min_version)?;
+    config.set_max_version(max_version)?;
+    config.push_cert(cert, key)?;
+    let mut context = Context::new(Arc::new(config));
+
+    match context.establish_async(conn, None).await {
+        Ok(()) => {
+            assert_eq!(context.version(), exp_version.unwrap());
+        }
+        Err(e) => {
+            match e {
+                // client just closes connection instead of sending alert
+                Error::NetSendFailed => {
+                    assert!(exp_version.is_none())
+                }
+                Error::SslBadHsProtocolVersion => {}
+                e => panic!("Unexpected error {}", e),
+            };
+            return Ok(());
+        }
+    };
+
+    //assert_eq!(ctx.get_alpn_protocol().unwrap().unwrap(), None);
+    let ciphersuite = context.ciphersuite().unwrap();
+    context
+        .write_all(format!("Server2Client {:4x}", ciphersuite).as_bytes())
+        .await
+        .unwrap();
+    let mut buf = [0u8; 13 + 1 + 4];
+    context.read_exact(&mut buf).await.unwrap();
+
+    assert_eq!(&buf, format!("Client2Server {:4x}", ciphersuite).as_bytes());
+    Ok(())
+}
+
+async fn with_client<F, R>(conn: TcpStream, f: F) -> R
+where
+    F: FnOnce(Context<TcpStream>) -> Pin<Box<dyn Future<Output = R> + Send>>,
+{
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None).unwrap());
+    let cacert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes()).unwrap());
+
+    let verify_callback = move |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+        verify_flags.remove(VerifyError::CERT_EXPIRED);
+        Ok(())
+    };
+
+    let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+    config.set_rng(rng);
+    config.set_verify_callback(verify_callback);
+    config.set_ca_list(cacert, None);
+    let mut context = Context::new(Arc::new(config));
+
+    context.establish_async(conn, None).await.unwrap();
+
+    f(context).await
+}
+
+async fn with_server<F, R>(conn: TcpStream, f: F) -> R
+where
+    F: FnOnce(Context<TcpStream>) -> Pin<Box<dyn Future<Output = R> + Send>>,
+{
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None).unwrap());
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::EXPIRED_CERT.as_bytes()).unwrap());
+    let key = Arc::new(Pk::from_private_key(keys::EXPIRED_KEY.as_bytes(), None).unwrap());
+
+    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+    config.set_rng(rng);
+    config.push_cert(cert, key).unwrap();
+    let mut context = Context::new(Arc::new(config));
+
+    context.establish_async(conn, None).await.unwrap();
+
+    f(context).await
+}
+
+#[cfg(unix)]
+mod test {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn async_session_client_server_test() {
+        use mbedtls::ssl::Version;
+
+        #[derive(Copy, Clone)]
+        struct TestConfig {
+            min_c: Version,
+            max_c: Version,
+            min_s: Version,
+            max_s: Version,
+            exp_ver: Option<Version>,
+        }
+
+        impl TestConfig {
+            pub fn new(min_c: Version, max_c: Version, min_s: Version, max_s: Version, exp_ver: Option<Version>) -> Self {
+                TestConfig {
+                    min_c,
+                    max_c,
+                    min_s,
+                    max_s,
+                    exp_ver,
+                }
+            }
+        }
+
+        let test_configs = [
+            TestConfig::new(
+                Version::Ssl3,
+                Version::Ssl3,
+                Version::Ssl3,
+                Version::Ssl3,
+                Some(Version::Ssl3),
+            ),
+            TestConfig::new(
+                Version::Ssl3,
+                Version::Tls1_2,
+                Version::Ssl3,
+                Version::Ssl3,
+                Some(Version::Ssl3),
+            ),
+            TestConfig::new(
+                Version::Tls1_0,
+                Version::Tls1_0,
+                Version::Tls1_0,
+                Version::Tls1_0,
+                Some(Version::Tls1_0),
+            ),
+            TestConfig::new(
+                Version::Tls1_1,
+                Version::Tls1_1,
+                Version::Tls1_1,
+                Version::Tls1_1,
+                Some(Version::Tls1_1),
+            ),
+            TestConfig::new(
+                Version::Tls1_2,
+                Version::Tls1_2,
+                Version::Tls1_2,
+                Version::Tls1_2,
+                Some(Version::Tls1_2),
+            ),
+            TestConfig::new(
+                Version::Tls1_0,
+                Version::Tls1_2,
+                Version::Tls1_0,
+                Version::Tls1_2,
+                Some(Version::Tls1_2),
+            ),
+            TestConfig::new(
+                Version::Tls1_2,
+                Version::Tls1_2,
+                Version::Tls1_0,
+                Version::Tls1_2,
+                Some(Version::Tls1_2),
+            ),
+            TestConfig::new(Version::Tls1_0, Version::Tls1_1, Version::Tls1_2, Version::Tls1_2, None),
+        ];
+
+        for config in &test_configs {
+            let min_c = config.min_c;
+            let max_c = config.max_c;
+            let min_s = config.min_s;
+            let max_s = config.max_s;
+            let exp_ver = config.exp_ver;
+
+            if (max_c < Version::Tls1_2 || max_s < Version::Tls1_2) && !cfg!(feature = "legacy_protocols") {
+                continue;
+            }
+
+            let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver.clone()));
+            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver));
+
+            c.await.unwrap().unwrap();
+            s.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn async_session_shutdown1() {
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+
+        let c = tokio::spawn(super::with_client(c, |mut session| {
+            Box::pin(async move {
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, |mut session| {
+            Box::pin(async move {
+                let mut buf = [0u8; 1];
+                match session.read(&mut buf).await {
+                    Ok(0) | Err(_) => {}
+                    _ => panic!("expected no data"),
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn async_session_shutdown2() {
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+
+        let c = tokio::spawn(super::with_client(c, |mut session| {
+            Box::pin(async move {
+                let mut buf = [0u8; 5];
+                session.read_exact(&mut buf).await.unwrap();
+                assert_eq!(&buf, b"hello");
+                match session.read(&mut buf).await {
+                    Ok(0) | Err(_) => {}
+                    _ => panic!("expected no data"),
+                }
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, |mut session| {
+            Box::pin(async move {
+                session.write_all(b"hello").await.unwrap();
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn async_session_shutdown3() {
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+
+        let c = tokio::spawn(super::with_client(c, |mut session| {
+            Box::pin(async move { session.shutdown().await })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, |mut session| {
+            Box::pin(async move { session.shutdown().await })
+        }));
+
+        match (c.await.unwrap(), s.await.unwrap()) {
+            (Err(_), Err(_)) => panic!("at least one should succeed"),
+            _ => {}
+        }
+    }
+
+    #[cfg(not(feature = "zlib"))]
+    #[tokio::test]
+    async fn write_large_buffer_ok() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize = 3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                session.write_all(&data_to_write).await.unwrap();
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(n) => {
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
+                    }
+                    Err(e) => {
+                        session.shutdown().await.unwrap();
+                        panic!("Unexpected error {:?}", e);
+                    }
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    /// write large buffer should ok when `poll_write` is getting an unchanging
+    /// buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
+    #[tokio::test]
+    async fn write_large_buffer_ok_with_unchanging_buffer() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize = 3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                // use a custom future for writing all buffer, which always use different length
+                // when calling `poll_write`
+                crate::support::custom_write_all::custom_write_all(&mut session, &data_to_write, 1)
+                    .await
+                    .unwrap();
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(n) => {
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
+                    }
+                    Err(e) => {
+                        session.shutdown().await.unwrap();
+                        panic!("Unexpected error {:?}", e);
+                    }
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    /// write large buffer should ok when `poll_write` is getting a increasing
+    /// buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
+    #[tokio::test]
+    async fn write_large_buffer_ok_with_changing_buffer_1() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize = 3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                // use a custom future for writing all buffer, which always use different length
+                // when calling `poll_write`
+                crate::support::custom_write_all::custom_write_all(&mut session, &data_to_write, 1)
+                    .await
+                    .unwrap();
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(n) => {
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
+                    }
+                    Err(e) => {
+                        session.shutdown().await.unwrap();
+                        panic!("Unexpected error {:?}", e);
+                    }
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    /// write large buffer should ok when `poll_write` is getting a decreasing
+    /// buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
+    #[tokio::test]
+    async fn write_large_buffer_ok_with_changing_buffer_2() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize = 3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                // use a custom future for writing all buffer, which always use different length
+                // when calling `poll_write`
+                crate::support::custom_write_all::custom_write_all(&mut session, &data_to_write, 1)
+                    .await
+                    .unwrap();
+                session.shutdown().await.unwrap();
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(n) => {
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
+                    }
+                    Err(e) => {
+                        session.shutdown().await.unwrap();
+                        panic!("Unexpected error {:?}", e);
+                    }
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+
+    /// when turn on `zlib` feature, c-mbedtls could not record buffer with
+    /// size > MBEDTLS_SSL_OUT_CONTENT_LEN (default: 16 * 1024)
+    /// Ref: mbedtls-sys/vendor/library/ssl_msg.c#L646-L653
+    #[cfg(feature = "zlib")]
+    #[tokio::test]
+    async fn write_large_buffer_should_fail_with_zlib() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize = 3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                let ret = session.write_all(&data_to_write).await;
+                assert!(ret.is_err());
+                let ref err = ret.unwrap_err();
+                assert_eq!(err.kind(), std::io::ErrorKind::Other);
+                assert!(err.to_string().contains("SslBadInputData"));
+            })
+        }));
+
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(_) => {
+                        panic!("should return error");
+                    }
+                    Err(e) => {
+                        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+                    }
+                }
+            })
+        }));
+
+        c.await.unwrap();
+        s.await.unwrap();
+    }
+}

--- a/mbedtls/tests/client_server.rs
+++ b/mbedtls/tests/client_server.rs
@@ -197,6 +197,49 @@ fn server<C: IoCallback<T> + TransportType, T>(
     Ok(())
 }
 
+fn with_client<F, R>(conn: TcpStream, f: F) -> R
+where
+    F: FnOnce(Context<TcpStream>) -> R,
+{
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None).unwrap());
+    let cacert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes()).unwrap());
+
+    let verify_callback = move |_crt: &Certificate, _depth: i32, verify_flags: &mut VerifyError| {
+        verify_flags.remove(VerifyError::CERT_EXPIRED);
+        Ok(())
+    };
+
+    let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
+    config.set_rng(rng);
+    config.set_verify_callback(verify_callback);
+    config.set_ca_list(cacert, None);
+    let mut context = Context::new(Arc::new(config));
+
+    context.establish(conn, None).unwrap();
+
+    f(context)
+}
+
+fn with_server<F, R>(conn: TcpStream, f: F) -> R
+where
+    F: FnOnce(Context<TcpStream>) -> R,
+{
+    let entropy = Arc::new(entropy_new());
+    let rng = Arc::new(CtrDrbg::new(entropy, None).unwrap());
+    let cert = Arc::new(Certificate::from_pem_multiple(keys::EXPIRED_CERT.as_bytes()).unwrap());
+    let key = Arc::new(Pk::from_private_key(keys::EXPIRED_KEY.as_bytes(), None).unwrap());
+
+    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
+    config.set_rng(rng);
+    config.push_cert(cert, key).unwrap();
+    let mut context = Context::new(Arc::new(config));
+
+    context.establish(conn, None).unwrap();
+
+    f(context)
+}
+
 #[cfg(unix)]
 mod test {
     use std::thread;
@@ -296,5 +339,76 @@ mod test {
             s.join().unwrap();
             c.join().unwrap();
         }
+    }
+    
+    #[cfg(not(feature = "zlib"))]
+    #[test]
+    fn write_large_buffer_should_ok() {
+        use std::io::{Read, Write};
+        
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize =  3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair().unwrap();
+        let c = thread::spawn(move || super::with_client(c, move |mut session| {
+            let ret = session.write_all(&data_to_write);
+            assert!(ret.is_ok());
+        }));
+
+        let s = thread::spawn(move || super::with_server(s, move |mut session| {
+            let mut buf = vec![0; buffer_size];
+            match session.read_exact(&mut buf) {
+                Ok(()) => {
+                    assert!(&buf[..] == &expected_data[..], "wrong read data");
+                }
+                Err(e) => {
+                    panic!("Unexpected error {:?}", e);
+                }
+            }
+        }));
+
+        c.join().unwrap();
+        s.join().unwrap();
+    }
+
+    /// when turn on `zlib` feature, c-mbedtls could not record buffer with
+    /// size > MBEDTLS_SSL_OUT_CONTENT_LEN (default: 16 * 1024)
+    /// Ref: mbedtls-sys/vendor/library/ssl_msg.c#L646-L653
+    #[cfg(feature = "zlib")]
+    #[test]
+    fn write_large_buffer_should_fail_with_zlib() {
+        use std::io::{Read, Write};
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize =  3 * 1024 * 1024;
+        let expected_data: Vec<u8> = std::iter::repeat_with(rand::random).take(buffer_size).collect();
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_pair().unwrap();
+        let c = thread::spawn(move || super::with_client(c, move |mut session| {
+            let ret = session.write_all(&data_to_write);
+            assert!(ret.is_err());
+            let ref err = ret.unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::Other);
+            assert!(err.to_string().contains("SslBadInputData"));
+        }));
+
+        let s = thread::spawn(move || super::with_server(s, move |mut session| {
+            let mut buf = vec![0; buffer_size];
+            match session.read_exact(&mut buf) {
+                Ok(()) => {
+                    panic!("should return error");
+                }
+                Err(e) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+                }
+            }
+        }));
+
+        c.join().unwrap();
+        s.join().unwrap();
     }
 }

--- a/mbedtls/tests/support/custom_write_all.rs
+++ b/mbedtls/tests/support/custom_write_all.rs
@@ -1,0 +1,102 @@
+#![cfg(all(feature = "std", feature = "async"))]
+use tokio::io::AsyncWrite;
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io;
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// A future returned by `custom_write_all` function that writes all data from a buffer to an AsyncWrite stream.
+    ///
+    /// This struct is used to control the behavior of writing data to the stream when it returns `Poll::Pending`.
+    /// The buffer size will be adjusted based on the percentage specified in `buffer_change_percent`.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct CustomWriteAll<'a, W: ?Sized> {
+        writer: &'a mut W,
+        // The buffer containing the data to be written.
+        buf: &'a [u8],
+        // The left index of the current buffer.
+        l: usize,
+        // The right index of the current buffer (inclusive).
+        r: usize,
+        // The percentage number used to control how the buffer is changed when `poll_write` returns `Poll::Pending`.
+        buffer_change_percent: i8,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+/// This function will create a custom Future is for writing all data from a
+/// buffer to an AsyncWrite stream. When [`AsyncWrite::poll_write`] returns
+/// [`Poll::Pending`], this future will change the size of the buffer passed to
+/// [`AsyncWrite::poll_write`] by `buffer_change_percent` percents.
+///
+/// This behavior is mainly for testing whether the underlying IO implementation
+/// can resolve the limitation that comes from `mbedtls_ssl_write`. When
+/// `mbedtls_ssl_write` returns `Error::SslWantWrite`, it needs to be called
+/// again with the same arguments.
+pub(crate) fn custom_write_all<'a, W>(writer: &'a mut W, buf: &'a [u8], buffer_change_percent: i8) -> CustomWriteAll<'a, W>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    let min_len = 8 * 1024;
+    assert!(buf.len() > min_len, "Please provide a buffer with length > {}", min_len);
+    CustomWriteAll {
+        writer,
+        buf,
+        l: 0,
+        r: min_len,
+        buffer_change_percent,
+        _pin: PhantomPinned,
+    }
+}
+
+/// This custom Future is for writing all data from a buffer to an AsyncWrite
+/// stream. When [`AsyncWrite::poll_write`] returns [`Poll::Pending`], this
+/// future will change the size of the buffer passed to
+/// [`AsyncWrite::poll_write`].
+///
+/// This behavior is mainly for testing whether the underlying IO implementation
+/// can resolve the limitation that comes from `mbedtls_ssl_write`. When
+/// `mbedtls_ssl_write` returns `Error::SslWantWrite`, it needs to be called
+/// again with the same arguments.
+impl<W> Future for CustomWriteAll<'_, W>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let me = self.project();
+        while me.l < me.r {
+            let buf_len = me.buf.len();
+            match Pin::new(&mut *me.writer).poll_write(cx, &me.buf[*me.l..*me.r]) {
+                Poll::Ready(Ok(n)) => {
+                    if n == 0 {
+                        return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
+                    }
+                    *me.l += n;
+                    *me.r += n;
+                    if *me.r > buf_len {
+                        *me.r = buf_len;
+                    }
+                }
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => {
+                    *me.r = *me.l + (*me.r - *me.l) * (100 + *me.buffer_change_percent) as usize / 100;
+                    if *me.r > buf_len {
+                        *me.r = buf_len;
+                    }
+                    return Poll::Pending;
+                }
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}

--- a/mbedtls/tests/support/mod.rs
+++ b/mbedtls/tests/support/mod.rs
@@ -12,3 +12,5 @@ pub mod keys;
 #[cfg(sys_std_component = "net")]
 pub mod net;
 pub mod rand;
+#[cfg(all(feature = "std", feature = "async"))]
+pub mod custom_write_all;


### PR DESCRIPTION
# TLDR
This PR added:
- Async version of IO abstraction ( only stream part, IO abstraction is introduced on PR: [Add a new IO abstraction #237](237) )
- Implementation for TLS 

# Detailed Explanation

## Background

We use `mbedtls` for crypto and SSL handshake in rust. `mbedtls::ssl` module contains most FFI wrapper for c mbedtls API.

### How `mbedtls::ssl` works

To setup a TLS client or a TLS server with `mbedtls`, mainly you need to provide two things to `mbedtls`:
- [Config](https://github.com/fortanix/rust-mbedtls/blob/c39d93a19d043587dc2346fb4c54501e71190162/mbedtls/src/ssl/config.rs#L148): a config object containing settings and parameters needed for TLS handshake
- [`BIO`][1]: similar to `openssl`, `mbedtls` need you to provide a `BIO` to it. `BIO` stands for **Basic I/O abstraction**, at here you could simply treat them as source & destination of data such as a TCP socket or file i/o. In code level, it represent as two callbacks in rust:
	```rust
	// representation of the `mbedtls_ssl_send_t` and `mbedtls_ssl_recv_t` callback function pointers.
	unsafe extern "C" fn call_recv(user_data: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int where Self: Sized;
	unsafe extern "C" fn call_send(user_data: *mut c_void, data: *const c_uchar, len: size_t) -> c_int where Self: Sized;
	```
In `mbedtls`, we pass function pointers and user_data pointer to c mbedtls lib through FFI function `ssl_set_bio`.
During handshake and data transfer, the c mbedtls lib will utilize those two callbacks to send or receive data from underlying IO.

### IO abstraction

The IO abstraction PR #237 created and implemented safe rust abstraction of `BIO`:

<details>
<summary>Details</summary>

- Introduce unsafe trait [`IoCallbackUnsafe`](https://github.com/fortanix/rust-mbedtls/blob/c39d93a19d043587dc2346fb4c54501e71190162/mbedtls/src/ssl/io.rs#L36) to represent `mbedtls_ssl_send_t` and `mbedtls_ssl_recv_t` callback function pointers.
- Introduce safe trait [`IoCallback`](https://github.com/fortanix/rust-mbedtls/blob/c39d93a19d043587dc2346fb4c54501e71190162/mbedtls/src/ssl/io.rs#L48) : A safe representation of above trait. Also provides generic implementation of `IoCallback` for `IoCallbackUnsafe`. So user only need to implement this trait.
- Introduce trait [`Io`](https://github.com/fortanix/rust-mbedtls/blob/c39d93a19d043587dc2346fb4c54501e71190162/mbedtls/src/ssl/io.rs#L102) to represent a duplex socket or file descriptor that can be read from or written to in case you cannot use `std::io::Read` and `std::io::Write`.
- To integrate TCP, `std::net::TcpStream` implemented `std::io::Read` and `std::io::Write`:
	- Implemented `IoCallback` with Marker types:  `Stream` for `T: std::io::Read + std::io::Write`
	- Implemented `IoCallbackUnsafe` with Marker types:  `Stream` for `Contex<T>`
	- So you can pass `std::net::TcpStream` directly to [`mbedtls::ssl::context::Context::establish`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/context.rs#L234)
- To integrate UDP, since `std::net::UdpSocket` does not implement and reader/writer trait:
	- Introduced `ConnectedUdpSocket` as wrapper of `std::net::UdpSocket` and implemented `Io` for it
	- Implemented `IoCallback` with Marker types:  `AnyIo` for `T: Io`
	- Implemented `IoCallbackUnsafe` with Marker types:  `AnyIo` for `Contex<T>`
	- So you can pass `ConnectedUdpSocket` directly to [`mbedtls::ssl::context::Context::establish`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/context.rs#L234)

</details>

##  Async Support for TLS

###  Follow same path 

To add async support, we could use `tokio::net::TcpStream` and traits `tokio::io::Read` and `tokio::io::Write` and follow the same path of what we did for TCP in [IO abstraction](###IO_abstraction):

<details>
<summary>Details</summary>

- (new) Add marker type for async Steam IO: `AsyncStream`
- (new) Add [`establish_async`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/async_io.rs#L144) for `Context<T>`, this async function is implemented by wrapping the original blocking function [`handshake`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/context.rs#L271) in a custom `Future` implementation.
- Implemented `IoCallback` with Marker types:  `AsyncStream` for `T: tokio::io::Read + tokio::io::Write`
- Implemented `IoCallbackUnsafe` with Marker types:  `AsyncStream` for `Contex<T>`
- So you can pass `tokio::net::TcpStream` directly to [`Context::establish_async`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/async_io.rs#L144)

</details>

### Async need Context

But the key obstacle here is async code need context.
The functions needed by [`tokio::io::Read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) and [`tokio::io::Write` ](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html) both need a parameter: `cx` whose type is `std::task::Context`.

To address this, implementation need to adjust:
- `IoCallback` `impl`'s now are for a tuple `(&'a mut TaskContext<'b>, &'c mut T)` so that `Context` is accessible in the callback
- Introduced function [`with_bio_async`](https://github.com/fortanix/rust-mbedtls/blob/yx/async-support_master/mbedtls/src/ssl/context.rs#L199) to use a callback function to wrap the `Context` and callback functions' data pointer together and pass it to `mbedtls` through `set_bio_raw`

**Note**:
The async support for DTLS will be added in another PR: https://github.com/fortanix/rust-mbedtls/pull/241

[1]: https://www.openssl.org/docs/man1.1.1/man7/bio.html