### PR TITLE
Add x86_64-pc-windows-gnu target in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,26 @@ jobs:
           - rust: stable
             target: x86_64-apple-darwin
             os: macos-latest
+          - rust: stable
+            target: x86_64-pc-windows-gnu
+            os: ubuntu-24.04
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set up dependencies for windows cross compile
+      if: matrix.target == 'x86_64-pc-windows-gnu' && matrix.os == 'ubuntu-24.04'
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install --assume-yes --no-install-recommends \
+          gcc-mingw-w64-x86-64 \
+          g++-mingw-w64-x86-64 \
+          libz-mingw-w64-dev \
+          binfmt-support \
+          wine wine64
 
     - name: Cache Dependencies
       uses: Swatinem/rust-cache@988c164c3d0e93c4dbab36aaf5bbeb77425b2894

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ on:
       - master
       - 'v0.*'
   merge_group:
+  schedule:
+    - cron: "0 0 * * 1"  # Run CI on Monday weekly, so we can track changes from nightly rust
 
 env:
   RUST_BACKTRACE: 1

--- a/ci.sh
+++ b/ci.sh
@@ -4,77 +4,120 @@ cd "$(dirname "$0")"
 
 repo_root=$(readlink -f $(dirname "${BASH_SOURCE[0]}"))
 
-if [ -z $RUST_VERSION ]; then
-    echo "Expected RUST_VERSION to be set in env"
-    exit 1
-fi
+case "$RUST_VERSION" in
+    stable|beta|nightly)
+        echo "RUST_VERSION is valid: $RUST_VERSION"
+        ;;
+    *)
+        echo "Error: RUST_VERSION must be one of stable, beta, or nightly. Found: '$RUST_VERSION'" >&2
+        exit 1
+        ;;
+esac
 
-# Test logic start from here
 export CFLAGS_x86_64_fortanix_unknown_sgx="-isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
 export CC_x86_64_fortanix_unknown_sgx=clang-18
 export CMAKE_POLICY_VERSION_MINIMUM=3.5
 
 cargo_nextest="cargo nextest run"
 cargo_test="cargo test"
+cargo_build="cargo build"
 
+# Use cross-rs for aarch64 cross compile
 if [ "$TARGET" == "aarch64-unknown-linux-musl" ]; then
     cargo_nextest="cross test"
     cargo_test="cross test"
+    cargo_build="cross build"
+fi
+
+# Install the rust toolchain
+rustup default $RUST_VERSION
+rustup target add --toolchain $RUST_VERSION $TARGET
+
+function common_tests() {
+    $cargo_nextest --release --target $TARGET
+    $cargo_nextest --features pkcs12_rc2,dsa,ssl --target $TARGET
+    $cargo_nextest --test async_session --features=async-rt,ssl,legacy_protocols --target $TARGET
+    $cargo_nextest chrono --features=chrono,ssl,x509 --target $TARGET
+
+    # If AES-NI is supported, test the feature
+    if [ -n "$AES_NI_SUPPORT" ]; then
+        $cargo_nextest --features force_aesni_support --target $TARGET
+        $cargo_nextest --features force_aesni_support,x509,ssl --target $TARGET
+    fi
+    # If zlib is installed, test the zlib feature
+    if [ -n "$ZLIB_INSTALLED" ]; then
+        $cargo_nextest --features zlib --target $TARGET
+        $cargo_nextest --test async_session --features=async-rt,ssl,zlib --target $TARGET
+        $cargo_nextest --test async_session --features=async-rt,ssl,zlib,legacy_protocols --target $TARGET
+    fi
+}
+
+function check_sgx_build() {
+    $cargo_test --no-run --target=$TARGET
+    $cargo_test --no-run --features ssl --target=$TARGET
+}
+
+function no_std_tests() {
+    $cargo_nextest --no-default-features --features no_std_deps --target $TARGET
+    $cargo_nextest --no-default-features --features no_std_deps,rdrand,time,ssl --target $TARGET
+}
+
+if [[ "$TARGET" =~ ^x86_64-pc-windows- ]] && [[ "$MATRIX_OS" =~ ^ubuntu- ]]; then
+    export CROSS_TOOLCHAIN_PREFIX=x86_64-w64-mingw32-
+    export CROSS_TOOLCHAIN_SUFFIX=-posix
+    export CROSS_SYSROOT=/usr/x86_64-w64-mingw32
+    export CROSS_TARGET_RUNNER="env -u CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER wine"
+    export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX"
+    export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER="$CROSS_TARGET_RUNNER"
+    export AR_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"ar
+    export CC_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX"
+    export CXX_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++"$CROSS_TOOLCHAIN_SUFFIX"
+    export BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="--sysroot=$CROSS_SYSROOT -idirafter/usr/include"
+
+    # Initialize the wine prefix (virtual windows installation)
+    export WINEPREFIX=/tmp/wine
+    mkdir -p "${WINEPREFIX}"
+    wineboot &> /dev/null || true
+
+    # Put libstdc++ and some other mingw dlls in WINEPATH
+    # This must work for x86_64 and i686
+    P1="$(dirname "$(find /usr -name libwinpthread-1.dll)")"
+
+    WINEPATH="$(ls -d /usr/lib/gcc/*-w64-mingw32/*posix);${P1}"
+    export WINEPATH
 fi
 
 cd "${repo_root}/mbedtls"
