### PR TITLE
Fix SPDX license identifiers

### DIFF
--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "mbedtls-sys-auto"
 version = "2.28.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Rust bindings for MbedTLS.
 

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.9.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
-license = "Apache-2.0/GPL-2.0+"
+license = "Apache-2.0 OR GPL-2.0-or-later"
 description = """
 Idiomatic Rust wrapper for MbedTLS, allowing you to use MbedTLS with only safe
 code while being able to use such great Rust features like error handling and


### PR DESCRIPTION
- The [`GPL-2.0+` identifier is deprecated](https://spdx.org/licenses/GPL-2.0+.html) and should be replaced by `GPL-2.0-or-later`
- Using a `/` to separate multiple licenses is not a valid SPDX license expression and is [deprecated for Cargo.toml](https://doc.rust-lang.org/cargo/reference/manifest.html#slash)

We should fix this to enable automatic tools to successfully parse the license field.