### PR TITLE
fix nightly issue & bump mbedtls to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-stream",
  "bit-vec",

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mbedtls"
 # We jumped from v0.9 to v0.12 because v0.10 and v0.11 were based on mbedtls 3.X, which
 # we decided not to support.
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"

--- a/mbedtls/src/pkcs12/mod.rs
+++ b/mbedtls/src/pkcs12/mod.rs
@@ -430,6 +430,7 @@ enum Pkcs12BagSet {
     EncryptedPkcs8(Vec<u8>),
     Pkcs8(Vec<u8>),
     Cert(CertBag),
+    #[allow(dead_code)]
     UnknownBlob(Vec<u8>),
     // XXX CRL and Secret bags not supported
     //Crl(CrlBag),

--- a/mbedtls/src/rng/ctr_drbg.rs
+++ b/mbedtls/src/rng/ctr_drbg.rs
@@ -19,6 +19,7 @@ use crate::alloc_prelude::*;
 use crate::error::{IntoResult, Result};
 use crate::rng::{EntropyCallback, EntropyCallbackMut, RngCallback, RngCallbackMut};
 
+#[allow(dead_code)]
 enum EntropyHolder {
     Shared(Arc<dyn EntropyCallback + 'static>),
     Unique(Box<dyn EntropyCallbackMut + 'static>),


### PR DESCRIPTION
- Bump `mbedtls` version to have a new version to include https://github.com/fortanix/rust-mbedtls/pull/339
- Fix nightly code style issue