### PR TITLE
[RTE-294] Specify install directory libraries

### DIFF
--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -8,6 +8,8 @@
 
 impl super::BuildConfig {
     pub fn cmake(&self) {
+        static INSTALL_DIR: &str = "lib";
+
         let mut cmk = cmake::Config::new(&self.mbedtls_src);
         cmk.cflag(format!(
             r#"-DMBEDTLS_CONFIG_FILE="\"{}\"""#,
@@ -19,8 +21,8 @@ impl super::BuildConfig {
         .define("GEN_FILES", "ON")
         // Prefer unix-style over Apple-style Python3 on macOS, required for the Github Actions CI
         .define("Python3_FIND_FRAMEWORK", "LAST")
-        // Ensure "lib" directory is used on all platforms
-        .define("LIB_INSTALL_DIR", "lib")
+        // Ensure same installation directory is used on all platforms
+        .define("LIB_INSTALL_DIR", INSTALL_DIR)
         .build_target("install");
         for cflag in &self.cflags {
             cmk.cflag(cflag);
@@ -52,7 +54,7 @@ impl super::BuildConfig {
 
         println!(
             "cargo:rustc-link-search=native={}",
-            dst.join("lib").to_str().expect("link-search UTF-8 error")
+            dst.join(INSTALL_DIR).to_str().expect("link-search UTF-8 error")
         );
 
         println!("cargo:rustc-link-lib=static=mbedtls");

--- a/mbedtls-sys/build/cmake.rs
+++ b/mbedtls-sys/build/cmake.rs
@@ -19,6 +19,8 @@ impl super::BuildConfig {
         .define("GEN_FILES", "ON")
         // Prefer unix-style over Apple-style Python3 on macOS, required for the Github Actions CI
         .define("Python3_FIND_FRAMEWORK", "LAST")
+        // Ensure "lib" directory is used on all platforms
+        .define("LIB_INSTALL_DIR", "lib")
         .build_target("install");
         for cflag in &self.cflags {
             cmk.cflag(cflag);


### PR DESCRIPTION
Since mbedtls 2.28.8 they [changed](https://github.com/fortanix/rust-mbedtls/blob/mbedtls-sys-auto-2.28.9_old-bindgen/mbedtls-sys/vendor/ChangeLog#L74C1-L77C29) where libraries are installed on some platforms (e.g., on Amazon Linux it ends up in a lib64 library, on ubuntu it's lib). This causes issues like:
error: could not find native static library `mbedtls`, perhaps an -L flag is missing?

error: could not compile `mbedtls-platform-support` (lib) due to 1 previous error

The issue has been resolved on the `mbedtls-sys-auto-2.28.9_old-bindgen` branch in [rust-mbedtls PR377](https://github.com/fortanix/rust-mbedtls/pull/377) and [rust-mbedtls PR378](https://github.com/fortanix/rust-mbedtls/pull/378). This PR combines boths PRs and targets the master branch.