### PR TITLE
Set `MBEDTLS_SSL_OUT_CONTENT_LEN` to a smaller value to avoid client side record overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "3.5.0-alpha.2+0b3de6f"
+version = "3.5.0-alpha.3+0b3de6f"
 dependencies = [
  "bindgen",
  "cc",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "3.5.0-alpha.2+0b3de6f"
+version = "3.5.0-alpha.3+0b3de6f"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"

--- a/mbedtls-sys/build/config.rs
+++ b/mbedtls-sys/build/config.rs
@@ -421,6 +421,8 @@ pub const FEATURE_DEFINES: &'static [(&'static str, CDefine)] = &[
     ("tls13",                 ("MBEDTLS_SSL_TLS1_3_TICKET_AGE_TOLERANCE",                    DefinedAs("6000"))),
     ("tls13",                 ("MBEDTLS_SSL_TLS1_3_TICKET_NONCE_LENGTH",                     DefinedAs("32"))),
     ("tls13",                 ("MBEDTLS_SSL_TLS1_3_DEFAULT_NEW_SESSION_TICKETS",             DefinedAs("1"))),
+    // TODO: This is a temporary fix for issue: #293
+    ("tls13",                 ("MBEDTLS_SSL_OUT_CONTENT_LEN",                                DefinedAs("15360"))),
 ];
 
 #[cfg_attr(rustfmt, rustfmt_skip)]


### PR DESCRIPTION
In some cases, mbedlts will send a tls record with record length > 2^14 which breaks the rfc, as a result trigger client's record overflow error. This PR is a temporary fix for it