-case "$RUST_VERSION" in
-    stable|beta|nightly)
-        # Install the rust toolchain
-        rustup default $RUST_VERSION
-        rustup target add --toolchain $RUST_VERSION $TARGET
-        printenv
-
-        # The SGX target cannot be run under test like a ELF binary
-        if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then
-            # make sure that explicitly providing the default target works
-            $cargo_nextest --target $TARGET --release
-            $cargo_nextest --features pkcs12_rc2,dsa,ssl --target $TARGET
-
-            # If AES-NI is supported, test the feature
-            if [ -n "$AES_NI_SUPPORT" ]; then
-                $cargo_nextest --features force_aesni_support --target $TARGET
-                $cargo_nextest --features force_aesni_support,x509,ssl --target $TARGET
-            fi
-
-            # no_std tests only are able to run on x86 platform
-            if [ "$TARGET" == "x86_64-unknown-linux-gnu" ] || [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
-                $cargo_nextest --no-default-features --features no_std_deps --target $TARGET
-                $cargo_nextest --no-default-features --features no_std_deps,rdrand,time,ssl --target $TARGET
-            fi
-        else
-            $cargo_test --no-run --target=$TARGET
-            $cargo_test --no-run --features ssl --target=$TARGET
-        fi
-
-        if [ "$TARGET" == "x86_64-apple-darwin" ]; then
-            $cargo_nextest --no-default-features --features no_std_deps --target $TARGET
-        fi
+case "$TARGET" in
+    x86_64-unknown-linux-gnu)
+        common_tests
+        no_std_tests
+        ;;
+    x86_64-fortanix-unknown-sgx)
+        check_sgx_build
+        ;;
+    aarch64-unknown-linux-musl)
+        common_tests
+        ;;
+    x86_64-pc-windows-gnu)
+        $cargo_build --release --features ssl,dsa,rdrand,force_aesni_support,async-rt --target $TARGET
+        common_tests
+        no_std_tests
         # special case: mbedtls should compile successfully on windows only with `std` feature
-        if [[ "$TARGET" =~ ^x86_64-pc-windows- ]]; then
-            $cargo_nextest --no-default-features --features std --target $TARGET
-        fi
-
-        # The SGX target cannot be run under test like a ELF binary
-        if [ "$TARGET" != "x86_64-fortanix-unknown-sgx" ]; then
-            $cargo_nextest --test async_session --features=async-rt,ssl,legacy_protocols --target $TARGET
-            $cargo_nextest chrono --features=chrono,ssl,x509 --target $TARGET
-
-            # If zlib is installed, test the zlib feature
-            if [ -n "$ZLIB_INSTALLED" ]; then
-                $cargo_nextest --features zlib --target $TARGET
-                $cargo_nextest --test async_session --features=async-rt,ssl,zlib,legacy_protocols --target $TARGET
-            fi
-        fi
+        $cargo_nextest --no-default-features --features std --target $TARGET
+        ;;
+    x86_64-pc-windows-msvc)
+        common_tests
+        no_std_tests
+        # special case: mbedtls should compile successfully on windows only with `std` feature
+        $cargo_nextest --no-default-features --features std --target $TARGET
+        ;;
+    x86_64-apple-darwin)
+        common_tests
+        $cargo_nextest --no-default-features --features no_std_deps --target $TARGET
         ;;
     *)
-        # Default case: If RUST_VERSION does not match any of the above
-        echo "Unknown version $RUST_VERSION"
+        echo "Error: Unknown or unsupported target: $TARGET" >&2
         exit 1
         ;;
 esac

