### PR TITLE
Remove `WriteTracker` and use a simplified approach

### DIFF
--- a/ct.sh
+++ b/ct.sh
@@ -33,7 +33,9 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --features pkcs12 --target $TARGET
         cargo test --features pkcs12_rc2 --target $TARGET
         cargo test --features dsa --target $TARGET
-        cargo test --test async_session --features=async-rt,async-test --target $TARGET
+        cargo test --test async_session --features=async-rt --target $TARGET
+        cargo test --test async_session --features=async-rt,zlib --target $TARGET
+        cargo test --test async_session --features=async-rt,legacy_protocols --target $TARGET
 
         # If zlib is installed, test the zlib feature
         if [ -n "$ZLIB_INSTALLED" ]; then

--- a/ct.sh
+++ b/ct.sh
@@ -34,13 +34,13 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --features pkcs12_rc2 --target $TARGET
         cargo test --features dsa --target $TARGET
         cargo test --test async_session --features=async-rt --target $TARGET
-        cargo test --test async_session --features=async-rt,zlib --target $TARGET
         cargo test --test async_session --features=async-rt,legacy_protocols --target $TARGET
-        cargo test --test async_session --features=async-rt,zlib,legacy_protocols --target $TARGET
-
+        
         # If zlib is installed, test the zlib feature
         if [ -n "$ZLIB_INSTALLED" ]; then
             cargo test --features zlib --target $TARGET
+            cargo test --test async_session --features=async-rt,zlib --target $TARGET
+            cargo test --test async_session --features=async-rt,zlib,legacy_protocols --target $TARGET
         fi
 
         # If AES-NI is supported, test the feature

--- a/ct.sh
+++ b/ct.sh
@@ -36,6 +36,7 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         cargo test --test async_session --features=async-rt --target $TARGET
         cargo test --test async_session --features=async-rt,zlib --target $TARGET
         cargo test --test async_session --features=async-rt,legacy_protocols --target $TARGET
