### PR TITLE
Introduce separate features for pki and tls functionalities of mbedtls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cargo
 target/
+venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.3"
+version = "0.12.0"
 dependencies = [
  "async-stream",
  "bit-vec",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ This crate depends on the mbedtls-sys-auto crate, see below for build details.
 ### Features
 
 This is a list of the Cargo features available for mbedtls. Features in
+
+* *x509* Enable PKI functionality. The main code enabled by this feature is in
+         the `x509` module.
+
+* *ssl* Enable ssl/tls functionality. The main code enabled by this feature is
+        in the `ssl` module.
+
+Note: The above features were introduced so that this crate could be used as a
+crypto (or PKI) only library.
+
 **bold** are enabled by default.
 
 * **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
@@ -53,12 +63,12 @@ This is a list of the Cargo features available for mbedtls. Features in
                         unsupported processors. On SGX, this feature is
                         enabled automatically.
 * *mpi_force_c_code* Enables the `mpi_force_c_code` feature in mbedtls-sys
-* *legacy_protocols* Enable support for SSLv3, TLSv1.0 and TLSv1.1
+* *legacy_protocols* Enable support for SSLv3, TLSv1.0 and TLSv1.1. Implies *ssl*.
 * *no_std_deps* On no_std, you must enable this feature. It enables optional
                 dependencies needed on no_std. If the `std` feature is enabled,
                 this feature is ignored.
 * **padlock** Enable support for VIA padlock.
-* *pkcs12* Enable code to parse PKCS12 files using yasna
+* *pkcs12* Enable code to parse PKCS12 files using yasna. Implies *x509*.
 * *pkcs12_rc2* Enable use of RC2 crate to decrypt RC2-encrypted PKCS12 files
 * *rdrand* Enable the RDRAND random number generator. On SGX, this feature is
            enabled automatically.

--- a/ci.sh
+++ b/ci.sh
@@ -24,36 +24,42 @@ case "$TRAVIS_RUST_VERSION" in
         rustup target add --toolchain $TRAVIS_RUST_VERSION $TARGET
         printenv
 
+        for FEAT in "" "x509," "ssl,"; do
+            # The SGX target cannot be run under test like a ELF binary
+            if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then
+                # make sure that explicitly providing the default target works
+                cargo nextest run --features "$FEAT" --target $TARGET --release
+                cargo nextest run --features "$FEAT"pkcs12 --target $TARGET
+                cargo nextest run --features "$FEAT"pkcs12_rc2 --target $TARGET
+                cargo nextest run --features "$FEAT"dsa --target $TARGET
+
+                # If AES-NI is supported, test the feature
+                if [ -n "$AES_NI_SUPPORT" ]; then
+                    cargo nextest run --features "$FEAT"force_aesni_support --target $TARGET
+                fi
+
+                # no_std tests only are able to run on x86 platform
+                if [ "$TARGET" == "x86_64-unknown-linux-gnu" ] || [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
+                    cargo nextest run --no-default-features --features "$FEAT"no_std_deps,rdrand,time --target $TARGET
+                    cargo nextest run --no-default-features --features "$FEAT"no_std_deps --target $TARGET
+                fi
+
+            else
+                cargo +$TRAVIS_RUST_VERSION test --no-run --features "$FEAT" --target=$TARGET
+            fi
+        done
+
         # The SGX target cannot be run under test like a ELF binary
         if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then
-            # make sure that explicitly providing the default target works
-            cargo nextest run --target $TARGET --release
-            cargo nextest run --features pkcs12 --target $TARGET
-            cargo nextest run --features pkcs12_rc2 --target $TARGET
-            cargo nextest run --features dsa --target $TARGET
-            cargo nextest run --test async_session --features=async-rt --target $TARGET
-            cargo nextest run --test async_session --features=async-rt,legacy_protocols --target $TARGET
+            cargo nextest run --test async_session --features=async-rt,ssl --target $TARGET
+            cargo nextest run --test async_session --features=async-rt,ssl,legacy_protocols --target $TARGET
 
             # If zlib is installed, test the zlib feature
             if [ -n "$ZLIB_INSTALLED" ]; then
                 cargo nextest run --features zlib --target $TARGET
-                cargo nextest run --test async_session --features=async-rt,zlib --target $TARGET
-                cargo nextest run --test async_session --features=async-rt,zlib,legacy_protocols --target $TARGET
+                cargo nextest run --test async_session --features=async-rt,ssl,zlib --target $TARGET
+                cargo nextest run --test async_session --features=async-rt,ssl,zlib,legacy_protocols --target $TARGET
             fi
-
-            # If AES-NI is supported, test the feature
-            if [ -n "$AES_NI_SUPPORT" ]; then
-                cargo nextest run --features force_aesni_support --target $TARGET
-            fi
-
-            # no_std tests only are able to run on x86 platform
-            if [ "$TARGET" == "x86_64-unknown-linux-gnu" ] || [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
-                cargo nextest run --no-default-features --features no_std_deps,rdrand,time --target $TARGET
-                cargo nextest run --no-default-features --features no_std_deps --target $TARGET
-            fi
-
-        else
-            cargo +$TRAVIS_RUST_VERSION test --no-run --target=$TARGET
         fi
         ;;
     *)

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -60,6 +60,10 @@ cc = "1.0"
 
 [features]
 # Features are documented in the README
+
+x509 = []
+ssl = ["x509"]
+
 default = ["std", "aesni", "time", "padlock"]
 std = ["byteorder/std", "mbedtls-sys-auto/std", "serde/std", "yasna", "mbedtls-platform-support/std"]
 debug = ["mbedtls-sys-auto/debug"]
@@ -72,46 +76,45 @@ zlib = ["mbedtls-sys-auto/zlib"]
 time = ["mbedtls-platform-support/time"]
 padlock = ["mbedtls-sys-auto/padlock"]
 dsa = ["std", "yasna", "num-bigint", "bit-vec"]
-pkcs12 = ["std", "yasna"]
+pkcs12 = ["std", "yasna", "x509"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
-legacy_protocols = ["mbedtls-sys-auto/legacy_protocols"]
+legacy_protocols = ["mbedtls-sys-auto/legacy_protocols", "ssl"]
 async = ["std", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
 async-rt = ["async", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
 
 [[example]]
 name = "client"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[example]]
 name = "client_dtls"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[example]]
 name = "client_psk"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[example]]
 name = "server"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[test]]
 name = "client_server"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[test]]
 name = "ssl_conf_ca_cb"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[test]]
 name = "ssl_conf_verify"
