### PR TITLE
Allow of way to toggle freestanding platform features

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -32,7 +32,9 @@ impl super::BuildConfig {
         // thumbv6m-none-eabi, thumbv7em-none-eabi, thumbv7em-none-eabihf,
         // thumbv7m-none-eabi probably use arm-none-eabi-gcc which can cause the
         // cmake compiler test to fail.
-        if target.starts_with("thumbv") && target.contains("none-eabi") {
+        if target.starts_with("thumbv") && target.contains("none-eabi")
+            || crate::features::FEATURES.have_platform_component("c_compiler", "freestanding")
+        {
             // When building on Linux, -rdynamic flag is added automatically. Changing the
             // CMAKE_SYSTEM_NAME to Generic avoids this.
             cmk.define("CMAKE_SYSTEM_NAME", "Generic");

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -28,13 +28,16 @@ impl super::BuildConfig {
             cmk.define("CMAKE_C_COMPILER_FORCED", "TRUE");
         }
 
+        println!("cargo:rerun-if-env-changed=RUST_MBED_C_COMPILER_BAREMETAL");
+        let c_compiler_baremetal = std::env::var("RUST_MBED_C_COMPILER_BAREMETAL")
+            .map(|val| val == "1")
+            .unwrap_or_default();
+
         let target = std::env::var("TARGET").expect("TARGET environment variable should be set in build scripts");
         // thumbv6m-none-eabi, thumbv7em-none-eabi, thumbv7em-none-eabihf,
         // thumbv7m-none-eabi probably use arm-none-eabi-gcc which can cause the
         // cmake compiler test to fail.
-        if target.starts_with("thumbv") && target.contains("none-eabi")
-            || crate::features::FEATURES.have_platform_component("c_compiler", "freestanding")
-        {
+        if target.starts_with("thumbv") && target.contains("none-eabi") || c_compiler_baremetal {
             // When building on Linux, -rdynamic flag is added automatically. Changing the
             // CMAKE_SYSTEM_NAME to Generic avoids this.
             cmk.define("CMAKE_SYSTEM_NAME", "Generic");

--- a/mbedtls-sys/build/features.rs
+++ b/mbedtls-sys/build/features.rs
@@ -32,7 +32,12 @@ impl Features {
         let have_custom_threading = self.have_feature("custom_threading");
         let have_custom_gmtime_r = self.have_feature("custom_gmtime_r");
 
-        if !self.have_feature("std") || env_have_target_cfg("env", "sgx") || env_have_target_cfg("os", "none") {
+        println!("cargo:rerun-if-env-changed=RUST_MBED_C_COMPILER_FREESTANDING");
+        let freestanding = std::env::var("RUST_MBED_C_COMPILER_FREESTANDING")
+            .map(|x| x == "1")
+            .unwrap_or_default();
+
+        if !self.have_feature("std") || env_have_target_cfg("env", "sgx") || env_have_target_cfg("os", "none") || freestanding {
             self.with_feature("c_compiler").unwrap().insert("freestanding");
         }
         if let Some(components) = self.with_feature("threading") {

--- a/mbedtls-sys/build/features.rs
+++ b/mbedtls-sys/build/features.rs
@@ -32,12 +32,7 @@ impl Features {
         let have_custom_threading = self.have_feature("custom_threading");
         let have_custom_gmtime_r = self.have_feature("custom_gmtime_r");
 
-        println!("cargo:rerun-if-env-changed=RUST_MBED_C_COMPILER_FREESTANDING");
-        let freestanding = std::env::var("RUST_MBED_C_COMPILER_FREESTANDING")
-            .map(|x| x == "1")
-            .unwrap_or_default();
-
-        if !self.have_feature("std") || env_have_target_cfg("env", "sgx") || env_have_target_cfg("os", "none") || freestanding {
+        if !self.have_feature("std") || env_have_target_cfg("env", "sgx") || env_have_target_cfg("os", "none") {
             self.with_feature("c_compiler").unwrap().insert("freestanding");
         }
         if let Some(components) = self.with_feature("threading") {


### PR DESCRIPTION
`RUST_MBED_C_COMPILER_FREESTANDING=1` allows to skip cmake checks where the target must produce valid binaries.


Closes: #355 

cc: @Taowyoo 