### PR TITLE
Bugfix: Ensure lib directory is used on all platforms

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -19,6 +19,8 @@ impl super::BuildConfig {
         .define("GEN_FILES", "ON")
         // Prefer unix-style over Apple-style Python3 on macOS, required for the Github Actions CI
         .define("Python3_FIND_FRAMEWORK", "LAST")
+        // Ensure "lib" directory is used on all platforms
+        .define("LIB_INSTALL_DIR", "lib")
         .build_target("install");
         for cflag in &self.cflags {
             cmk.cflag(cflag);


### PR DESCRIPTION
Since mbedtls 2.28.8 they [changed](https://github.com/fortanix/rust-mbedtls/blob/mbedtls-sys-auto-2.28.9_old-bindgen/mbedtls-sys/vendor/ChangeLog#L74C1-L77C29) where libraries are installed on some platforms (e.g., on Amazon Linux it ends up in a `lib64` library, on ubuntu it's `lib`). This causes issues like:
```
error: could not find native static library `mbedtls`, perhaps an -L flag is missing?

error: could not compile `mbedtls-platform-support` (lib) due to 1 previous error
```
This PR changes this behavior to always install in a `lib` library.