### PR TITLE
Allow name-mangling for the mbedtls_free and mbedtls_calloc functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,20 +20,29 @@ env:
 jobs:
   build:
     name: test
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
           - rust: stable
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
           - rust: stable
             target: aarch64-unknown-linux-musl
+            os: ubuntu-20.04
           - rust: stable
             target: x86_64-fortanix-unknown-sgx
+            os: ubuntu-20.04
           - rust: beta
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
           - rust: nightly
             target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
+          - rust: stable
+            target: x86_64-apple-darwin
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/ct.sh
+++ b/ct.sh
@@ -2,21 +2,37 @@
 set -ex
 cd "$(dirname "$0")"
 
-# According to `mbedtls-sys/vendor/README.md`, need to install needed pkgs
-python3 -m pip install -r ./mbedtls-sys/vendor/scripts/basic.requirements.txt
-
 if [ -z $TRAVIS_RUST_VERSION ]; then
     echo "Expected TRAVIS_RUST_VERSION to be set in env"
     exit 1
 fi
 
+# checks if a file has a specific sha512 hash, compatible for Linux and macOS
+check_sha512() {
+    local hash="$1"
+    local file="$2"
+    local platform=$(uname)
+    case $platform in
+        Linux)
+            sha512sum -c <<< "$hash *$file"
+            ;;
+        Darwin)
+            shasum -a 512 -c <<< "$hash *$file"
+            ;;
+        *)
+            echo "Unsupported platform '$platfom'"
+            exit 1
+            ;;
+    esac
+}
+
 aarch64_cross_toolchain_hash=c8ee0e7fd58f5ec6811e3cec5fcdd8fc47cb2b49fb50e9d7717696ddb69c812547b5f389558f62dfbf9db7d6ad808a5a515cc466b8ea3e9ab3daeb20ba1adf33
-# save to directorie that will be cached
+# save to directory that will be cached
 aarch64_cross_toolchain_save_path=/tmp/aarch64-linux-musl-cross.tgz
 if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
-    if ! echo "${aarch64_cross_toolchain_hash} ${aarch64_cross_toolchain_save_path}" | sha512sum -c; then
+    if ! check_sha512 ${aarch64_cross_toolchain_hash} ${aarch64_cross_toolchain_save_path}; then
         wget https://more.musl.cc/10-20210301/x86_64-linux-musl/aarch64-linux-musl-cross.tgz -O ${aarch64_cross_toolchain_save_path}
-        echo "${aarch64_cross_toolchain_hash} ${aarch64_cross_toolchain_save_path}" | sha512sum -c
+        check_sha512 ${aarch64_cross_toolchain_hash} ${aarch64_cross_toolchain_save_path}
     fi
     tar -xf ${aarch64_cross_toolchain_save_path} -C /tmp;
 fi
@@ -31,28 +47,34 @@ export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER=qemu-aarch64
 
 # According to `mbedtls-sys/vendor/README.md`, need to install needed pkgs
 python3 -m pip install -r ./mbedtls-sys/vendor/scripts/basic.requirements.txt
-# function for downloading pre-built `cargo-nextest` on various platform
+
+# function for downloading pre-built `cargo-nextest` on various platforms
 download_cargo_nextest() {
     local platform="$1"
     local cargo_nextest_hash="$2"
     local url="$3"
     echo "Check if need to download pre-built $platform 'cargo-nextest'"
-    if ! echo "${cargo_nextest_hash} ${CARGO_HOME:-$HOME/.cargo}/bin/cargo-nextest" | sha512sum -c; then
+    if ! check_sha512 "${cargo_nextest_hash}" "${CARGO_HOME:-$HOME/.cargo}/bin/cargo-nextest"; then
         curl -LsSf "$url" | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
-        echo "${cargo_nextest_hash} ${CARGO_HOME:-$HOME/.cargo}/bin/cargo-nextest" | sha512sum -c
+        check_sha512 "${cargo_nextest_hash}" "${CARGO_HOME:-$HOME/.cargo}/bin/cargo-nextest"
     fi
 }
 # download pre-built `cargo-nextest`
-platform=$(dpkg --print-architecture)
-case "$platform" in
-  amd64)
+kernel=$(uname)
+architecture=$(uname -m)
+case "$kernel-$architecture" in
+  Linux-x86_64 | Linux-amd64)
     download_cargo_nextest "amd64" "d22ce5799f3056807fd0cd8223a290c7153a5f084d5ab931fce755c2cabd33f79c0f75542eb724fe07a7ca083f415ec1f84edc46584b06df43d97a0ff91018da" "https://get.nexte.st/0.9.52/linux"
     ;;
