### PR TITLE
Add missing setter for `conf->new_session_tickets_count`

### DIFF
--- a/mbedtls/src/ssl/config.rs
+++ b/mbedtls/src/ssl/config.rs
@@ -371,6 +371,11 @@ impl Config {
         set_session_tickets(u: UseSessionTickets) = ssl_conf_session_tickets
     );
 
+    #[cfg(feature = "tls13")]
+    setter!(
+        set_new_session_tickets_count(cnt: u16) = ssl_conf_new_session_tickets
+    );
+
     setter!(set_renegotiation(u: Renegotiation) = ssl_conf_renegotiation);
 
     setter!(


### PR DESCRIPTION
The file `include/mbedtls/ssl.h` in MbedTLS contains a setter for `conf->new_session_tickets_count`, which determines the number of new TLS session tickets generated for each session:

```c
#if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
    defined(MBEDTLS_SSL_SRV_C) && \
    defined(MBEDTLS_SSL_PROTO_TLS1_3)
void mbedtls_ssl_conf_new_session_tickets(mbedtls_ssl_config *conf,
                                          uint16_t num_tickets);
#endif
```

However, the correspoding Rust wrapper is missing, potentially due to this function being available only when `MBEDTLS_SSL_PROTO_TLS1_3` is defined (which is not the case for the default configuration).

We should add this setter back when the `tls13` feature is enabled:

```rs
  #[cfg(feature = "tls13")]
  setter!(
      set_new_session_tickets_count(cnt: u16) = ssl_conf_new_session_tickets
  );
```