### PR TITLE
Add async support for DTLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.64",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +511,7 @@ name = "mbedtls"
 version = "0.9.1"
 dependencies = [
  "async-stream",
+ "async-trait",
  "bit-vec",
  "bitflags",
  "byteorder",

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -30,13 +30,14 @@ cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 cfg-if = "1.0.0"
 tokio = { version = "1.16.1", optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.2.0"
 chrono = "0.4"
 
 [dependencies.mbedtls-sys-auto]
-version = "2.25.0"
+version = "2.28.0"
 default-features = false
 features = ["trusted_cert_callback", "threading"]
 path = "../mbedtls-sys"
@@ -78,7 +79,7 @@ pkcs12 = ["std", "yasna"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
 async = ["std", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
-async-rt = ["async", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
+async-rt = ["async","async-trait", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
 
 [[example]]
 name = "client"

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -124,6 +124,9 @@ pub struct Context<T> {
     /// be stored in [`Context`] first so that it can be set after the `ssl_session_reset` in the
     /// [`establish`](Context::establish) call.
     client_transport_id: Option<Vec<u8>>,
+
+    #[cfg(all(feature = "std", feature = "async"))]
+    pub(super) write_tracker: super::async_io::WriteTracker,
 }
 
 impl<'a, T> Into<*const ssl_context> for &'a Context<T> {
@@ -160,6 +163,8 @@ impl<T> Context<T> {
             io: None,
             timer_callback: None,
             client_transport_id: None,
+            #[cfg(all(feature = "std", feature = "async"))]
+            write_tracker: super::async_io::WriteTracker::new(),
         }
     }
 

--- a/mbedtls/tests/async_session.rs
+++ b/mbedtls/tests/async_session.rs
@@ -15,8 +15,10 @@ use std::sync::Arc;
 
 use mbedtls::pk::Pk;
 use mbedtls::rng::CtrDrbg;
+use mbedtls::ssl::async_io::{AsyncIo, ConnectedAsyncUdpSocket};
 use mbedtls::ssl::config::{Endpoint, Preset, Transport};
 use mbedtls::ssl::{Config, Context, Version};
+use mbedtls::ssl::io::IoCallback;
 use mbedtls::x509::{Certificate, VerifyError};
 use mbedtls::Error;
 use mbedtls::Result as TlsResult;
@@ -28,17 +30,68 @@ use support::entropy::entropy_new;
 use support::keys;
 use tokio::net::TcpStream;
 
-// TODO: Add unified interface for TCP and UDP like `TransportType` in
-// `client_server.rs`
+#[async_trait]
+trait TransportType: Sized {
+    fn get_transport_type() -> Transport;
 
-async fn client(conn: TcpStream, min_version: Version, max_version: Version, exp_version: Option<Version>) -> TlsResult<()> {
+    async fn recv(ctx: &mut Context<Self>, buf: &mut [u8]) -> TlsResult<usize>;
+    async fn send(ctx: &mut Context<Self>, buf: &[u8]) -> TlsResult<usize>;
+}
+
+#[async_trait]
+impl TransportType for TcpStream {
+    fn get_transport_type() -> Transport {
+        Transport::Stream
+    }
+
+    async fn recv(ctx: &mut Context<Self>, buf: &mut [u8]) -> TlsResult<usize> {
+        ctx.read(buf).await.map_err(|_| Error::NetRecvFailed)
+    }
+
+    async fn send(ctx: &mut Context<Self>, buf: &[u8]) -> TlsResult<usize> {
+        ctx.write(buf).await.map_err(|_| Error::NetSendFailed)
+    }
+}
+
+#[async_trait]
+impl TransportType for ConnectedAsyncUdpSocket {
+    fn get_transport_type() -> Transport {
+        Transport::Datagram
+    }
+
+    async fn recv(ctx: &mut Context<Self>, buf: &mut [u8]) -> TlsResult<usize> {
+        AsyncIo::recv(ctx, buf).await.map_err(|_| Error::NetRecvFailed)
+    }
+
+    async fn send(ctx: &mut Context<Self>, buf: &[u8]) -> TlsResult<usize> {
+        AsyncIo::send(ctx, buf).await.map_err(|_| Error::NetSendFailed)
+    }
+}
+
+use std::task::Context as TaskContext;
+async fn client<C, T>(
+    conn: C,
+    min_version: Version,
+    max_version: Version,
+    exp_version: Option<Version>,
+    use_psk: bool,
+) -> TlsResult<()>
+where
+    C: TransportType + Unpin + 'static,
+    for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut C): IoCallback<T>,
+{
     let entropy = Arc::new(entropy_new());
     let rng = Arc::new(CtrDrbg::new(entropy, None)?);
-    let cacert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes())?);
-    let expected_flags = VerifyError::empty();
-    #[cfg(feature = "time")]
-    let expected_flags = expected_flags | VerifyError::CERT_EXPIRED;
-    {
+    let mut config = Config::new(Endpoint::Client, C::get_transport_type(), Preset::Default);
+    config.set_rng(rng);
+    config.set_min_version(min_version)?;
+    config.set_max_version(max_version)?;
+    if !use_psk {
+        // for certificate-based operation, set up ca and verification callback
+        let cacert = Arc::new(Certificate::from_pem_multiple(keys::ROOT_CA_CERT.as_bytes())?);
+        let expected_flags = VerifyError::empty();
+        #[cfg(feature = "time")]
+        let expected_flags = expected_flags | VerifyError::CERT_EXPIRED;
         let verify_callback = move |crt: &Certificate, depth: i32, verify_flags: &mut VerifyError| {
             match (crt.subject().unwrap().as_str(), depth, &verify_flags) {
                 ("CN=RootCA", 1, _) => (),
@@ -51,78 +104,111 @@ async fn client(conn: TcpStream, min_version: Version, max_version: Version, exp
                                                             // VerifyError
             Ok(())
         };
-        let mut config = Config::new(Endpoint::Client, Transport::Stream, Preset::Default);
-        config.set_rng(rng);
         config.set_verify_callback(verify_callback);
         config.set_ca_list(cacert, None);
-        config.set_min_version(min_version)?;
-        config.set_max_version(max_version)?;
-        let mut ctx = Context::new(Arc::new(config));
+    } else {
+        // for psk-based operation, only PSK required
+        config.set_psk(&[0x12, 0x34, 0x56, 0x78], "client")?;
+    }
+    let mut ctx = Context::new(Arc::new(config));
+    // For DTLS, timers are required to support retransmissions
+    if C::get_transport_type() == Transport::Datagram {
+        ctx.set_timer_callback(Box::new(Timer::new()));
+    }
 
-        match ctx.establish_async(conn, None).await {
-            Ok(()) => {
-                assert_eq!(ctx.version(), exp_version.unwrap());
-            }
-            Err(e) => {
-                match e {
-                    Error::SslBadHsProtocolVersion => {
-                        assert!(exp_version.is_none())
-                    }
-                    Error::SslFatalAlertMessage => {}
-                    e => panic!("Unexpected error {}", e),
-                };
-                return Ok(());
-            }
-        };
-
-        let ciphersuite = ctx.ciphersuite().unwrap();
-        ctx.write_all(format!("Client2Server {:4x}", ciphersuite).as_bytes())
-            .await
-            .unwrap();
-        let mut buf = [0u8; 13 + 4 + 1];
-        ctx.read_exact(&mut buf).await.unwrap();
-        assert_eq!(&buf, format!("Server2Client {:4x}", ciphersuite).as_bytes());
-    } // drop verify_callback, releasing borrow of verify_args
-    Ok(())
-}
-
-async fn server(conn: TcpStream, min_version: Version, max_version: Version, exp_version: Option<Version>) -> TlsResult<()> {
-    let entropy = entropy_new();
-    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
-    let cert = Arc::new(Certificate::from_pem_multiple(keys::EXPIRED_CERT.as_bytes())?);
-    let key = Arc::new(Pk::from_private_key(keys::EXPIRED_KEY.as_bytes(), None)?);
-    let mut config = Config::new(Endpoint::Server, Transport::Stream, Preset::Default);
-    config.set_rng(rng);
-    config.set_min_version(min_version)?;
-    config.set_max_version(max_version)?;
-    config.push_cert(cert, key)?;
-    let mut context = Context::new(Arc::new(config));
-
-    match context.establish_async(conn, None).await {
+    match ctx.establish_async(conn, None).await {
         Ok(()) => {
-            assert_eq!(context.version(), exp_version.unwrap());
+            assert_eq!(ctx.version(), exp_version.unwrap());
         }
         Err(e) => {
             match e {
-                // client just closes connection instead of sending alert
-                Error::NetSendFailed => {
+                Error::SslBadHsProtocolVersion => {
                     assert!(exp_version.is_none())
                 }
-                Error::SslBadHsProtocolVersion => {}
+                Error::SslFatalAlertMessage => {}
                 e => panic!("Unexpected error {}", e),
             };
             return Ok(());
         }
     };
 
-    //assert_eq!(ctx.get_alpn_protocol().unwrap().unwrap(), None);
-    let ciphersuite = context.ciphersuite().unwrap();
-    context
-        .write_all(format!("Server2Client {:4x}", ciphersuite).as_bytes())
-        .await
-        .unwrap();
+    let ciphersuite = ctx.ciphersuite().unwrap();
+    let buf = format!("Client2Server {:4x}", ciphersuite);
+    assert_eq!(<C as TransportType>::send(&mut ctx, buf.as_bytes()).await.unwrap(), buf.len());
+    let mut buf = [0u8; 13 + 4 + 1];
+    assert_eq!(<C as TransportType>::recv(&mut ctx, &mut buf).await.unwrap(), buf.len());
+    assert_eq!(&buf, format!("Server2Client {:4x}", ciphersuite).as_bytes());
+    Ok(())
+}
+
+async fn server<C, T>(
+    conn: C,
+    min_version: Version,
+    max_version: Version,
+    exp_version: Option<Version>,
+    use_psk: bool,
+) -> TlsResult<()> 
+where
+    C: TransportType + Unpin + 'static,
+    for<'c, 'cx> (&'c mut TaskContext<'cx>, &'c mut C): IoCallback<T>,
+{
+    let entropy = entropy_new();
+    let rng = Arc::new(CtrDrbg::new(Arc::new(entropy), None)?);
+    let mut config = Config::new(Endpoint::Server, C::get_transport_type(), Preset::Default);
+    if C::get_transport_type() == Transport::Datagram {
+        // For DTLS, we need a cookie context to work against DoS attacks
+        let cookies = CookieContext::new(rng.clone())?;
+        config.set_dtls_cookies(Arc::new(cookies));
+    }
+    config.set_rng(rng);
+    config.set_min_version(min_version)?;
+    config.set_max_version(max_version)?;
+    if !use_psk { // for certificate-based operation, set up certificates
+        let cert = Arc::new(Certificate::from_pem_multiple(keys::EXPIRED_CERT.as_bytes())?);
+        let key = Arc::new(Pk::from_private_key(keys::EXPIRED_KEY.as_bytes(), None)?);
+        config.push_cert(cert, key)?;
+    } else { // for psk-based operation, only PSK required
+        config.set_psk(&[0x12, 0x34, 0x56, 0x78], "client")?;
+    }
+    let mut ctx = Context::new(Arc::new(config));
+
+    let res = if C::get_transport_type() == Transport::Datagram {
+        // For DTLS, timers are required to support retransmissions and the DTLS server needs a client
+        // ID to create individual cookies per client
+        ctx.set_timer_callback(Box::new(Timer::new()));
+        ctx.set_client_transport_id_once(b"127.0.0.1:12341");
+        // The first connection setup attempt will fail because the ClientHello is received without
+        // a cookie
+        match ctx.establish_async(conn, None).await {
+            Err(Error::SslHelloVerifyRequired) => {}
+            Ok(()) => panic!("SslHelloVerifyRequired expected, got Ok instead"),
+            Err(e) => panic!("SslHelloVerifyRequired expected, got {} instead", e),
+        }
+        ctx.handshake_async().await
+    } else {
+        ctx.establish_async(conn, None).await // For TLS, establish the connection which should just work
+    };
+
+    match res {
+        Ok(()) => {
+            assert_eq!(ctx.version(), exp_version.unwrap());
+        }
+        Err(e) => {
+            match e {
+                // client just closes connection instead of sending alert
+                Error::NetSendFailed => {assert!(exp_version.is_none())},
+                Error::SslBadHsProtocolVersion => {},
+                e => panic!("Unexpected error {}", e),
+            };
+            return Ok(());
+        }
+    };
+
+    let ciphersuite = ctx.ciphersuite().unwrap();
+    let buf = format!("Server2Client {:4x}", ciphersuite);
+    assert_eq!(<C as TransportType>::send(&mut ctx, buf.as_bytes()).await.unwrap(), buf.len());
     let mut buf = [0u8; 13 + 1 + 4];
-    context.read_exact(&mut buf).await.unwrap();
+    assert_eq!(<C as TransportType>::recv(&mut ctx, &mut buf).await.unwrap(), buf.len());
 
     assert_eq!(&buf, format!("Client2Server {:4x}", ciphersuite).as_bytes());
     Ok(())
@@ -173,7 +259,8 @@ where
 
 #[cfg(unix)]
 mod test {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use mbedtls::ssl::async_io::ConnectedAsyncUdpSocket;
+    use tokio::{io::{AsyncReadExt, AsyncWriteExt}, net::UdpSocket};
 
     #[tokio::test]
     async fn async_session_client_server_test() {
@@ -264,12 +351,58 @@ mod test {
                 continue;
             }
 
+            // TLS tests using certificates
+
             let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
-            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver.clone()));
-            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver));
+            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver, false));
+            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver, false));
 
             c.await.unwrap().unwrap();
             s.await.unwrap().unwrap();
+            
+            // TLS tests using PSK
+
+            let (c, s) = crate::support::net::create_tcp_pair_async().unwrap();
+            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver, true));
+            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver, true));
+
+            c.await.unwrap().unwrap();
+            s.await.unwrap().unwrap();
+
+            // DTLS tests using certificates
+
+            // DTLS 1.0 is based on TSL 1.1
+            if min_c < Version::Tls1_1 || min_s < Version::Tls1_1 || exp_ver.is_none() {
+                continue;
+            }
+
+            let s = UdpSocket::bind("127.0.0.1:12340").await.expect("could not bind UdpSocket");
+            let s = ConnectedAsyncUdpSocket::connect(s, "127.0.0.1:12341").await.expect("could not connect UdpSocket");
+            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver, false));
+            let c = UdpSocket::bind("127.0.0.1:12341").await.expect("could not bind UdpSocket");
+            let c = ConnectedAsyncUdpSocket::connect(c, "127.0.0.1:12340").await.expect("could not connect UdpSocket");
+            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver, false));
+            
+
+            s.await.unwrap().unwrap();
+            c.await.unwrap().unwrap();
+
+            // TODO There seems to be a race condition which does not allow us to directly reuse
+            // the UDP address? Without a short delay here, the DTLS tests using PSK fail with
+            // NetRecvFailed in some cases.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+
+            // DTLS tests using PSK
+
+            let s = UdpSocket::bind("127.0.0.1:12340").await.expect("could not bind UdpSocket");
+            let s = ConnectedAsyncUdpSocket::connect(s, "127.0.0.1:12341").await.expect("could not connect UdpSocket");
+            let s = tokio::spawn(super::server(s, min_s, max_s, exp_ver, true));
+            let c = UdpSocket::bind("127.0.0.1:12341").await.expect("could not bind UdpSocket");
+            let c = ConnectedAsyncUdpSocket::connect(c, "127.0.0.1:12340").await.expect("could not connect UdpSocket");
+            let c = tokio::spawn(super::client(c, min_c, max_c, exp_ver, true));
+
+            s.await.unwrap().unwrap();
+            c.await.unwrap().unwrap();
         }
     }
 


### PR DESCRIPTION
To keep things simple, the async support for DTLS is implemented by:

- Added `ConnectedAsyncUdpSocket`
- Impl `AsyncRead` and `AsyncWrite` for `ConnectedAsyncUdpSocket`
- Extend `async-session` test for testing DTLS