### PR TITLE
Add suffix to `mbedtls_log` to avoid link name conflict error

### DIFF
--- a/mbedtls/src/rust_printf.c
+++ b/mbedtls/src/rust_printf.c
@@ -9,7 +9,12 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-extern void mbedtls_log(const char* msg);
+// Use several macros to get the preprocessor to actually replace RUST_MBEDTLS_METADATA_HASH
+#define append_macro_inner(a, b) a##_##b
+#define append_macro(a, b) append_macro_inner(a, b)
+#define APPEND_METADATA_HASH(f) append_macro(f, RUST_MBEDTLS_METADATA_HASH)
+
+extern void APPEND_METADATA_HASH(mbedtls_log)(const char* msg);
 
 extern int mbedtls_printf(const char *fmt, ...) {
     va_list ap;
@@ -31,7 +36,7 @@ extern int mbedtls_printf(const char *fmt, ...) {
     if (n<0)
        return -1;
 
-    mbedtls_log(p);
+    APPEND_METADATA_HASH(mbedtls_log)(p);
 
     return n;
 }

--- a/mbedtls/src/self_test.rs
+++ b/mbedtls/src/self_test.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         // needs to be pub for global visiblity
         #[doc(hidden)]
-        #[no_mangle]
+        #[export_name = concat!("\u{1}mbedtls_log_", env!("RUST_MBEDTLS_METADATA_HASH"))]
         pub unsafe extern "C" fn mbedtls_log(msg: *const std::os::raw::c_char) {
             print!("{}", std::ffi::CStr::from_ptr(msg).to_string_lossy());
         }
@@ -34,7 +34,7 @@ cfg_if::cfg_if! {
 
         // needs to be pub for global visiblity
         #[doc(hidden)]
-        #[no_mangle]
+        #[export_name = concat!("\u{1}mbedtls_log_", env!("RUST_MBEDTLS_METADATA_HASH"))]
         pub unsafe extern "C" fn mbedtls_log(msg: *const c_char) {
             log_f.expect("Called self-test log without enabling self-test")(msg)
         }


### PR DESCRIPTION
## Summary of Changes in this PR

This PR addresses the link name conflict error that occurs when using different versions of the `mbedtls` crate in a single project, by adopting the approach used in PR #234.

## Rationale Behind the Approach

During testing, it was discovered that simply renaming `mbedtls_log` resolves the linking error. Therefore, the [`export_name`](https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute) attribute is employed here, as done in PR #243.

Upon further investigation, it was found that the linker error stems from multiple definitions of `mbedtls_log` in the Rust code. The C compiler attempts to locate and link the `mbedtls_log` function implemented in Rust to the C library, but it encounters duplicate instances of the function with the same name.

It's important to note that the linking search direction is from C to Rust, so naming on the C side is not a concern. Functions named `mbedtls_printf` in multiple `rust_printf.c` files are similar to other functions in the C mbedtls code and do not cause link name conflict errors.
