### PR TITLE
Fix 'cc --print-sysroot' call

### DIFF
--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -104,7 +104,7 @@ impl super::BuildConfig {
         if compiler.is_like_gnu() {
             let output = compiler.to_command().args(&["--print-sysroot"]).output();
             match output {
-                Ok(sysroot) => {
+                Ok(sysroot) if sysroot.status.success() => {
                     let path = std::str::from_utf8(&sysroot.stdout).expect("Malformed sysroot");
                     let trimmed_path = path
                         .strip_suffix("\r\n")


### PR DESCRIPTION
This PR contains two changes:

1. The first commit fixes a bug that the result of `cc --print-sysroot` is not properly checked before it is evaluated and added as a compiler flag. This one should be easy to accept.
2. The second commit is harder to accept because it changes code in the `vendor` directory which should probably stay untouched? I just did not know how to append a compiler flag to the CMake process without doing so.

Without the new compiler flag `-Wno-unused-but-set-variable`, Apple clang 14 fails with the following error message and this conclusion seems to be _correct_:
```
mbedtls-sys/vendor/library/bignum.c:1395:29: error: variable 't' set but not used [-Werror,-Wunused-but-set-variable]
      mbedtls_mpi_uint c = 0, t = 0;
                              ^
```

So to fix builds for compilers which properly detect this, we need to somehow change the compiler flags for the C code. Setting it with `cmk.cflag(...)` in `mbedtls-sys/build/cmake.rs` did not work. I have thought about setting `CMAKE_C_FLAGS` before calling CMake but the new flag _must_ appear behind `-Wall` which is set by the `CMakeLists.txt` so I guess this will not work either. So how would you like to do this? Any other ideas?

Edit: The second commit has been removed (see discussion)