### PR TITLE
Make `x509::Time` more useful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cargo
 target/
 venv/
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "cbc",
  "cc",
  "cfg-if 1.0.0",
+ "chrono",
  "futures",
  "hex",
  "hyper",

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ crypto (or PKI) only library.
 * **time** Enable time support in mbedtls-sys.
 * *zlib* Enable zlib support in mbedtls-sys.
 * *async-rt* Enable async support for SSL.
-
-PRs adding new features are encouraged.
+* *chrono* Enable [`chrono`](https://docs.rs/chrono/) support (e.g., implementation of conversion traits between `x509::Time` and `chrono` types)
 
 # mbedtls-sys-auto
 

--- a/ci.sh
+++ b/ci.sh
@@ -53,6 +53,7 @@ case "$TRAVIS_RUST_VERSION" in
         if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then
             cargo nextest run --test async_session --features=async-rt,ssl --target $TARGET
             cargo nextest run --test async_session --features=async-rt,ssl,legacy_protocols --target $TARGET
+            cargo nextest run chrono --features=chrono,ssl,x509 --target $TARGET
 
             # If zlib is installed, test the zlib feature
             if [ -n "$ZLIB_INSTALLED" ]; then

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -31,6 +31,7 @@ cbc = { version = "0.1.2", optional = true }
 rc2 = { version = "0.8.1", optional = true }
 cfg-if = "1.0.0"
 tokio = { version = "1.16.1", optional = true }
+chrono = { version = "0.4", optional = true }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.2.0"


### PR DESCRIPTION
This PR makes the `x509::Time` type more useful by 
 - adding getters for its fields (`year`, `hour`, etc.)
 - implementing conversion traits between `chrono::NaiveDateTime` and `x509::Time` (gated by the `chrono` feature) 