--- a/ci.sh
+++ b/ci.sh
@@ -62,6 +62,9 @@ function no_std_tests() {
     $cargo_nextest --no-default-features --features no_std_deps,rdrand,time,ssl --target $TARGET
 }
 
+# Following script setups required environment variables for cargo cross compile targeting x86_64_pc_windows_gnu.
+# Ref: <https://github.com/cross-rs/cross/blob/51f46f296253d8122c927c5bb933e3c4f27cc317/docker/Dockerfile.x86_64-pc-windows-gnu#L41-L55>
+# We use this approach instead of using `cross` because `cross`'s docker image is using old softwares: Ubuntu 20.04 and 9.0 wine.
 if [[ "$TARGET" =~ ^x86_64-pc-windows- ]] && [[ "$MATRIX_OS" =~ ^ubuntu- ]]; then
     export CROSS_TOOLCHAIN_PREFIX=x86_64-w64-mingw32-
     export CROSS_TOOLCHAIN_SUFFIX=-posix

--- a/mbedtls-sys/vendor-patches/0003-fix-MBEDTLS_PRINTF_xxx-for-mingw.patch
+++ b/mbedtls-sys/vendor-patches/0003-fix-MBEDTLS_PRINTF_xxx-for-mingw.patch
@@ -1,0 +1,37 @@
+From ba70fd6970843b4697aba9be6a17d62e038b90c8 Mon Sep 17 00:00:00 2001
+From: Yuxiang Cao <yuxiang.cao@fortanix.com>
+Date: Wed, 18 Jun 2025 15:26:36 -0700
+Subject: [PATCH] fix MBEDTLS_PRINTF_xxx for mingw
+
+I64d is not available in linux mingw
+---
+ mbedtls-sys/vendor/include/mbedtls/debug.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/mbedtls-sys/vendor/include/mbedtls/debug.h b/mbedtls-sys/vendor/include/mbedtls/debug.h
+index 1da0726f..06231ac2 100644
+--- a/mbedtls-sys/vendor/include/mbedtls/debug.h
++++ b/mbedtls-sys/vendor/include/mbedtls/debug.h
+@@ -108,16 +108,16 @@
+  *
+  * This module provides debugging functions.
+  */
+-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)
++#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900)
+    #include <inttypes.h>
+    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
+    #define MBEDTLS_PRINTF_LONGLONG  "I64d"
+ #else \
+-    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
++    /* (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+    #define MBEDTLS_PRINTF_SIZET     "zu"
+    #define MBEDTLS_PRINTF_LONGLONG  "lld"
+ #endif \
+-    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
++    /* (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+ 
+ #ifdef __cplusplus
+ extern "C" {
+-- 
+2.43.0
+

--- a/mbedtls-sys/vendor/include/mbedtls/debug.h
+++ b/mbedtls-sys/vendor/include/mbedtls/debug.h
@@ -108,16 +108,16 @@
  *
  * This module provides debugging functions.
  */
-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900)
+#if (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900)
    #include <inttypes.h>
    #define MBEDTLS_PRINTF_SIZET     PRIuPTR
    #define MBEDTLS_PRINTF_LONGLONG  "I64d"
 #else \
-    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+    /* (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
    #define MBEDTLS_PRINTF_SIZET     "zu"
    #define MBEDTLS_PRINTF_LONGLONG  "lld"
 #endif \
-    /* defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1900) */
+    /* (defined(__MINGW32__) && __USE_MINGW_ANSI_STDIO == 0) || (defined(_MSC_VER) && _MSC_VER < 1900) */
 
 #ifdef __cplusplus
 extern "C" {

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -67,7 +67,7 @@ cc = "1.0"
 rustc_version = "0.4.0"
 
 # feature 'time` is necessary under windows
-[target.'cfg(target_env = "msvc")'.dependencies]
+[target.'cfg(target_family = "windows")'.dependencies]
 mbedtls-platform-support = { version = "0.1", path = "../mbedtls-platform-support", features = [
     "time",
 ] }


### PR DESCRIPTION
This PR add x86_64-pc-windows-gnu target support for `mbedtls` and `mbedtls-sys-auto`.

- It fixs a conditional macro issue in `mbedtls-sys-auto` for mingw in `mbedtls-sys/vendor/include/mbedtls/debug.h`.
- It updates `mbedtls` target dependency to be compatible with `x86_64-pc-windows-gnu`.
- It updates CI to able to cross compile targeting `x86_64-pc-windows-gnu` and use `wine` to run tests.
- It also schedules CI to run on Monday weekly, so we can track changes from nightly rust.
