### PR TITLE
 Handle multi-valued `target_family`

### DIFF
--- a/mbedtls-sys/build/features.rs
+++ b/mbedtls-sys/build/features.rs
@@ -36,21 +36,21 @@ impl Features {
             self.with_feature("c_compiler").unwrap().insert("freestanding");
         }
         if let Some(components) = self.with_feature("threading") {
-            if !have_custom_threading && env_have_target_cfg("family", "unix") {
+            if !have_custom_threading && env_have_target_family("unix") {
                 components.insert("pthread");
             } else {
                 components.insert("custom");
             }
         }
         if let Some(components) = self.with_feature("std") {
-            if env_have_target_cfg("family", "unix") || env_have_target_cfg("family", "windows") {
+            if env_have_target_family("unix") || env_have_target_family("windows") {
                 components.insert("net");
                 components.insert("fs");
                 components.insert("entropy");
             }
         }
         if let Some(components) = self.with_feature("time") {
-            if !have_custom_gmtime_r && (env_have_target_cfg("family", "unix") || env_have_target_cfg("family", "windows")) {
+            if !have_custom_gmtime_r && (env_have_target_family("unix") || env_have_target_family("windows")) {
                 components.insert("libc");
             } else {
                 components.insert("custom");
@@ -98,6 +98,10 @@ impl Features {
 fn env_have_target_cfg(var: &'static str, value: &'static str) -> bool {
     let env = format!("CARGO_CFG_TARGET_{}", var).to_uppercase().replace("-", "_");
     env::var_os(env).map_or(false, |s| s == value)
+}
+
+fn env_have_target_family(value: &'static str) -> bool {
+    env::var("CARGO_CFG_TARGET_FAMILY").map_or(false, |var| var.split(",").any(|s| s == value))
 }
 
 fn env_have_feature(feature: &'static str) -> bool {


### PR DESCRIPTION
[`target_family`](https://doc.rust-lang.org/reference/conditional-compilation.html#target_family) / `CARGO_CFG_TARGET_FAMILY` is documented to be multi-valued.

This was found by a crater run in https://github.com/rust-lang/rust/pull/124355#issuecomment-2091278128. This crate may fail to compile in the future if Rust decides to add further target families.

~Additionally, I've bumped the version of `mbedtls-sys-auto` to `v2.28.8` to make it easier for you to release.~
EDIT: Moved to https://github.com/fortanix/rust-mbedtls/pull/368