-required-features = ["std"]
+required-features = ["std", "ssl"]
 
 [[test]]
 name = "hyper"
-required-features = ["std"]
-
+required-features = ["std", "ssl"]
 
 [[test]]
 name = "async_session"
 path = "tests/async_session.rs"
-required-features = ["async-rt"]
+required-features = ["async-rt", "ssl"]

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "mbedtls"
-version = "0.9.3"
+# We jumped from v0.9 to v0.12 because v0.10 and v0.11 were based on mbedtls 3.X, which
+# we decided not to support.
+version = "0.12.0"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -15,8 +15,6 @@ compile_error!("Either the `std` or `no_std_deps` feature needs to be enabled");
 
 
 #[macro_use]
-extern crate bitflags;
-#[macro_use]
 extern crate serde_derive;
 // required explicitly to force inclusion at link time
 #[cfg(target_env = "sgx")]
@@ -37,8 +35,11 @@ pub mod hash;
 pub mod pk;
 pub mod rng;
 pub use mbedtls_platform_support::self_test as self_test;
+#[cfg(feature = "ssl")]
 pub mod ssl;
+#[cfg(feature = "x509")]
 pub mod x509;
+#[cfg(any(feature = "x509", feature = "ssl"))]
 pub mod alloc;
 
 #[cfg(feature = "pkcs12")]

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -39,7 +39,7 @@ pub use mbedtls_platform_support::self_test as self_test;
 pub mod ssl;
 #[cfg(feature = "x509")]
 pub mod x509;
-#[cfg(any(feature = "x509", feature = "ssl"))]
+#[cfg(any(feature = "x509", feature = "ssl", feature = "pkcs12"))]
 pub mod alloc;
 
 #[cfg(feature = "pkcs12")]

--- a/mbedtls/src/private.rs
+++ b/mbedtls/src/private.rs
@@ -92,6 +92,7 @@ pub unsafe fn cstr_to_slice<'a>(ptr: *const c_char) -> &'a [u8] {
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 #[cfg(feature = "std")]
+#[allow(dead_code)]
 pub fn error_to_io_error(e: Error) -> IoError {
     IoError::new(IoErrorKind::Other, e.to_string())
 }

--- a/mbedtls/src/x509/certificate.rs
+++ b/mbedtls/src/x509/certificate.rs
@@ -561,6 +561,7 @@ impl MbedtlsList<Certificate> {
         Self { inner: None }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn into_raw(mut self) -> *mut x509_crt {
         // This leaks a *mut Certificate that we can cast to x509_crt as it's transparent and has no extra fields.
         self.inner.take().map(|x| x.into_raw()).unwrap_or(core::ptr::null_mut()) as *mut x509_crt

--- a/mbedtls/src/x509/mod.rs
+++ b/mbedtls/src/x509/mod.rs
@@ -27,6 +27,7 @@ pub use self::csr::Csr;
 #[doc(inline)]
 pub use self::profile::Profile;
 
+use bitflags::bitflags;
 use mbedtls_sys::*;
 use mbedtls_sys::types::raw_types::{c_int, c_uint, c_void};
 bitflags! {


### PR DESCRIPTION
To statically guarantee that unwanted capabilities of this crate are not used (e.g., a client could only require the crypto functionality of this crate and not its ssl capabilities), this PR introduces two features: `x509` and `ssl`. `x509` enables the pki functionality of the crate and `ssl` enables its tls/ssl capabilities. 