### PR TITLE
Make mbedtls-platform-support no_std

### DIFF
--- a/mbedtls-platform-support/src/lib.rs
+++ b/mbedtls-platform-support/src/lib.rs
@@ -6,6 +6,8 @@
  * option. This file may not be copied, modified, or distributed except
  * according to those terms. */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(not(feature = "std"))]
 #[allow(unused)]
 #[macro_use]


### PR DESCRIPTION
The relatively new `mbedtls_platform-support` needs to declare `#![no_std]` if the `std` feature is not selected. @Taowyoo maybe you can merge this?