### PR TITLE
ci: add workflow to publish crates to crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -18,7 +18,7 @@ jobs:
             toolchain: stable
             override: true
       - run: |
-          crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('-', 1)[0])") && \
+          crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('_v', 1)[0])") && \
           cargo publish --token ${CARGO_REGISTRY_TOKEN} --package "$crate_name" --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,22 @@
+name: Publish Crates
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+      - uses: katyo/publish-crates@v1
+        with:
+            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -18,7 +18,7 @@ jobs:
             toolchain: stable
             override: true
       - run: |
-          crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('-', 1)[0])")
+          crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('-', 1)[0])") && \
           cargo publish --token ${CARGO_REGISTRY_TOKEN} --package "$crate_name"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -17,6 +17,8 @@ jobs:
         with:
             toolchain: stable
             override: true
-      - uses: katyo/publish-crates@v1
-        with:
-            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: |
+          crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('-', 1)[0])")
+          cargo publish --token ${CARGO_REGISTRY_TOKEN} --package "$crate_name"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -19,6 +19,6 @@ jobs:
             override: true
       - run: |
           crate_name=$(python3 -c "print('$GITHUB_REF'.split('/')[2].rsplit('-', 1)[0])") && \
-          cargo publish --token ${CARGO_REGISTRY_TOKEN} --package "$crate_name"
+          cargo publish --token ${CARGO_REGISTRY_TOKEN} --package "$crate_name" --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR add a github action to automate the publish of crates to crates.io.
In this PR I added `--dry-run` so we could test it first to avoid anything wrong.

And this action need the tag used for creating release follow this syntax: {crate_name}_v{version_value}

This workflow depends on the secret `CARGO_REGISTRY_TOKEN`
> [Using environments for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment): Then since we need secret to be used to publish new versions to crates.io , GitHub offers Configure environments to set rules before a job can proceed and to limit access to secrets. so jobs that need access to specific secret need approval, more ref: [security-guides/encrypted-secrets](https://docs.github.com/en/github-ae@latest/actions/security-guides/encrypted-secrets)

Need owner to add this organization level secret named `CARGO_REGISTRY_TOKEN` with proper access policy!
CC: @jethrogb  @Goirad  @chavipuri 