-  arm64)
+  Linux-arm64)
     download_cargo_nextest "arm64" "cff3297c84560de8693e7f887fcf6cf33ab0036e27a9debf2b0a0832094555335f34dc30d0f9d1128ce8472dcb4594a3cf33be2357b19dcc94269b58090cc1a9" "https://get.nexte.st/0.9.52/linux-arm"
     ;;
+  Darwin-x86_64)
+    download_cargo_nextest "Darwin-amd64" "0bb8b77ce019de3d06ee6b7382d830ed67309f187781e0de3866a0635879b494c7db48d55eee7553cfaa0bfca59abd8f8540a6d81ed703f06f9c81514d20073d" "https://get.nexte.st/0.9.52/mac"
+    ;;
   *)
-    echo "Unknown platform"
+    echo "Unknown platform '$kernel-$architecture'"
+    exit 1
     ;;
 esac
 
@@ -81,6 +103,9 @@ if [ "$TRAVIS_RUST_VERSION" == "stable" ] || [ "$TRAVIS_RUST_VERSION" == "beta" 
         if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
             cargo nextest run --no-default-features --features no_std_deps,rdrand,time --target $TARGET
             cargo nextest run --no-default-features --features no_std_deps,rdrand --target $TARGET
+        fi
+        if [ "$TARGET" == "x86_64-apple-darwin" ]; then
+            cargo nextest run --no-default-features --features no_std_deps --target $TARGET
         fi
     else
         cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -17,6 +17,8 @@ impl super::BuildConfig {
         ))
         .define("ENABLE_PROGRAMS", "OFF")
         .define("ENABLE_TESTING", "OFF")
+        // Prefer unix-style over Apple-style Python3 on macOS, required for the Github Actions CI
+        .define("Python3_FIND_FRAMEWORK", "LAST")
         .build_target("lib");
         for cflag in &self.cflags {
             cmk.cflag(cflag);

--- a/mbedtls/src/alloc.rs
+++ b/mbedtls/src/alloc.rs
@@ -15,9 +15,9 @@ use core::mem::ManuallyDrop;
 use mbedtls_sys::types::raw_types::c_void;
 
 extern "C" {
-    #[link_name = concat!("\u{1}forward_mbedtls_free_", env!("RUST_MBEDTLS_METADATA_HASH"))]
+    #[link_name = concat!("forward_mbedtls_free_", env!("RUST_MBEDTLS_METADATA_HASH"))]
     pub(crate) fn mbedtls_free(n: *mut mbedtls_sys::types::raw_types::c_void);
-    #[link_name = concat!("\u{1}forward_mbedtls_calloc_", env!("RUST_MBEDTLS_METADATA_HASH"))]
+    #[link_name = concat!("forward_mbedtls_calloc_", env!("RUST_MBEDTLS_METADATA_HASH"))]
     pub(crate) fn mbedtls_calloc(n: mbedtls_sys::types::size_t, size: mbedtls_sys::types::size_t) -> *mut mbedtls_sys::types::raw_types::c_void;
 }
 

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -108,10 +108,10 @@ define!(
 );
 
 extern "C" {
-    // Since in mbedtld 3.X, upstream hide the `mbedtls_ssl_flush_output`, but we still need it for
+    // Since in mbedtls 3.X, upstream hide the `mbedtls_ssl_flush_output`, but we still need it for
     // async here. Ref: https://github.com/Mbed-TLS/mbedtls/issues/4183
     // So we mannully access it through defining it in `extern "C"` here
-    #[link_name = "\u{1}mbedtls_ssl_flush_output"]
+    #[link_name = "mbedtls_ssl_flush_output"]
     fn ssl_flush_output(ssl: *mut ssl_context) -> c_int;
 }
 


### PR DESCRIPTION
According to the discussion in https://github.com/rust-lang/rust-bindgen/issues/1221#issuecomment-442950753, the `\u{1}` is a hint to LLVM to avoid name-mangling but this might be required on some platforms to link against the right name, e.g. on macOS.

So this fixes builds on macOS.

@jethrogb you have been part in that discussion so maybe you can evaluate if this change is the right thing to do or if this will potentially lead to other problems?