### PR TITLE
[v0.9] Bump version of `mbedtls-sys-auto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.3+patch1"
+version = "2.28.4+mbedtls-2.28.3"
 dependencies = [
  "bindgen",
  "cc",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.28.3+patch1"
+version = "2.28.4+mbedtls-2.28.3"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"
@@ -12,6 +12,11 @@ readme = "../README.md"
 repository = "https://github.com/fortanix/rust-mbedtls"
 documentation = "https://docs.rs/mbedtls-sys-auto/"
 links = "mbedtls"
+
+[package.metadata.mbedtls]
+git = "https://github.com/Mbed-TLS/mbedtls.git"
+version = "2.28.3"
+rev = "981743de6fcdbe672e482b6fd724d31d0a0d2476"
 
 [lib]
 name = "mbedtls_sys"


### PR DESCRIPTION
Since from [README.md](https://github.com/fortanix/rust-mbedtls/blob/cbcc38e0a9b74725e62fe075739fe4e147a8b097/README.md) we do not statement that the patch version of `mbedtls-sys-auto` should match the C mbedtls's version, so I bump the patch version normally to represent the code change