### PR TITLE
Remove LTO for static function wrappers.

### DIFF
--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -141,7 +141,6 @@ impl BuildConfig {
             cc.flag("-ffreestanding");
         }
         cc
-        .flag_if_supported("-flto=thin")
         .file(&self.static_wrappers_c)
         .compile("libstatic-wrappers.a");
     }


### PR DESCRIPTION
LTO doesn't works good with rust-lld.
Remove LTO to fix the link issue #304.