### PR TITLE
Bump `mbedtls-sys` version to `2.28.10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.9"
+version = "2.28.10"
 dependencies = [
  "bindgen",
  "cc",

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.28.9"
+version = "2.28.10"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"


### PR DESCRIPTION
So we can have a new release that includes the recent improvements to how this crate builds the vendored mbedtls.