### PR TITLE
[RTE-427] Update cmake minimum required version

### DIFF
--- a/mbedtls-sys/vendor/CMakeLists.txt
+++ b/mbedtls-sys/vendor/CMakeLists.txt
@@ -20,7 +20,7 @@
 #   mbedtls, mbedx509, mbedcrypto and apidoc targets.
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # https://cmake.org/cmake/help/latest/policy/CMP0011.html
 # Setting this policy is required in CMake >= 3.18.0, otherwise a warning is generated. The OLD

--- a/mbedtls-sys/vendor/programs/test/cmake_subproject/CMakeLists.txt
+++ b/mbedtls-sys/vendor/programs/test/cmake_subproject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 # Test the target renaming support by adding a prefix to the targets built
 set(MBEDTLS_TARGET_PREFIX subproject_test_)


### PR DESCRIPTION
The `rust-sgx` CI already updated to ubuntu24. It now comes with cmake 4.0.0. Unfortunately support for cmake files <3.5 has been removed. This results in errors such as:
```
  running: cd "/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out/build" && CMAKE_PREFIX_PATH="" "cmake" "/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mbedtls-sys-auto-2.28.10/vendor" "-DENABLE_PROGRAMS=OFF" "-DENABLE_TESTING=OFF" "-DGEN_FILES=ON" "-DPython3_FIND_FRAMEWORK=LAST" "-DLIB_INSTALL_DIR=lib" "-DCMAKE_INSTALL_PREFIX=/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out" "-DCMAKE_C_FLAGS= -DMBEDTLS_CONFIG_FILE=\"\\\"/home/runner/work/rust-sgx/rust-sgx/target/debug/build/mbedtls-sys-auto-c66539428ec212d0/out/config.h\\\"\" -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_C_COMPILER=/usr/bin/clang-18" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_CXX_COMPILER=/usr/bin/clang-18" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64 --target=x86_64-unknown-linux-gnu" "-DCMAKE_ASM_COMPILER=/usr/bin/clang-18" "-DCMAKE_BUILD_TYPE=Debug"
  -- Configuring incomplete, errors occurred!

  --- stderr
  CMake Error at CMakeLists.txt:23 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.



  thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.44/src/lib.rs:885:5:

  command did not execute successfully, got: exit status: 1
```
[rust-sgx PR736](https://github.com/fortanix/rust-sgx/pull/736) resolved this by setting the `CMAKE_POLICY_VERSION_MINIMUM` environment variable, but it should be fixed here.