### PR TITLE
Enabled `x509` and `ssl` features for `doc.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "rand",
  "rc2",
  "rs-libc",
+ "rustc_version",
  "serde",
  "serde_cbor",
  "serde_derive",
@@ -1057,6 +1058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1099,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -19,6 +19,9 @@ repository = "https://github.com/fortanix/rust-mbedtls"
 documentation = "https://docs.rs/mbedtls/"
 keywords = ["MbedTLS", "mbed", "TLS", "SSL", "cryptography"]
 
+[package.metadata.docs.rs]
+features = ["x509", "ssl"]
+
 [dependencies]
 bitflags = "1"
 serde = { version = "1.0.7", default-features = false, features = ["alloc"] }
@@ -61,6 +64,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [build-dependencies]
 cc = "1.0"
+rustc_version = "0.4.0"
 
 # feature 'time` is necessary under windows
 [target.'cfg(target_env = "msvc")'.dependencies]

--- a/mbedtls/build.rs
+++ b/mbedtls/build.rs
@@ -9,6 +9,8 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 
+use rustc_version::Channel;
+
 /// Return the crate hash that Cargo will be passing to `rustc -C metadata=`.
 // If there's a panic in this code block, that means Cargo's way of running the
 // build script has changed, and this code should be updated to handle the new
@@ -23,6 +25,11 @@ fn get_compilation_metadata_hash() -> String {
 }
 
 fn main() {
+    // used for configuring rustdoc attrs for now
+    if rustc_version::version_meta().is_ok_and(|v| v.channel == Channel::Nightly) {
+        println!("cargo:rustc-cfg=nightly");
+    }
+
     let metadata_hash = get_compilation_metadata_hash();
     println!("cargo:rustc-env=RUST_MBEDTLS_METADATA_HASH={}", metadata_hash);
 

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(warnings)]
 #![allow(unused_doc_comments)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 
 #[cfg(not(any(feature = "std", feature = "no_std_deps")))]
 compile_error!("Either the `std` or `no_std_deps` feature needs to be enabled");


### PR DESCRIPTION
Currently, `x509` and `ssl` modules do not show up on `docs.rs`: https://docs.rs/mbedtls/0.12.3/mbedtls/ 

This PR modifies `Cargo.toml` to add these features when generating docs for `docs.rs`, and enables the nightly feature `doc_auto_cfg` so that in the docs, these modules are marked with the features required to enable them.