### PR TITLE
Fix performance issue introduced by vendor code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "3.5.0-alpha.1+0b3de6f"
+version = "3.5.0-alpha.2+0b3de6f"
 dependencies = [
  "bindgen",
  "cc",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "3.5.0-alpha.1+0b3de6f"
+version = "3.5.0-alpha.2+0b3de6f"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"

--- a/mbedtls-sys/build/config.rs
+++ b/mbedtls-sys/build/config.rs
@@ -444,3 +444,17 @@ pub const SUFFIX: &'static str = r#"
 #include "mbedtls/target_config.h"
 #endif
 "#;
+
+pub const INLINE_MEMCPY_SUFFIX: &'static str = r#"
+// In SGX, use following macro to ensure all calls to memcpy is calling __builtin_memcpy
+// so that ensure compiler can optimize it
+#define memcpy not_memcpy_
+#include <string.h>
+#undef memcpy
+#ifndef MEMCPY_WRAPPER_
+#define MEMCPY_WRAPPER_
+static inline void memcpy(void *dst, const void *src, size_t n) {
+    __builtin_memcpy(dst, src, n);
+}
+#endif
+"#;

--- a/mbedtls-sys/build/features.rs
+++ b/mbedtls-sys/build/features.rs
@@ -91,7 +91,7 @@ impl Features {
     }
 }
 
-fn env_have_target_cfg(var: &'static str, value: &'static str) -> bool {
+pub(super) fn env_have_target_cfg(var: &'static str, value: &'static str) -> bool {
     let env = format!("CARGO_CFG_TARGET_{}", var).to_uppercase().replace("-", "_");
     env::var_os(env).map_or(false, |s| s == value)
 }


### PR DESCRIPTION
## Performance issue about unaligned memory access
In `mbedtls` `3.4.0`, upstream refactor the code of accessing unaligned address from using **bit calculation** to **use pointer + `memcpy` + clang's bitswap**.

This is fine in no-sgx environment, but become very slow in fortanix SGX environment.
I think the most possible reason here is call of `memcpy`.

This PR mainly replace all these new functions with old implementation in https://github.com/Mbed-TLS/mbedtls/blob/v3.3.0/library/common.h

Performance tests result:
Command used to run bench:
`cargo +stable bench --no-default-features --features dsa,force_aesni_support,mpi_force_c_code,rdrand,std,time --target=x86_64-fortanix-unknown-sgx`
```
Branch for testing: `yx/mbedtls-9_bench` at e51d4d17591817922928b3f23b6a85de4c3b2501 : 
Benchmarking pbkdf2_hmac
Benchmarking pbkdf2_hmac: Warming up for 3.0000 s
Benchmarking pbkdf2_hmac: Collecting 100 samples in estimated 7.6594 s (200 iterations)
Benchmarking pbkdf2_hmac: Analyzing
pbkdf2_hmac             time:   [38.324 ms 38.332 ms 38.339 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Branch for testing: `yx/mbedtls-11_bench` at 489cad5a6d8dc1042329de5aaf9d0a801a7ba802 : 
Benchmarking pbkdf2_hmac
Benchmarking pbkdf2_hmac: Warming up for 3.0000 s
Benchmarking pbkdf2_hmac: Collecting 100 samples in estimated 14.664 s (100 iterations)
Benchmarking pbkdf2_hmac: Analyzing
pbkdf2_hmac             time:   [146.82 ms 146.86 ms 146.91 ms]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
```
After this PR, the performance number back to be as same as `yx/mbedtls-9_bench` one

## Performance issue about `explicit_bzero` (debug mode only)

When providing the `explicit_bzero` function through rust, there is a big performance downgrade in SGX

For example, when running the `pbkdf` :
Command: `cargo +stable nextest run --test pbkdf --no-default-features --features dsa,force_aesni_support,mpi_force_c_code,rdrand,std,time  --target=x86_64-fortanix-unknown-sgx`

```
# debug
PASS [   7.689s] mbedtls::pbkdf test_pbkdf2
# release
PASS [   0.233s] mbedtls::pbkdf test_pbkdf2
```
After ensure C mbedtls side to not call `explicit_bzero`, the time reduce to
```
# debug
PASS [   1.785s] mbedtls::pbkdf test_pbkdf2
# release
PASS [   0.234s] mbedtls::pbkdf test_pbkdf2
```

This performance issue should be not related to usage of `Zeroize` crate, because above tests results are reproduced by following minimal implementation of `explicit_bzero`:
```rust
#[no_mangle]
pub unsafe extern "C" fn explicit_bzero(buf: *mut std::ffi::c_void, len: alloc::size_t) {
    // TODO: use `volatile_set_memory` when stabilized
    for i in 0..len {
        let ptr = (buf as *mut u8).add(i);
        core::ptr::write_volatile(ptr, 0u8);
    }
}
```