### PR TITLE
Namespace symbols for mbedtls_malloc to avoid conflicts.

### DIFF
--- a/mbedtls/src/alloc.rs
+++ b/mbedtls/src/alloc.rs
@@ -15,7 +15,10 @@ use core::mem::ManuallyDrop;
 use mbedtls_sys::types::raw_types::c_void;
 
 extern "C" {
-    pub(crate) fn forward_mbedtls_free(n: *mut mbedtls_sys::types::raw_types::c_void);
+    #[link_name = concat!("\u{1}forward_mbedtls_free_", env!("RUST_MBEDTLS_METADATA_HASH"))]
+    pub(crate) fn mbedtls_free(n: *mut mbedtls_sys::types::raw_types::c_void);
+    #[link_name = concat!("\u{1}forward_mbedtls_calloc_", env!("RUST_MBEDTLS_METADATA_HASH"))]
+    pub(crate) fn mbedtls_calloc(n: mbedtls_sys::types::size_t, size: mbedtls_sys::types::size_t) -> *mut mbedtls_sys::types::raw_types::c_void;
 }
 
 #[repr(transparent)]
@@ -53,7 +56,7 @@ impl<T> Drop for Box<T> {
     fn drop(&mut self) {
         unsafe {
             drop_in_place(self.inner.as_ptr());
-            forward_mbedtls_free(self.inner.as_ptr() as *mut c_void)
+            mbedtls_free(self.inner.as_ptr() as *mut c_void)
         }
     }
 }

--- a/mbedtls/src/mbedtls_malloc.c
+++ b/mbedtls/src/mbedtls_malloc.c
@@ -21,11 +21,15 @@
 #define mbedtls_free      free
 #endif
 
-extern void *forward_mbedtls_calloc( size_t n, size_t size ) {
+// Use several macros to get the preprocessor to actually replace RUST_MBEDTLS_METADATA_HASH
+#define append_macro_inner(a, b) a##_##b
+#define append_macro(a, b) append_macro_inner(a, b)
+#define APPEND_METADATA_HASH(f) append_macro(f, RUST_MBEDTLS_METADATA_HASH)
+
+extern void *APPEND_METADATA_HASH(forward_mbedtls_calloc)( size_t n, size_t size ) {
     return mbedtls_calloc(n, size);
 }
 
-extern void forward_mbedtls_free( void *ptr ) {
+extern void APPEND_METADATA_HASH(forward_mbedtls_free)( void *ptr ) {
     mbedtls_free(ptr);
 }
-

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -13,7 +13,7 @@ use core::ptr::NonNull;
 use mbedtls_sys::*;
 use mbedtls_sys::types::raw_types::{c_char, c_void};
 
-use crate::alloc::{List as MbedtlsList, Box as MbedtlsBox};
+use crate::alloc::{List as MbedtlsList, Box as MbedtlsBox, mbedtls_calloc};
 #[cfg(not(feature = "std"))]
 use crate::alloc_prelude::*;
 use crate::error::{Error, IntoResult, Result};
@@ -22,10 +22,6 @@ use crate::pk::Pk;
 use crate::private::UnsafeFrom;
 use crate::rng::Random;
 use crate::x509::{self, Crl, Time, VerifyCallback};
-
-extern "C" {
-    pub(crate) fn forward_mbedtls_calloc(n: mbedtls_sys::types::size_t, size: mbedtls_sys::types::size_t) -> *mut mbedtls_sys::types::raw_types::c_void;
-}
 
 #[cfg(feature = "std")]
 use yasna::{BERDecodable, BERReader, ASN1Result, ASN1Error, ASN1ErrorKind, models::ObjectIdentifier};
@@ -502,7 +498,7 @@ impl<'a> Builder<'a> {
 impl MbedtlsBox<Certificate> {
     fn init() -> Result<Self> {
         unsafe {
-            let inner = forward_mbedtls_calloc(1, core::mem::size_of::<x509_crt>()) as *mut x509_crt;
+            let inner = mbedtls_calloc(1, core::mem::size_of::<x509_crt>()) as *mut x509_crt;
 
             // If alignment is wrong it means someone pushed their own allocator to mbedtls and that is not functioning correctly.
             assert_eq!(inner.align_offset(core::mem::align_of::<x509_crt>()), 0);


### PR DESCRIPTION
Dependents of this crate may use multiple different versions of this crate. These different versions all define mbedtls_calloc and mbedtls_free, which can result in linking conflicts. Since these functions are defined in and only used by this crate, we can namespace the symbols to avoid conflicts. We use Cargo's crate disambiguator for this purpose.