### PR TITLE
fix: return error when verify empty cert chain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -19,8 +19,8 @@ env:
   CARGO_NET_RETRY: 10
 
 jobs:
-  build:
-    name: test
+  test:
+    name: Test
     strategy:
       matrix:
         include:
@@ -74,3 +74,13 @@ jobs:
         TARGET: ${{ matrix.target }}
         ZLIB_INSTALLED: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && 'true' || '' }}
         AES_NI_SUPPORT: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && 'true' || '' }}
+  ci-success:
+    name: ci
+    if: always()
+    needs:
+      - test
+    runs-on: ubuntu-20.04
+    steps:
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+      - name: Done
+        run: exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mbedtls"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-stream",
  "bencher",

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
 status = [
-  "test",
+  "ci",
 ]
 timeout_sec = 36000 # ten hours

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"

--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -338,6 +338,9 @@ impl Config {
     }
 
     pub fn push_cert(&mut self, own_cert: Arc<MbedtlsList<Certificate>>, own_pk: Arc<Pk>) -> Result<()> {
+        if own_cert.is_empty() {
+            return Err(crate::error::codes::SslBadInputData.into());
+        }
         // Need to ensure own_cert/pk_key outlive the config.
         self.own_cert.push(own_cert.clone());
         self.own_pk.push(own_pk.clone());

--- a/mbedtls/src/ssl/context.rs
+++ b/mbedtls/src/ssl/context.rs
@@ -573,7 +573,7 @@ impl HandshakeContext {
         key: Arc<Pk>,
     ) -> Result<()> {
         // mbedtls_ssl_set_hs_own_cert does not check for NULL handshake.
-        if self.inner.private_handshake as *const _ == ::core::ptr::null() {
+        if self.inner.private_handshake as *const _ == ::core::ptr::null() || chain.is_empty() {
             return Err(codes::SslBadInputData.into());
         }
 


### PR DESCRIPTION
For #307 on master.

Several back-port PRs needed for older versions.

Only return X509BadInputData error when candidate certificate chain is empty because:
- underlying `mbedtls` does not have null pointer check on it.
- underlying `mbedtls` has null pointer check on `trust_ca` chain during the process of finding parent certificate in the chain.