### PR TITLE
Fix windows build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-stream",
  "bit-vec",

--- a/ci.sh
+++ b/ci.sh
@@ -39,22 +39,22 @@ case "$TRAVIS_RUST_VERSION" in
                 fi
 
                 # no_std tests only are able to run on x86 platform
-                if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
+                if [ "$TARGET" == "x86_64-unknown-linux-gnu" ] || [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
                     cargo nextest run --no-default-features --features "$FEAT"no_std_deps,rdrand,time --target $TARGET
                     cargo nextest run --no-default-features --features "$FEAT"no_std_deps --target $TARGET
                 fi
-                if [ "$TARGET" == "x86_64-apple-darwin" ]; then
-                    cargo nextest run --no-default-features --features no_std_deps --target $TARGET
-                fi
-                if [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
-                    cargo nextest run --no-default-features --features "$FEAT"std --target $TARGET
-                    cargo nextest run --no-default-features --features "$FEAT"no_std_deps --target $TARGET
-                fi
-
             else
                 cargo +$TRAVIS_RUST_VERSION test --no-run --features "$FEAT" --target=$TARGET
             fi
         done
+
+        if [ "$TARGET" == "x86_64-apple-darwin" ]; then
+            cargo nextest run --no-default-features --features no_std_deps --target $TARGET
+        fi
+        # special case: mbedtls should compile successfully on windows only with `std` feature
+        if [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
+            cargo nextest run --no-default-features --features std --target $TARGET
+        fi
 
         # The SGX target cannot be run under test like a ELF binary
         if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then

--- a/ci.sh
+++ b/ci.sh
@@ -39,12 +39,16 @@ case "$TRAVIS_RUST_VERSION" in
                 fi
 
                 # no_std tests only are able to run on x86 platform
-                if [ "$TARGET" == "x86_64-unknown-linux-gnu" ] || [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
+                if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
                     cargo nextest run --no-default-features --features "$FEAT"no_std_deps,rdrand,time --target $TARGET
                     cargo nextest run --no-default-features --features "$FEAT"no_std_deps --target $TARGET
                 fi
                 if [ "$TARGET" == "x86_64-apple-darwin" ]; then
                     cargo nextest run --no-default-features --features no_std_deps --target $TARGET
+                fi
+                if [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
+                    cargo nextest run --no-default-features --features "$FEAT"std --target $TARGET
+                    cargo nextest run --no-default-features --features "$FEAT"no_std_deps --target $TARGET
                 fi
 
             else

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mbedtls"
 # We jumped from v0.9 to v0.12 because v0.10 and v0.11 were based on mbedtls 3.X, which
 # we decided not to support.
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -17,14 +17,17 @@ environment."""
 readme = "../README.md"
 repository = "https://github.com/fortanix/rust-mbedtls"
 documentation = "https://docs.rs/mbedtls/"
-keywords = ["MbedTLS","mbed","TLS","SSL","cryptography"]
+keywords = ["MbedTLS", "mbed", "TLS", "SSL", "cryptography"]
 
 [dependencies]
 bitflags = "1"
 serde = { version = "1.0.7", default-features = false, features = ["alloc"] }
 serde_derive = "1.0.7"
 byteorder = { version = "1.0.0", default-features = false }
-yasna = { version = "0.2", optional = true, features = ["num-bigint", "bit-vec"] }
+yasna = { version = "0.2", optional = true, features = [
+    "num-bigint",
+    "bit-vec",
+] }
 num-bigint = { version = "0.2", optional = true }
 bit-vec = { version = "0.5", optional = true }
 cbc = { version = "0.1.2", optional = true }
@@ -33,18 +36,15 @@ cfg-if = "1.0.0"
 tokio = { version = "1.16.1", optional = true }
 chrono = { version = "0.4", optional = true }
 
+mbedtls-sys-auto = { path = "../mbedtls-sys", version = "2.25.0", default-features = false, features = [
+    "trusted_cert_callback",
+    "threading",
+] }
+
+mbedtls-platform-support = { version = "0.1", path = "../mbedtls-platform-support" }
+
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 rs-libc = "0.2.0"
-
-[dependencies.mbedtls-sys-auto]
-version = "2.25.0"
-default-features = false
-features = ["trusted_cert_callback", "threading"]
-path = "../mbedtls-sys"
-
-[dependencies.mbedtls-platform-support]
-version = "0.1"
-path = "../mbedtls-platform-support"
 
 [dev-dependencies]
 libc = "0.2.0"
@@ -62,10 +62,15 @@ pin-project-lite = "0.2"
 cc = "1.0"
 
 # feature 'time` is necessary under windows
-[target.'cfg(target_os = "windows")'.mbedtls-platform-support]
-version = "0.1"
-path = "../mbedtls-platform-support"
-features = ["time"]
+[target.'cfg(target_env = "msvc")'.dependencies]
+mbedtls-platform-support = { version = "0.1", path = "../mbedtls-platform-support", features = [
+    "time",
+] }
+mbedtls-sys-auto = { path = "../mbedtls-sys", version = "2.25.0", default-features = false, features = [
+    "trusted_cert_callback",
+    "threading",
+    "time",
+] }
 
 [features]
 # Features are documented in the README
@@ -74,7 +79,13 @@ x509 = []
 ssl = ["x509"]
 
 default = ["std", "aesni", "time", "padlock"]
-std = ["byteorder/std", "mbedtls-sys-auto/std", "serde/std", "yasna", "mbedtls-platform-support/std"]
+std = [
+    "byteorder/std",
+    "mbedtls-sys-auto/std",
+    "serde/std",
+    "yasna",
+    "mbedtls-platform-support/std",
+]
 debug = ["mbedtls-sys-auto/debug"]
 no_std_deps = ["mbedtls-platform-support/spin", "serde/alloc"]
 force_aesni_support = ["mbedtls-platform-support/force_aesni_support", "aesni"]
@@ -88,7 +99,7 @@ dsa = ["std", "yasna", "num-bigint", "bit-vec"]
 pkcs12 = ["std", "yasna", "x509"]
 pkcs12_rc2 = ["pkcs12", "rc2", "cbc"]
 legacy_protocols = ["mbedtls-sys-auto/legacy_protocols", "ssl"]
-async = ["std", "tokio","tokio/net","tokio/io-util", "tokio/macros"]
+async = ["std", "tokio", "tokio/net", "tokio/io-util", "tokio/macros"]
 async-rt = ["async", "tokio/rt", "tokio/sync", "tokio/rt-multi-thread"]
 
 [[example]]


### PR DESCRIPTION
This PR changes CI to cover build `mbedtls` only with `std` feature under windows, which was broken.

This PR changes the features used when compiling to `msvc` to solve above issue.