### PR TITLE
Fix traitobject conflict with latest nightly rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "traitobject"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "04a79e25382e2e852e8da874249358d382ebaf259d0d34e75d8db16a7efabbc7"
 
 [[package]]
 name = "typeable"


### PR DESCRIPTION
Upgrade `traitobject` crate version to `0.1.1` to solve conflict error with latest rust nightly:

```
error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/traitobject-0.1.0/src/impls.rs:72:1
   |
71 | unsafe impl Trait for ::std::marker::Send + Sync { }
   | ------------------------------------------------ first implementation here
72 | unsafe impl Trait for ::std::marker::Send + Send + Sync { }
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
```

`traitobject` crate `0.1.1` fix the conflict mentioned in https://github.com/reem/rust-traitobject/issues/8 and now takes affect in latest rust nightly.