### PR TITLE
Revert serde to v1.0.7 and update patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-stream",
  "bit-vec",

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mbedtls"
 # We jumped from v0.9 to v0.12 because v0.10 and v0.11 were based on mbedtls 3.X, which
 # we decided not to support.
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"
@@ -24,8 +24,8 @@ features = ["x509", "ssl"]
 
 [dependencies]
 bitflags = "1"
-serde = { version = "1.0.214", default-features = false, features = ["alloc"] }
-serde_derive = "1.0.214"
+serde = { version = "1.0.7", default-features = false, features = ["alloc"] }
+serde_derive = "1.0.7"
 byteorder = { version = "1.0.0", default-features = false }
 yasna = { version = "0.2", optional = true, features = [
     "num-bigint",


### PR DESCRIPTION
Serde version updated in [PR#372](https://github.com/fortanix/rust-mbedtls/pull/372) needs to be reverted to 1.0.7 
to avoid version conflicts issue while updating rust-sgx/ crate with the mbedtls_v0.13.x
This PR reverts the serde version from 1.0.214 to 1.0.7 (as was before PR#372) 
and bumps mbedtls patch version to 0.13.1