### PR TITLE
linking C libraries staticly and Bazel compatibility

### DIFF
--- a/mbedtls-platform-support/build.rs
+++ b/mbedtls-platform-support/build.rs
@@ -34,8 +34,4 @@ fn main() {
             .flag("-ffreestanding");
     }
     b.compile("librust-mbedtls-platform-support.a");
-    // Force correct link order for mbedtls_printf
-    println!("cargo:rustc-link-lib=static=mbedtls");
-    println!("cargo:rustc-link-lib=static=mbedx509");
-    println!("cargo:rustc-link-lib=static=mbedcrypto");
 }

--- a/mbedtls-platform-support/build.rs
+++ b/mbedtls-platform-support/build.rs
@@ -34,4 +34,8 @@ fn main() {
             .flag("-ffreestanding");
     }
     b.compile("librust-mbedtls-platform-support.a");
+    // Force correct link order for mbedtls_printf
+    println!("cargo:rustc-link-lib=static=mbedtls");
+    println!("cargo:rustc-link-lib=static=mbedx509");
+    println!("cargo:rustc-link-lib=static=mbedcrypto");
 }

--- a/mbedtls-sys/build/bindgen.rs
+++ b/mbedtls-sys/build/bindgen.rs
@@ -103,7 +103,7 @@ impl super::BuildConfig {
         if cc.get_compiler().is_like_msvc() {
             cc.flag("--driver-mode=cl");
         }
-        cc.include(&self.mbedtls_include).define(
+        cc.include(&self.out_dir.join("include")).define(
             "MBEDTLS_CONFIG_FILE",
             Some(format!(r#""{}""#, self.config_h.to_str().expect("config.h UTF-8 error")).as_str()),
         );

--- a/mbedtls-sys/build/build.rs
+++ b/mbedtls-sys/build/build.rs
@@ -28,7 +28,6 @@ use std::path::{Path, PathBuf};
 struct BuildConfig {
     out_dir: PathBuf,
     mbedtls_src: PathBuf,
-    mbedtls_include: PathBuf,
     config_h: PathBuf,
     cflags: Vec<String>,
 }
@@ -83,7 +82,6 @@ impl BuildConfig {
         let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR environment not set?"));
         let config_h = out_dir.join("config.h");
         let mbedtls_src = PathBuf::from(env::var("RUST_MBEDTLS_SYS_SOURCE").unwrap_or("vendor".to_owned()));
-        let mbedtls_include = mbedtls_src.join("include");
 
         let mut cflags = vec![];
         if FEATURES.have_platform_component("c_compiler", "freestanding") {
@@ -97,7 +95,6 @@ impl BuildConfig {
             config_h,
             out_dir,
             mbedtls_src,
-            mbedtls_include,
             cflags,
         }
     }

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -53,9 +53,9 @@ impl super::BuildConfig {
             dst.to_str().expect("link-search UTF-8 error")
         );
 
-        println!("cargo:rustc-link-lib=mbedtls");
-        println!("cargo:rustc-link-lib=mbedx509");
-        println!("cargo:rustc-link-lib=mbedcrypto");
+        println!("cargo:rustc-link-lib=static=mbedtls");
+        println!("cargo:rustc-link-lib=static=mbedx509");
+        println!("cargo:rustc-link-lib=static=mbedcrypto");
 
         println!("cargo:include={}/include", dst.to_str().expect("include/ UTF-8 error"));
         println!("cargo:config_h={}", self.config_h.to_str().expect("config.h UTF-8 error"));

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -46,11 +46,10 @@ impl super::BuildConfig {
             cmk.define("CMAKE_TRY_COMPILE_TARGET_TYPE", "STATIC_LIBRARY");
         }
 
-        let mut dst = cmk.build();
+        let dst = cmk.build();
 
-        dst.push("lib");
         println!(
-            "cargo:rustc-link-search=native={}",
+            "cargo:rustc-link-search=native={}/lib",
             dst.to_str().expect("link-search UTF-8 error")
         );
 
@@ -58,14 +57,7 @@ impl super::BuildConfig {
         println!("cargo:rustc-link-lib=mbedx509");
         println!("cargo:rustc-link-lib=mbedcrypto");
 
-        println!(
-            "cargo:include={}",
-            ::std::env::current_dir()
-                .unwrap()
-                .join(&self.mbedtls_include)
-                .to_str()
-                .expect("include/ UTF-8 error")
-        );
+        println!("cargo:include={}/include", dst.to_str().expect("include/ UTF-8 error"));
         println!("cargo:config_h={}", self.config_h.to_str().expect("config.h UTF-8 error"));
     }
 }

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -49,15 +49,18 @@ impl super::BuildConfig {
         let dst = cmk.build();
 
         println!(
-            "cargo:rustc-link-search=native={}/lib",
-            dst.to_str().expect("link-search UTF-8 error")
+            "cargo:rustc-link-search=native={}",
+            dst.join("lib").to_str().expect("link-search UTF-8 error")
         );
 
         println!("cargo:rustc-link-lib=static=mbedtls");
         println!("cargo:rustc-link-lib=static=mbedx509");
         println!("cargo:rustc-link-lib=static=mbedcrypto");
 
-        println!("cargo:include={}/include", dst.to_str().expect("include/ UTF-8 error"));
+        println!(
+            "cargo:include={}",
+            dst.join("include").to_str().expect("include/ UTF-8 error")
+        );
         println!("cargo:config_h={}", self.config_h.to_str().expect("config.h UTF-8 error"));
     }
 }


### PR DESCRIPTION
This PR addresses two issues I encountered with Bazel that Cargo can handle. My approach was to solve them with minimal changes while remaining practical and aligned with Cargo and Rust guidelines.

~~* Since `mbedtls-sys` is responsible for providing the C libraries to dependent crates, we do not need to instruct Cargo to link them in the `mbedtls-platform-support` crate as well. While Cargo can handle this additional request, Bazel’s sandboxing prevents sharing the intermediate build script outputs of one crate with a dependent crate by default. Only .rlib or other library output files of dependent crates are accessible.~~

* The default linking type in `cargo:rustc-link-lib` is dynamic. However, since we are building vendor C libraries from source, we need to explicitly link them statically in the `mbedtls-sys` crate.

* Cargo has access to the entire file system at all stages, so passing `DEP_KEY=VALUE` from one crate's build script to a dependent crate's build script is possible through various methods. However, because Bazel’s Rust rules strictly limit the input data for each build task, it's preferable to share information by referencing the `OUT_DIR` of dependencies.
Now, `mbedtls-sys` crate provides `cargo:include` by pointing to its OUT_DIR, and `mbedtls-platform-support` can access header files using the `DEP_MBEDTLS_INCLUDE` environment variable. Then we don't need to customize the build process in Bazel for that.