### PR TITLE
Bump version of `mbedtls-sys-auto` to `v2.28.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.7"
+version = "2.28.8"
 dependencies = [
  "bindgen",
  "cc",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.28.7"
+version = "2.28.8"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"


### PR DESCRIPTION
Motivation: to get https://github.com/fortanix/rust-mbedtls/pull/362 out as soon as possible.