+        cargo test --test async_session --features=async-rt,zlib,legacy_protocols --target $TARGET
 
         # If zlib is installed, test the zlib feature
         if [ -n "$ZLIB_INSTALLED" ]; then

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -79,7 +79,6 @@ pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 async = ["std", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
 async-rt = ["async", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
-async-test = []
 
 [[example]]
 name = "client"
@@ -117,4 +116,4 @@ required-features = ["std"]
 [[test]]
 name = "async_session"
 path = "tests/async_session.rs"
-required-features = ["async-rt", "async-test"]
+required-features = ["async-rt"]

--- a/mbedtls/src/ssl/async_io.rs
+++ b/mbedtls/src/ssl/async_io.rs
@@ -155,7 +155,7 @@ where
         {
             Err(Error::SslWantWrite) => Poll::Pending,
             Err(e) => Poll::Ready(Err(crate::private::error_to_io_error(e))),
-            Ok(()) => Poll::Ready(Ok(())),
+            Ok(_) => Poll::Ready(Ok(())),
         }
     }
 

--- a/mbedtls/src/ssl/async_io.rs
+++ b/mbedtls/src/ssl/async_io.rs
@@ -155,7 +155,7 @@ where
         {
             Err(Error::SslWantWrite) => Poll::Pending,
             Err(e) => Poll::Ready(Err(crate::private::error_to_io_error(e))),
-            Ok(_) => Poll::Ready(Ok(())),
+            Ok(()) => Poll::Ready(Ok(())),
         }
     }
 

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -235,7 +235,8 @@ impl<T> Context<T>  {
         // when calling `send()` here, already ensured that `ssl_context.out_left` == 0
         match self.send(buf) {
             // Although got `Error::SslWantWrite` means underlying IO is blocked, but some of `buf` is still saved into c-mbedtls's
-            // buffer, so we need to return size of bytes that has been buffered
+            // buffer, so we need to return size of bytes that has been buffered.
+            // Since we know before this call `out_left` was 0, all buffer (with in the MBEDTLS_SSL_OUT_CONTENT_LEN part) is buffered
             Err(Error::SslWantWrite) => Ok(std::cmp::min(unsafe { ssl_get_max_out_record_payload((&*self).into()).into_result()? as usize }, buf.len())),
             ret @ _ => ret,
         }

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -231,18 +231,12 @@ impl<T> Context<T>  {
     // Returned value `Ok(n)` always means n bytes of data has been sent into c-mbedtls's buffer (some of them might be sent out through underlying IO)
     pub(super) fn async_write(&mut self, buf: &[u8]) -> Result<usize> {
         // keep looping until we get an error or `out_left` is 0
-        let _original_left = self.handle().out_left;
-        // if self.handle().out_left > 0 {
-        //     let before = self.handle().out_left;
-        //     match self.flush_output() {
-        //         Ok(()) => {
-        //             let flushed = before - self.handle().out_left;
-        //             eprintln!("flush, after: {}, before: {},", self.handle().out_left, before);
-        //             return Ok(flushed);
-        //         },
-        //         Err(e) => { return Err(e); },
-        //     }
-        // }
+        while self.handle().out_left > 0 {
+            match self.flush_output() {
+                Ok(()) => {},
+                Err(e) => { return Err(e); },
+            }
+        }
         // when calling `send()` here, already ensured that `ssl_context.out_left` == 0
         match self.send(buf) {
             // Although got `Error::SslWantWrite` means underlying IO is blocked, but some of `buf` is still saved into c-mbedtls's
@@ -251,18 +245,7 @@ impl<T> Context<T>  {
             // - `out_left` was 0 prior to above call 
             // - in current implementation `Error::SslWantWrite` is only return by function [`IoCallback<AsyncStream>::send`], 
             // So in this case no data is written into underlying IO, which means `out_left` == size of data buffered
-            // Err(Error::SslWantWrite) if self.handle().out_left > 0 => {
-            //     loop {
-            //         let before = self.handle().out_left;
-            //         match self.flush_output() {
-            //             Ok(flushed) => {
-            //                 eprintln!("flushed {}, after: {}, before: {},",flushed, self.handle().out_left, before);
-            //                 return Ok(flushed);
-            //             },
-            //             Err(e) => return Err(e),
-            //         }
-            //     }
-            // },
+            Err(Error::SslWantWrite) => Ok(self.handle().out_left),
             ret @ _ => ret,
         }
     }
@@ -347,10 +330,10 @@ impl<T> Context<T> {
         }
     }
 
-    pub(super) fn flush_output(&mut self) -> Result<usize> {
+    pub(super) fn flush_output(&mut self) -> Result<()> {
         unsafe {
             // non-negative return value just means `ssl_flush_output` is succeed
-            ssl_flush_output(self.into()).into_result().map(|r| r as usize)
+            ssl_flush_output(self.into()).into_result_discard()
         }
     }
 

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -225,13 +225,6 @@ impl<T> Context<T>  {
     // This function ultimately ensure the semitics:
     // Returned value `Ok(n)` always means n bytes of data has been sent into c-mbedtls's buffer (some of them might be sent out through underlying IO)
     pub(super) fn async_write(&mut self, buf: &[u8]) -> Result<usize> {
-        let max_len = unsafe { ssl_get_max_out_record_payload((&*self).into()).into_result()? as usize };
-        #[cfg(feature = "zlib")]
-        // todo: this number is found during debug, change name or size after we found the actual reason for this
-        static RESERVE_SIZE: usize = 10;
-        #[cfg(feature = "zlib")]
-        let buf = &buf[..std::cmp::min(max_len - RESERVE_SIZE, buf.len())];
-        
         // keep looping until we get an error or `out_left` is 0
         while self.handle().out_left > 0 {
             match self.flush_output() {
@@ -243,7 +236,7 @@ impl<T> Context<T>  {
         match self.send(buf) {
             // Although got `Error::SslWantWrite` means underlying IO is blocked, but some of `buf` is still saved into c-mbedtls's
             // buffer, so we need to return size of bytes that has been buffered
-            Err(Error::SslWantWrite) => Ok(std::cmp::min(max_len, buf.len())),
+            Err(Error::SslWantWrite) => Ok(std::cmp::min(unsafe { ssl_get_max_out_record_payload((&*self).into()).into_result()? as usize }, buf.len())),
             ret @ _ => ret,
         }
     }

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -227,6 +227,7 @@ impl<T> Context<T>  {
     pub(super) fn async_write(&mut self, buf: &[u8]) -> Result<usize> {
         let max_len = unsafe { ssl_get_max_out_record_payload((&*self).into()).into_result()? as usize };
         #[cfg(feature = "zlib")]
+        // todo: this number is found during debug, change name or size after we found the actual reason for this
         static RESERVE_SIZE: usize = 10;
         #[cfg(feature = "zlib")]
         let buf = &buf[..std::cmp::min(max_len - RESERVE_SIZE, buf.len())];

--- a/mbedtls/tests/async_session.rs
+++ b/mbedtls/tests/async_session.rs
@@ -174,7 +174,6 @@ where
 #[cfg(unix)]
 mod test {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use mbedtls::ssl::async_io::WRITE_TRACKER_ERROR_MSG;
 
     #[tokio::test]
     async fn async_session_client_server_test() {
@@ -343,20 +342,18 @@ mod test {
         }
     }
     
-    /// Write tracker should ok when use normal functions
+    /// should ok when use normal functions
     #[tokio::test]
     async fn test_write_tracker_should_ok_1() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let enable_tracker = true;
         let expected_data = random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                session.enable_write_tracker(enable_tracker);
                 println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 session.write_all(&data_to_write).await.unwrap();
@@ -386,20 +383,18 @@ mod test {
         s.await.unwrap();
     }
 
-    /// Write tracker should ok when `poll_write` is getting a increasing buffer when meet `Poll::Pending`
+    /// should ok when `poll_write` is getting an unchanging buffer when meet `Poll::Pending`
     #[tokio::test]
     async fn test_write_tracker_should_ok_2() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let enable_tracker = true;
         let expected_data = random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                session.enable_write_tracker(enable_tracker);
                 println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
@@ -429,20 +424,18 @@ mod test {
         s.await.unwrap();
     }
 
-    /// Without write tracker, async write  should fail when `poll_write` is getting a increasing buffer when meet `Poll::Pending`
+    /// should ok when `poll_write` is getting a increasing buffer when meet `Poll::Pending`
     #[tokio::test]
-    async fn test_write_tracker_should_fail_1() {
+    async fn test_write_tracker_should_ok_3() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let enable_tracker = false;
         let expected_data = random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                session.enable_write_tracker(enable_tracker);
                 println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
@@ -454,13 +447,15 @@ mod test {
             Box::pin(async move {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
-                    Ok(_) => {
-                        panic!("should not succeed to read");
+                    Ok(n) => {
+                        eprintln!("server read {}", n);
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
                     }
                     Err(e) => {
                         session.shutdown().await.unwrap();
-                        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
-                        return;
+                        panic!("Unexpected error {:?}", e);
                     }
                 }
             })
@@ -470,27 +465,21 @@ mod test {
         s.await.unwrap();
     }
 
-    /// Write tracker should throw error when `poll_write` is getting a decreasing buffer when meet `Poll::Pending`
+    /// should ok when `poll_write` is getting a decreasing buffer when meet `Poll::Pending`
     #[tokio::test]
-    async fn test_write_tracker_should_fail_2() {
+    async fn test_write_tracker_should_ok_4() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let enable_tracker = true;
         let expected_data = random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                session.enable_write_tracker(enable_tracker);
                 println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
-                let ret = crate::support::write_all::write_all(&mut session, &data_to_write, -1).await;
-                assert!(ret.is_err());
-                let ref err = ret.unwrap_err();
-                assert_eq!(err.kind(), std::io::ErrorKind::Other);
-                assert!(err.to_string().contains(WRITE_TRACKER_ERROR_MSG));
+                crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
                 session.shutdown().await.unwrap();
             })
         }));
@@ -499,13 +488,15 @@ mod test {
             Box::pin(async move {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
-                    Ok(_) => {
-                        panic!("should not succeed to read");
+                    Ok(n) => {
+                        eprintln!("server read {}", n);
+                        assert_eq!(n, buffer_size, "wrong length");
+                        assert!(&buf[..] == &expected_data[..], "wrong read data");
+                        return;
                     }
                     Err(e) => {
                         session.shutdown().await.unwrap();
-                        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
-                        return;
+                        panic!("Unexpected error {:?}", e);
                     }
                 }
             })

--- a/mbedtls/tests/async_session.rs
+++ b/mbedtls/tests/async_session.rs
@@ -342,20 +342,18 @@ mod test {
         }
     }
     
-    /// should ok when use normal functions
+    // #[cfg(not(feature = "zlib"))]
     #[tokio::test]
-    async fn test_write_tracker_should_ok_1() {
+    async fn write_large_buffer_ok() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let expected_data = random_data(buffer_size);
+        let expected_data = crate::support::rand::random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                println!("client write_all {} bytes", buffer_size);
-                // use a custom write all, which always use different length when calling `poll_write` 
                 session.write_all(&data_to_write).await.unwrap();
                 session.shutdown().await.unwrap();
             })
@@ -366,7 +364,6 @@ mod test {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
                     Ok(n) => {
-                        eprintln!("server read {}", n);
                         assert_eq!(n, buffer_size, "wrong length");
                         assert!(&buf[..] == &expected_data[..], "wrong read data");
                         return;
@@ -383,19 +380,19 @@ mod test {
         s.await.unwrap();
     }
 
-    /// should ok when `poll_write` is getting an unchanging buffer when meet `Poll::Pending`
+    /// write large buffer should ok when `poll_write` is getting an unchanging buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
     #[tokio::test]
-    async fn test_write_tracker_should_ok_2() {
+    async fn write_large_buffer_ok_with_unchanging_buffer() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let expected_data = random_data(buffer_size);
+        let expected_data = crate::support::rand::random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
                 session.shutdown().await.unwrap();
@@ -407,7 +404,6 @@ mod test {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
                     Ok(n) => {
-                        eprintln!("server read {}", n);
                         assert_eq!(n, buffer_size, "wrong length");
                         assert!(&buf[..] == &expected_data[..], "wrong read data");
                         return;
@@ -424,19 +420,19 @@ mod test {
         s.await.unwrap();
     }
 
-    /// should ok when `poll_write` is getting a increasing buffer when meet `Poll::Pending`
+    /// write large buffer should ok when `poll_write` is getting a increasing buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
     #[tokio::test]
-    async fn test_write_tracker_should_ok_3() {
+    async fn write_large_buffer_ok_with_changing_buffer_1() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let expected_data = random_data(buffer_size);
+        let expected_data = crate::support::rand::random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
                 session.shutdown().await.unwrap();
@@ -448,7 +444,6 @@ mod test {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
                     Ok(n) => {
-                        eprintln!("server read {}", n);
                         assert_eq!(n, buffer_size, "wrong length");
                         assert!(&buf[..] == &expected_data[..], "wrong read data");
                         return;
@@ -465,19 +460,19 @@ mod test {
         s.await.unwrap();
     }
 
-    /// should ok when `poll_write` is getting a decreasing buffer when meet `Poll::Pending`
+    /// write large buffer should ok when `poll_write` is getting a decreasing buffer when meet `Poll::Pending`
+    #[cfg(not(feature = "zlib"))]
     #[tokio::test]
-    async fn test_write_tracker_should_ok_4() {
+    async fn write_large_buffer_ok_with_changing_buffer_2() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be
         // full filled so that block appears during `mbedtls_ssl_write`
         let buffer_size: usize =  3 * 1024 * 1024;
-        let expected_data = random_data(buffer_size);
+        let expected_data = crate::support::rand::random_data(buffer_size);
         let data_to_write = expected_data.clone();
         assert_eq!(expected_data, data_to_write);
         let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
         let c = tokio::spawn(super::with_client(c, move |mut session| {
             Box::pin(async move {
-                println!("client write_all {} bytes", buffer_size);
                 // use a custom write all, which always use different length when calling `poll_write` 
                 crate::support::write_all::write_all(&mut session, &data_to_write, 1).await.unwrap();
                 session.shutdown().await.unwrap();
@@ -489,7 +484,6 @@ mod test {
                 let mut buf = vec![0; buffer_size];
                 match session.read_exact(&mut buf).await {
                     Ok(n) => {
-                        eprintln!("server read {}", n);
                         assert_eq!(n, buffer_size, "wrong length");
                         assert!(&buf[..] == &expected_data[..], "wrong read data");
                         return;
@@ -506,15 +500,47 @@ mod test {
         s.await.unwrap();
     }
 
-    fn random_data(sz: usize) -> Vec<u8> {
-        use rand::Rng;
-        let mut rng = rand::thread_rng();
-        let mut data: Vec<u8> = Vec::with_capacity(sz);
+    /// when turn on `zlib` feature, c-mbedtls could not record buffer with
+    /// size > MBEDTLS_SSL_OUT_CONTENT_LEN (default: 16 * 1024)
+    /// Ref: mbedtls-sys/vendor/library/ssl_msg.c#L646-L653
+    #[cfg(feature = "zlib")]
+    #[tokio::test]
+    async fn write_large_buffer_should_fail_with_zlib() {
+        // create a big truck of data to write&read, so that OS's Tcp buffer will be
+        // full filled so that block appears during `mbedtls_ssl_write`
+        let buffer_size: usize =  3 * 1024 * 1024;
+        let expected_data = crate::support::rand::random_data(buffer_size);
+        let data_to_write = expected_data.clone();
+        assert_eq!(expected_data, data_to_write);
+        let (c, s) = crate::support::net::create_tcp_stream_pair_loopback_async();
+        let c = tokio::spawn(super::with_client(c, move |mut session| {
+            Box::pin(async move {
+                let ret = session.write_all(&data_to_write).await;
+                session.shutdown().await.unwrap();
+                assert!(ret.is_err());
+                let ref err = ret.unwrap_err();
+                assert_eq!(err.kind(), std::io::ErrorKind::Other);
+                assert!(err.to_string().contains("SslBadInputData"));
+            })
+        }));
 
-        for _ in 0..sz {
-            data.push(rng.gen_range(0, 255));
-        }
+        let s = tokio::spawn(super::with_server(s, move |mut session| {
+            Box::pin(async move {
+                let mut buf = vec![0; buffer_size];
+                match session.read_exact(&mut buf).await {
+                    Ok(_) => {
+                        session.shutdown().await.unwrap();
+                        panic!("should return error");
+                    }
+                    Err(e) => {
+                        session.shutdown().await.unwrap();
+                        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+                    }
+                }
+            })
+        }));
 
-        data
+        c.await.unwrap();
+        s.await.unwrap();
     }
 }

--- a/mbedtls/tests/async_session.rs
+++ b/mbedtls/tests/async_session.rs
@@ -342,7 +342,7 @@ mod test {
         }
     }
     
-    // #[cfg(not(feature = "zlib"))]
+    #[cfg(not(feature = "zlib"))]
     #[tokio::test]
     async fn write_large_buffer_ok() {
         // create a big truck of data to write&read, so that OS's Tcp buffer will be

--- a/mbedtls/tests/ssl_conf_ca_cb.rs
+++ b/mbedtls/tests/ssl_conf_ca_cb.rs
@@ -18,14 +18,14 @@ use mbedtls::pk::Pk;
 use mbedtls::rng::CtrDrbg;
 use mbedtls::ssl::config::{Endpoint, Preset, Transport};
 use mbedtls::ssl::{Config, Context};
-use mbedtls::x509::{Certificate};
+use mbedtls::x509::Certificate;
 use mbedtls::Result as TlsResult;
 use mbedtls::ssl::config::CaCallback;
 
 mod support;
 use support::entropy::entropy_new;
 
-use mbedtls::alloc::{List as MbedtlsList};
+use mbedtls::alloc::List as MbedtlsList;
 
 fn client<F>(conn: TcpStream, ca_callback: F) -> TlsResult<()>
     where

--- a/mbedtls/tests/support/net.rs
+++ b/mbedtls/tests/support/net.rs
@@ -26,7 +26,7 @@ pub fn create_tcp_pair() -> IoResult<(TcpStream, TcpStream)> {
     }
 }
 
-fn create_tcp_stream_pair_loopback() -> (TcpStream, TcpStream) {
+pub fn create_tcp_stream_pair_loopback() -> (TcpStream, TcpStream) {
     // Create a TcpListener on the loopback address.
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let listener_addr = listener.local_addr().unwrap();

--- a/mbedtls/tests/support/rand.rs
+++ b/mbedtls/tests/support/rand.rs
@@ -47,6 +47,7 @@ pub fn test_rng() -> TestRandom {
 }
 
 /// Testing only helper function to create a buffer with random content
+#[cfg(feature = "std")]
 pub fn random_data(sz: usize) -> Vec<u8> {
     let mut rng = rand::thread_rng();
     let mut data: Vec<u8> = Vec::with_capacity(sz);

--- a/mbedtls/tests/support/rand.rs
+++ b/mbedtls/tests/support/rand.rs
@@ -45,3 +45,15 @@ impl crate::mbedtls::rng::RngCallback for TestRandom {
 pub fn test_rng() -> TestRandom {
     TestRandom(XorShiftRng::new_unseeded())
 }
+
+/// Testing only helper function to create a buffer with random content
+pub fn random_data(sz: usize) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    let mut data: Vec<u8> = Vec::with_capacity(sz);
+
+    for _ in 0..sz {
+        data.push(rng.gen_range(0, 255));
+    }
+
+    data
+}

--- a/mbedtls/tests/support/write_all.rs
+++ b/mbedtls/tests/support/write_all.rs
@@ -31,7 +31,7 @@ pub(crate) fn write_all<'a, W>(writer: &'a mut W, buf: &'a [u8], buffer_change_p
 where
     W: AsyncWrite + Unpin + ?Sized,
 {
-    let min_len = 1000;
+    let min_len = 8 * 1024;
     assert!(buf.len() > min_len, "Please provide a buffer with length > {}", min_len);
     WriteAll {
         writer,


### PR DESCRIPTION
Current implementation is not correct, the test [test_write_tracker](https://github.com/fortanix/rust-mbedtls/blob/b6e204c6aff46cceaad995e6567bea9aa219e56d/mbedtls/tests/async_session.rs#L346) cannot pass 
