### PR TITLE
Reduce amount of pointer loads in RSA hot loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.14"
+version = "2.28.15"
 dependencies = [
  "bindgen",
  "cc",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+# rust-mbedtls
+
 > [!WARNING]
 > The state of this repository is changed to maintenance. We will not accept any more feature requests. Please check [Change of status](#change-of-status) for details
 
-
-# mbedtls
+## mbedtls
 
 [![Build Status](https://travis-ci.com/fortanix/rust-mbedtls.svg?branch=master)](https://travis-ci.com/fortanix/rust-mbedtls)
 
@@ -13,7 +14,7 @@ handling and closures.
 Additionally, building on MbedTLS's focus on embedded use, this crate can be
 used in a no_std environment.
 
-## Change of status
+### Change of status
 
 We discovered that `mbedtls 3.4.X` is not thread safe and will not work
 properly with multiple threads. This problem will not be fixed in short time,
@@ -30,59 +31,59 @@ Related issue: [#320](https://github.com/fortanix/rust-mbedtls/issues/320)
 Reference links:
 
 - Design changes:
-  - https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/message/RJ7YPNBNWUNW2ICQJ72H2JMKPDKGQOLT/
+  - <https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/message/RJ7YPNBNWUNW2ICQJ72H2JMKPDKGQOLT/>
 - Bugs
-  - https://github.com/fortanix/rust-mbedtls/issues/301
-  - https://github.com/fortanix/rust-mbedtls/issues/293
-  - https://github.com/Mbed-TLS/mbedtls/issues/3263
+  - <https://github.com/fortanix/rust-mbedtls/issues/301>
+  - <https://github.com/fortanix/rust-mbedtls/issues/293>
+  - <https://github.com/Mbed-TLS/mbedtls/issues/3263>
 
-## Building
+### Building
 
 This crate depends on the mbedtls-sys-auto crate, see below for build details.
 
-### Features
+### `mbedtls` crate features
 
 This is a list of the Cargo features available for mbedtls. Features in
 **bold** are enabled by default.
 
-* *x509* Enable PKI functionality. The main code enabled by this feature is in
+- *x509* Enable PKI functionality. The main code enabled by this feature is in
          the `x509` module.
-* *ssl* Enable ssl/tls functionality. The main code enabled by this feature is
+- *ssl* Enable ssl/tls functionality. The main code enabled by this feature is
         in the `ssl` module.
 
 Note: The above features were introduced so that this crate could be used as a
 crypto (or PKI) only library.
 
-* **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
+- **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
             enabled automatically.
-* *debug* Enable debug printing to stdout. You need to configure the debug
+- *debug* Enable debug printing to stdout. You need to configure the debug
           threshold at runtime.
-* *dsa* Enable support for DSA signatures
-* *force_aesni_support* MbedTLS normally uses runtime detection of AES-NI
+- *dsa* Enable support for DSA signatures
+- *force_aesni_support* MbedTLS normally uses runtime detection of AES-NI
                         support. With this feature, always use AES-NI. This
                         will result in undefined instruction exceptions on
                         unsupported processors. On SGX, this feature is
                         enabled automatically.
-* *mpi_force_c_code* Enables the `mpi_force_c_code` feature in mbedtls-sys
-* *legacy_protocols* Enable support for SSLv3, TLSv1.0 and TLSv1.1. Implies *ssl*.
-* *no_std_deps* On no_std, you must enable this feature. It enables optional
+- *mpi_force_c_code* Enables the `mpi_force_c_code` feature in mbedtls-sys
+- *legacy_protocols* Enable support for SSLv3, TLSv1.0 and TLSv1.1. Implies *ssl*.
+- *no_std_deps* On no_std, you must enable this feature. It enables optional
                 dependencies needed on no_std. If the `std` feature is enabled,
                 this feature is ignored.
-* **padlock** Enable support for VIA padlock.
-* *pkcs12* Enable code to parse PKCS12 files using yasna. Implies *x509*.
-* *pkcs12_rc2* Enable use of RC2 crate to decrypt RC2-encrypted PKCS12 files
-* *rdrand* Enable the RDRAND random number generator. On SGX, this feature is
+- **padlock** Enable support for VIA padlock.
+- *pkcs12* Enable code to parse PKCS12 files using yasna. Implies *x509*.
+- *pkcs12_rc2* Enable use of RC2 crate to decrypt RC2-encrypted PKCS12 files
+- *rdrand* Enable the RDRAND random number generator. On SGX, this feature is
            enabled automatically.
-* **std** If this feature is not enabled, this crate is a no_std crate. (An
+- **std** If this feature is not enabled, this crate is a no_std crate. (An
           allocator is *required*) The necessary C functions to make MbedTLS
           work without libc will be provided.
-* **time** Enable time support in mbedtls-sys.
-* *zlib* Enable zlib support in mbedtls-sys.
-* *async-rt* Enable async support for SSL.
-* *chrono* Enable [`chrono`](https://docs.rs/chrono/) support (e.g.,
+- **time** Enable time support in mbedtls-sys.
+- *zlib* Enable zlib support in mbedtls-sys.
+- *async-rt* Enable async support for SSL.
+- *chrono* Enable [`chrono`](https://docs.rs/chrono/) support (e.g.,
            implementation of conversion traits between `x509::Time` and `chrono` types)
 
-# mbedtls-sys-auto
+## mbedtls-sys-auto
 
 Unfortunately, the `mbedtls-sys` crate on crates.io is claimed by another,
 apparently inactive, project.
@@ -90,7 +91,7 @@ apparently inactive, project.
 To use this crate, you will need to have **clang** and **cmake** installed, see
 below for details.
 
-## Configuring and linking MbedTLS
+### Configuring and linking MbedTLS
 
 MbedTLS has a plethora of compile-time configuration options that significantly
 impact what functionality is available. To make sure Rust's view of MbedTLS
@@ -105,43 +106,44 @@ custom source that is based on a different version of MbedTLS than the one
 provided in the crate.
 
 The build script will perform the following steps:
+
 1. generate an appropriate config.h (any existing config.h is ignored),
 2. compile a statically-linked MbedTLS, this requires cmake to be installed,
 3. generate Rust bindings based on the configuration, this requires clang to be
    installed.
 
-### Features
+### `mbedtls-sys-auto` crate features
 
 This is a list of the Cargo features available for mbedtls-sys. Features in
 **bold** are enabled by default.
 
-* **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
+- **aesni** Enable support for the AES-NI instructions. On SGX, this feature is
             enabled automatically.
-* *aes_alt* Allow an alternative implementation of AES, replacing the
+- *aes_alt* Allow an alternative implementation of AES, replacing the
   T-tables code.
-* *custom_has_support* Override runtime feature detection. In a dependent
+- *custom_has_support* Override runtime feature detection. In a dependent
                        crate, you must define the functions
                        `mbedtls_aesni_has_support` and
                        `mbedtls_padlock_has_support` following the MbedTLS
                        function signatures. On SGX, this feature is enabled
                        automatically.
-* *custom_printf* Provide a custom printf implementation. printf is only used
+- *custom_printf* Provide a custom printf implementation. printf is only used
                   for the self tests. In a dependent crate, you must define the
                   `mbedtls_printf` function with the standard printf signature.
-* **debug** Enable debug callbacks.
-* *havege* Enable the Hardware Volatile Entropy Gathering and Expansion
+- **debug** Enable debug callbacks.
+- *havege* Enable the Hardware Volatile Entropy Gathering and Expansion
            (HAVEGE) algorithm.
-* **legacy_protocols** Enable support for SSLv3, TLSv1.0 and TLSv1.1
-* *mpi_force_c_code* MbedTLS uses assembly code for MPI functions, when available.
+- **legacy_protocols** Enable support for SSLv3, TLSv1.0 and TLSv1.1
+- *mpi_force_c_code* MbedTLS uses assembly code for MPI functions, when available.
                      In some situations we may prefer C code instead. This is in
                      particular the case on x86 platforms where compile-time mitigation
                      for speculative execution is required (e.g., LVI). Letting the
                      compiler insert the required lfences during C-code compilation may
                      result in faster code than letting the compiler apply mitigations
                      on assembly code.
-* **padlock** Enable support for VIA padlock.
-* *pkcs11* Enable PKCS#11 support. This requires pkcs11-helper to be installed.
-* **std** If this feature is not enabled, this crate is a no_std crate. In a
+- **padlock** Enable support for VIA padlock.
+- *pkcs11* Enable PKCS#11 support. This requires pkcs11-helper to be installed.
+- **std** If this feature is not enabled, this crate is a no_std crate. In a
           no_std configuration without libc, you need to provide your own
           versions of the following standard C functions: `calloc()`/`free()`,
           and `strstr()`/`strlen()`/`strncpy()`/`strncmp()`/`strcmp()`/
@@ -150,45 +152,64 @@ This is a list of the Cargo features available for mbedtls-sys. Features in
           `custom_printf` feature. `rand()` is only needed for the selftests.
           On UNIX platforms, this also enables networking, filesystems and OS
           entropy.
-* **threading** Enable threading support. On `cfg(unix)` platforms, this uses
+- **threading** Enable threading support. On `cfg(unix)` platforms, this uses
                 pthreads. On other platforms, you need to provide a custom
                 threading implementation. In a dependent crate, you must define
                 the functions `mbedtls_mutex_init()`, `mbedtls_mutex_free()`,
                 `mbedtls_mutex_lock()`, and `mbedtls_mutex_unlock()` following
                 the  MbedTLS function signatures.
-* **time** Enable time support. On `cfg(unix)` platforms, this uses `libc`. On
+- **time** Enable time support. On `cfg(unix)` platforms, this uses `libc`. On
            other platforms, you need to provide your own implementations of
            `mbedtls_platform_gmtime_r(const long long*, struct tm*)` and
            `mbedtls_time(long long*)`.
-* *trusted_cert_callback* Enable trusted certificate callback support.
-* **zlib** Enable zlib support.
+- *trusted_cert_callback* Enable trusted certificate callback support.
+- **zlib** Enable zlib support.
 
 For the complete mapping of features to config.h defines, see
 [mbedtls-sys/build/config.rs]. PRs adding new features are encouraged.
 
 ## MbedTLS version updates
 
-Instructions for updating to new MbedTLS source code releases in `mbedtls-sys/`:
+The vendored MbedTLS source lives in `mbedtls-sys/vendor`. Local changes that
+must survive vendor refreshes are stored as `git am` patches in
+`mbedtls-sys/vendor-patches`.
 
-1. Wipe out `vendor/` and replace it with the contents of the distribution tarball.
-2. Cherry-pick any local changes from the previous version.
-3. Use the command in `build/headers.rs` to generate the list of headers,
-   and update that file as appropriate.
-4. Check `build/config.rs` vs. `vendor/include/mbedtls/config.h`.
-5. Update `Cargo.toml` version and also the `[package.metadata.mbedtls]` section with the upstream version (and commit hash).
+To update the vendored source to a new upstream tag or branch, run the helper
+script from a non-`master` branch:
 
-# mbedtls-selftest
+```sh
+./upgrade_vendor.sh <tag-name-or-branch-name>
+```
 
-This Rust crate is designed for separating self-test code that needs to export Rust
-functions and define C functions to be used by C `mbedtls`. By separating this code,
-different versions of Rust `mbedtls` crates can be used within a single crate, which
-helps to solve link name conflict errors.
+The script recreates `mbedtls-sys/vendor` from the upstream MbedTLS repository,
+commits the vendor update, then applies every patch in
+`mbedtls-sys/vendor-patches` with `git am --3way`. If a patch no longer applies,
+resolve the conflict and continue the `git am` flow.
 
-**Note**: Although multiple versions of Rust `mbedtls` crates can be used within a
-single crate, only one `mbedtls-selftest` and one `mbedtls-sys-auto` crate can be
-used since they are built as native libraries.
+When adding or refreshing a local vendor change, first commit the desired
+changes under `mbedtls-sys/vendor` on your feature branch. Then generate a new
+patch file from the aggregate diff between `master` and `HEAD`, limited to that
+vendor directory:
 
-# Contributing
+```sh
+./create_vendor_patch.sh "Short patch title"
+```
+
+The script writes the next numbered patch file under
+`mbedtls-sys/vendor-patches`, for example
+`mbedtls-sys/vendor-patches/0005-Short-patch-title.patch`. Uncommitted changes
+are not included.
+
+After updating vendor code or patches:
+
+1. Use the command in `mbedtls-sys/build/headers.rs` to generate the list of
+   headers, and update that file as appropriate.
+2. Check `mbedtls-sys/build/config.rs` against
+   `mbedtls-sys/vendor/include/mbedtls/config.h`.
+3. Update the `mbedtls-sys/Cargo.toml` version and the
+   `[package.metadata.mbedtls]` upstream version and commit hash.
+
+## Contributing
 
 We gratefully accept bug reports and contributions from the community.
 By participating in this community, you agree to abide by [Code of Conduct](./CODE_OF_CONDUCT.md).
@@ -220,7 +241,7 @@ personal information I submit with it, including my sign-off) is
 maintained indefinitely and may be redistributed consistent with
 this project or the open source license(s) involved.
 
-# License
+## License
 
 This project is primarily distributed under the terms of the Apache License
 version 2.0 and the GNU General Public License version 2, see

--- a/create_vendor_patch.sh
+++ b/create_vendor_patch.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "This script creates a git-am-compatible patch file from the"
+    echo "aggregate diff between master and HEAD under mbedtls-sys/vendor."
+    echo
+    echo "Usage: $0 <patch-name>"
+    echo "Example: $0 Load-less-pointers-to-avoid-LFENCE-instructions"
+    exit 1
+fi
+
+cd "$(dirname "$0")"
+
+BASE_REF="master"
+VENDOR_FOLDER="mbedtls-sys/vendor"
+PATCHES_FOLDER="mbedtls-sys/vendor-patches"
+PATCH_TITLE=$1
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+    echo "Base ref '$BASE_REF' does not exist."
+    exit 1
+fi
+
+if git diff --quiet "$BASE_REF"..HEAD -- "$VENDOR_FOLDER"; then
+    echo "No committed changes found between '$BASE_REF' and HEAD under '$VENDOR_FOLDER'."
+    exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Warning: uncommitted changes exist and will not be included."
+fi
+
+mkdir -p "$PATCHES_FOLDER"
+
+PATCH_NAME=$(printf '%s' "$PATCH_TITLE" | tr '[:space:]' '-' | tr -cd '[:alnum:]._-')
+if [ -z "$PATCH_NAME" ]; then
+    echo "Patch name is empty after sanitizing."
+    exit 1
+fi
+
+next_number=1
+for patch in "$PATCHES_FOLDER"/[0-9][0-9][0-9][0-9]-*.patch; do
+    [ -e "$patch" ] || continue
+    number=$(basename "$patch" | cut -d- -f1)
+    if [ "$number" -ge "$next_number" ]; then
+        next_number=$((number + 1))
+    fi
+done
+
+PATCH_FILE="$PATCHES_FOLDER/$(printf "%04d" "$next_number")-$PATCH_NAME.patch"
+
+if [ -e "$PATCH_FILE" ]; then
+    echo "Patch file already exists: $PATCH_FILE"
+    exit 1
+fi
+
+{
+    echo "From $(git rev-parse HEAD) Mon Sep 17 00:00:00 2001"
+    echo "From: $(git show -s --format='%an <%ae>' HEAD)"
+    echo "Date: $(git show -s --format='%aD' HEAD)"
+    echo "Subject: [PATCH] $PATCH_TITLE"
+    echo
+    echo "Generated from:"
+    echo "  git diff $BASE_REF..HEAD -- $VENDOR_FOLDER"
+    echo "---"
+    git diff --stat "$BASE_REF"..HEAD -- "$VENDOR_FOLDER"
+    echo
+    git diff --binary --full-index "$BASE_REF"..HEAD -- "$VENDOR_FOLDER"
+} > "$PATCH_FILE"
+
+echo "Created patch file: $PATCH_FILE"

--- a/mbedtls-sys/Cargo.toml
+++ b/mbedtls-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbedtls-sys-auto"
-version = "2.28.14"
+version = "2.28.15"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build/build.rs"
 license = "Apache-2.0 OR GPL-2.0-or-later"

--- a/mbedtls-sys/vendor-patches/0004-Load-less-pointers-to-avoid-LFENCE-instructions.patch
+++ b/mbedtls-sys/vendor-patches/0004-Load-less-pointers-to-avoid-LFENCE-instructions.patch
@@ -1,0 +1,370 @@
+From e7eb4b580d9faff0a34dd6c8fa8bf7a35e05ebb9 Mon Sep 17 00:00:00 2001
+From: francisco <francisco.vialprado@fortanix.com>
+Date: Wed, 24 Jun 2026 17:09:00 +0200
+Subject: [PATCH] Load-less-pointers-to-avoid-LFENCE-instructions
+
+Generated from:
+  git diff master..HEAD -- mbedtls-sys/vendor
+---
+ mbedtls-sys/vendor/library/bignum.c | 100 +++++++++++++++++++++++-------------
+ 1 file changed, 64 insertions(+), 36 deletions(-)
+
+diff --git a/mbedtls-sys/vendor/library/bignum.c b/mbedtls-sys/vendor/library/bignum.c
+index fadd9e9cc2a2a3bd56c68beac71766131b160eb8..ac552d779b906d91c1d58899a32e656cf040f255 100644
+--- a/mbedtls-sys/vendor/library/bignum.c
++++ b/mbedtls-sys/vendor/library/bignum.c
+@@ -142,8 +142,9 @@ int mbedtls_mpi_shrink(mbedtls_mpi *X, size_t nblimbs)
+     }
+     /* After this point, then X->n > nblimbs and in particular X->n > 0. */
+ 
++    const mbedtls_mpi_uint *Xp = X->p;
+     for (i = X->n - 1; i > 0; i--) {
+-        if (X->p[i] != 0) {
++        if (Xp[i] != 0) {
+             break;
+         }
+     }
+@@ -157,7 +158,7 @@ int mbedtls_mpi_shrink(mbedtls_mpi *X, size_t nblimbs)
+         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
+     }
+ 
+-    if (X->p != NULL) {
++    if (Xp != NULL) {
+         memcpy(p, X->p, i * ciL);
+         mbedtls_mpi_zeroize(X->p, X->n);
+         mbedtls_free(X->p);
+@@ -213,8 +214,9 @@ int mbedtls_mpi_copy(mbedtls_mpi *X, const mbedtls_mpi *Y)
+         return 0;
+     }
+ 
++    const mbedtls_mpi_uint *Yp = Y->p;
+     for (i = Y->n - 1; i > 0; i--) {
+-        if (Y->p[i] != 0) {
++        if (Yp[i] != 0) {
+             break;
+         }
+     }
+@@ -228,7 +230,7 @@ int mbedtls_mpi_copy(mbedtls_mpi *X, const mbedtls_mpi *Y)
+         memset(X->p + i, 0, (X->n - i) * ciL);
+     }
+ 
+-    memcpy(X->p, Y->p, i * ciL);
++    memcpy(X->p, Yp, i * ciL);
+ 
+ cleanup:
+ 
+@@ -295,8 +297,8 @@ int mbedtls_mpi_get_bit(const mbedtls_mpi *X, size_t pos)
+ }
+ 
+ /* Get a specific byte, without range checks. */
+-#define GET_BYTE(X, i)                                \
+-    (((X)->p[(i) / ciL] >> (((i) % ciL) * 8)) & 0xff)
++#define GET_BYTE(Xp, i)                                \
++    (((Xp)[(i) / ciL] >> (((i) % ciL) * 8)) & 0xff)
+ 
+ /*
+  * Set a bit to a specific value of 0 or 1
+@@ -336,9 +338,11 @@ size_t mbedtls_mpi_lsb(const mbedtls_mpi *X)
+     size_t i, j, count = 0;
+     MBEDTLS_INTERNAL_VALIDATE_RET(X != NULL, 0);
+ 
++    const mbedtls_mpi_uint *Xp = X->p;
++
+     for (i = 0; i < X->n; i++) {
+         for (j = 0; j < biL; j++, count++) {
+-            if (((X->p[i] >> j) & 1) != 0) {
++            if (((Xp[i] >> j) & 1) != 0) {
+                 return count;
+             }
+         }
+@@ -372,18 +376,19 @@ static size_t mbedtls_clz(const mbedtls_mpi_uint x)
+ size_t mbedtls_mpi_bitlen(const mbedtls_mpi *X)
+ {
+     size_t i, j;
++    const mbedtls_mpi_uint *Xp = X->p;
+ 
+     if (X->n == 0) {
+         return 0;
+     }
+ 
+     for (i = X->n - 1; i > 0; i--) {
+-        if (X->p[i] != 0) {
++        if (Xp[i] != 0) {
+             break;
+         }
+     }
+ 
+-    j = biL - mbedtls_clz(X->p[i]);
++    j = biL - mbedtls_clz(Xp[i]);
+ 
+     return (i * biL) + j;
+ }
+@@ -573,6 +578,7 @@ int mbedtls_mpi_write_string(const mbedtls_mpi *X, int radix,
+         *p++ = '-';
+         buflen--;
+     }
++    const mbedtls_mpi_uint *Xp = X->p;
+ 
+     if (radix == 16) {
+         int c;
+@@ -580,7 +586,7 @@ int mbedtls_mpi_write_string(const mbedtls_mpi *X, int radix,
+ 
+         for (i = X->n, k = 0; i > 0; i--) {
+             for (j = ciL; j > 0; j--) {
+-                c = (X->p[i - 1] >> ((j - 1) << 3)) & 0xFF;
++                c = (Xp[i - 1] >> ((j - 1) << 3)) & 0xFF;
+ 
+                 if (c == 0 && k == 0 && (i + j) != 2) {
+                     continue;
+@@ -867,6 +873,7 @@ int mbedtls_mpi_write_binary_le(const mbedtls_mpi *X,
+     size_t bytes_to_copy;
+     size_t i;
+ 
++    const mbedtls_mpi_uint *Xp = X->p;
+     if (stored_bytes < buflen) {
+         bytes_to_copy = stored_bytes;
+     } else {
+@@ -875,14 +882,14 @@ int mbedtls_mpi_write_binary_le(const mbedtls_mpi *X,
+         /* The output buffer is smaller than the allocated size of X.
+          * However X may fit if its leading bytes are zero. */
+         for (i = bytes_to_copy; i < stored_bytes; i++) {
+-            if (GET_BYTE(X, i) != 0) {
++            if (GET_BYTE(Xp, i) != 0) {
+                 return MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL;
+             }
+         }
+     }
+ 
+     for (i = 0; i < bytes_to_copy; i++) {
+-        buf[i] = GET_BYTE(X, i);
++        buf[i] = GET_BYTE(Xp, i);
+     }
+ 
+     if (stored_bytes < buflen) {
+@@ -908,6 +915,7 @@ int mbedtls_mpi_write_binary(const mbedtls_mpi *X,
+     MPI_VALIDATE_RET(buflen == 0 || buf != NULL);
+ 
+     stored_bytes = X->n * ciL;
++    const mbedtls_mpi_uint *Xp = X->p;
+ 
+     if (stored_bytes < buflen) {
+         /* There is enough space in the output buffer. Write initial
+@@ -924,14 +932,14 @@ int mbedtls_mpi_write_binary(const mbedtls_mpi *X,
+         bytes_to_copy = buflen;
+         p = buf;
+         for (i = bytes_to_copy; i < stored_bytes; i++) {
+-            if (GET_BYTE(X, i) != 0) {
++            if (GET_BYTE(Xp, i) != 0) {
+                 return MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL;
+             }
+         }
+     }
+ 
+     for (i = 0; i < bytes_to_copy; i++) {
+-        p[bytes_to_copy - i - 1] = GET_BYTE(X, i);
++        p[bytes_to_copy - i - 1] = GET_BYTE(Xp, i);
+     }
+ 
+     return 0;
+@@ -1041,14 +1049,16 @@ int mbedtls_mpi_cmp_abs(const mbedtls_mpi *X, const mbedtls_mpi *Y)
+     MPI_VALIDATE_RET(X != NULL);
+     MPI_VALIDATE_RET(Y != NULL);
+ 
++    const mbedtls_mpi_uint *Xp = X->p;
++    const mbedtls_mpi_uint *Yp = Y->p;
+     for (i = X->n; i > 0; i--) {
+-        if (X->p[i - 1] != 0) {
++        if (Xp[i - 1] != 0) {
+             break;
+         }
+     }
+ 
+     for (j = Y->n; j > 0; j--) {
+-        if (Y->p[j - 1] != 0) {
++        if (Yp[j - 1] != 0) {
+             break;
+         }
+     }
+@@ -1065,10 +1075,10 @@ int mbedtls_mpi_cmp_abs(const mbedtls_mpi *X, const mbedtls_mpi *Y)
+     }
+ 
+     for (; i > 0; i--) {
+-        if (X->p[i - 1] > Y->p[i - 1]) {
++        if (Xp[i - 1] > Yp[i - 1]) {
+             return 1;
+         }
+-        if (X->p[i - 1] < Y->p[i - 1]) {
++        if (Xp[i - 1] < Yp[i - 1]) {
+             return -1;
+         }
+     }
+@@ -1084,15 +1094,17 @@ int mbedtls_mpi_cmp_mpi(const mbedtls_mpi *X, const mbedtls_mpi *Y)
+     size_t i, j;
+     MPI_VALIDATE_RET(X != NULL);
+     MPI_VALIDATE_RET(Y != NULL);
++    const mbedtls_mpi_uint *Xp = X->p;
++    const mbedtls_mpi_uint *Yp = Y->p;
+ 
+     for (i = X->n; i > 0; i--) {
+-        if (X->p[i - 1] != 0) {
++        if (Xp[i - 1] != 0) {
+             break;
+         }
+     }
+ 
+     for (j = Y->n; j > 0; j--) {
+-        if (Y->p[j - 1] != 0) {
++        if (Yp[j - 1] != 0) {
+             break;
+         }
+     }
+@@ -1116,10 +1128,10 @@ int mbedtls_mpi_cmp_mpi(const mbedtls_mpi *X, const mbedtls_mpi *Y)
+     }
+ 
+     for (; i > 0; i--) {
+-        if (X->p[i - 1] > Y->p[i - 1]) {
++        if (Xp[i - 1] > Yp[i - 1]) {
+             return X->s;
+         }
+-        if (X->p[i - 1] < Y->p[i - 1]) {
++        if (Xp[i - 1] < Yp[i - 1]) {
+             return -X->s;
+         }
+     }
+@@ -1253,8 +1265,9 @@ int mbedtls_mpi_sub_abs(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
+     MPI_VALIDATE_RET(A != NULL);
+     MPI_VALIDATE_RET(B != NULL);
+ 
++    const mbedtls_mpi_uint *Bp = B->p;
+     for (n = B->n; n > 0; n--) {
+-        if (B->p[n - 1] != 0) {
++        if (Bp[n - 1] != 0) {
+             break;
+         }
+     }
+@@ -1489,8 +1502,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
+         MBEDTLS_MPI_CHK(mbedtls_mpi_copy(&TB, B)); B = &TB;
+     }
+ 
++    mbedtls_mpi_uint *Ap = A->p;
+     for (i = A->n; i > 0; i--) {
+-        if (A->p[i - 1] != 0) {
++        if (Ap[i - 1] != 0) {
+             break;
+         }
+     }
+@@ -1498,8 +1512,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
+         result_is_zero = 1;
+     }
+ 
++    mbedtls_mpi_uint *Bp = B->p;
+     for (j = B->n; j > 0; j--) {
+-        if (B->p[j - 1] != 0) {
++        if (Bp[j - 1] != 0) {
+             break;
+         }
+     }
+@@ -1510,8 +1525,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
+     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(X, i + j));
+     MBEDTLS_MPI_CHK(mbedtls_mpi_lset(X, 0));
+ 
++    mbedtls_mpi_uint *Xp = X->p;
+     for (; j > 0; j--) {
+-        mpi_mul_hlp(i, A->p, X->p + j - 1, B->p[j - 1]);
++        mpi_mul_hlp(i, Ap, Xp + j - 1, Bp[j - 1]);
+     }
+ 
+     /* If the result is 0, we don't shortcut the operation, which reduces
+@@ -1541,7 +1557,8 @@ int mbedtls_mpi_mul_int(mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint b
+ 
+     /* mpi_mul_hlp can't deal with a leading 0. */
+     size_t n = A->n;
+-    while (n > 0 && A->p[n - 1] == 0) {
++    mbedtls_mpi_uint *Ap = A->p;
++    while (n > 0 && Ap[n - 1] == 0) {
+         --n;
+     }
+ 
+@@ -1880,8 +1897,10 @@ int mbedtls_mpi_mod_int(mbedtls_mpi_uint *r, const mbedtls_mpi *A, mbedtls_mpi_s
+     /*
+      * general case
+      */
++
++    const mbedtls_mpi_uint *Ap = A->p;
+     for (i = A->n, y = 0; i > 0; i--) {
+-        x  = A->p[i - 1];
++        x  = Ap[i - 1];
+         y  = (y << biH) | (x >> biH);
+         z  = y / b;
+         y -= z * b;
+@@ -1936,15 +1955,22 @@ void mbedtls_mpi_montmul(mbedtls_mpi *A,
+     n = N->n;
+     m = (B->n < n) ? B->n : n;
+ 
++    // Load these pointers before the loop, to avoid LVI mitigations slowing
++    // down inside. Note that this does not affect effectiveness of LVI
++    // mitigations.
++    mbedtls_mpi_uint *Ap = A->p;
++    const mbedtls_mpi_uint *Bp = B->p;
++    const mbedtls_mpi_uint *Np = N->p;
++
+     for (i = 0; i < n; i++) {
+         /*
+          * T = (T + u0*B + u1*N) / 2^biL
+          */
+-        u0 = A->p[i];
+-        u1 = (d[0] + u0 * B->p[0]) * mm;
++        u0 = Ap[i];
++        u1 = (d[0] + u0 * Bp[0]) * mm;
+ 
+-        mpi_mul_hlp(m, B->p, d, u0);
+-        mpi_mul_hlp(n, N->p, d, u1);
++        mpi_mul_hlp(m, Bp, d, u0);
++        mpi_mul_hlp(n, Np, d, u1);
+ 
+         *d++ = u0; d[n + 1] = 0;
+     }
+@@ -1960,14 +1986,14 @@ void mbedtls_mpi_montmul(mbedtls_mpi *A,
+      * do the calculation without using conditional tests. */
+     /* Set d to d0 + (2^biL)^n - N where d0 is the current value of d. */
+     d[n] += 1;
+-    d[n] -= mpi_sub_hlp(n, d, d, N->p);
++    d[n] -= mpi_sub_hlp(n, d, d, Np);
+     /* If d0 < N then d < (2^biL)^n
+      * so d[n] == 0 and we want to keep A as it is.
+      * If d0 >= N then d >= (2^biL)^n, and d <= (2^biL)^n + N < 2 * (2^biL)^n
+      * so d[n] == 1 and we want to set A to the result of the subtraction
+      * which is d - (2^biL)^n, i.e. the n least significant limbs of d.
+      * This exactly corresponds to a conditional assignment. */
+-    mbedtls_ct_mpi_uint_cond_assign(n, A->p, d, (unsigned char) d[n]);
++    mbedtls_ct_mpi_uint_cond_assign(n, Ap, d, (unsigned char) d[n]);
+ }
+ 
+ /*
+@@ -2214,6 +2240,8 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
+     nbits   = 0;
+     state   = 0;
+ 
++    mbedtls_mpi_uint *Ep = E->p;
++
+     while (1) {
+         if (bufsize == 0) {
+             if (nblimbs == 0) {
+@@ -2227,7 +2255,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
+ 
+         bufsize--;
+ 
+-        ei = (E->p[nblimbs] >> bufsize) & 1;
++        ei = (Ep[nblimbs] >> bufsize) & 1;
+ 
+         /*
+          * skip leading 0s
+@@ -2296,7 +2324,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
+      */
+     mpi_montred(&W[x_index], N, mm, &T);
+ 
+-    if (neg && E->n != 0 && (E->p[0] & 1) != 0) {
++    if (neg && E->n != 0 && (Ep[0] & 1) != 0) {
+         W[x_index].s = -1;
+         MBEDTLS_MPI_CHK(mbedtls_mpi_add_mpi(&W[x_index], N, &W[x_index]));
+     }

--- a/mbedtls-sys/vendor/library/bignum.c
+++ b/mbedtls-sys/vendor/library/bignum.c
@@ -142,8 +142,9 @@ int mbedtls_mpi_shrink(mbedtls_mpi *X, size_t nblimbs)
     }
     /* After this point, then X->n > nblimbs and in particular X->n > 0. */
 
+    const mbedtls_mpi_uint *Xp = X->p;
     for (i = X->n - 1; i > 0; i--) {
-        if (X->p[i] != 0) {
+        if (Xp[i] != 0) {
             break;
         }
     }
@@ -157,7 +158,7 @@ int mbedtls_mpi_shrink(mbedtls_mpi *X, size_t nblimbs)
         return MBEDTLS_ERR_MPI_ALLOC_FAILED;
     }
 
-    if (X->p != NULL) {
+    if (Xp != NULL) {
         memcpy(p, X->p, i * ciL);
         mbedtls_mpi_zeroize(X->p, X->n);
         mbedtls_free(X->p);
@@ -213,8 +214,9 @@ int mbedtls_mpi_copy(mbedtls_mpi *X, const mbedtls_mpi *Y)
         return 0;
     }
 
+    const mbedtls_mpi_uint *Yp = Y->p;
     for (i = Y->n - 1; i > 0; i--) {
-        if (Y->p[i] != 0) {
+        if (Yp[i] != 0) {
             break;
         }
     }
@@ -228,7 +230,7 @@ int mbedtls_mpi_copy(mbedtls_mpi *X, const mbedtls_mpi *Y)
         memset(X->p + i, 0, (X->n - i) * ciL);
     }
 
-    memcpy(X->p, Y->p, i * ciL);
+    memcpy(X->p, Yp, i * ciL);
 
 cleanup:
 
@@ -295,8 +297,8 @@ int mbedtls_mpi_get_bit(const mbedtls_mpi *X, size_t pos)
 }
 
 /* Get a specific byte, without range checks. */
-#define GET_BYTE(X, i)                                \
-    (((X)->p[(i) / ciL] >> (((i) % ciL) * 8)) & 0xff)
+#define GET_BYTE(Xp, i)                                \
+    (((Xp)[(i) / ciL] >> (((i) % ciL) * 8)) & 0xff)
 
 /*
  * Set a bit to a specific value of 0 or 1
@@ -336,9 +338,11 @@ size_t mbedtls_mpi_lsb(const mbedtls_mpi *X)
     size_t i, j, count = 0;
     MBEDTLS_INTERNAL_VALIDATE_RET(X != NULL, 0);
 
+    const mbedtls_mpi_uint *Xp = X->p;
+
     for (i = 0; i < X->n; i++) {
         for (j = 0; j < biL; j++, count++) {
-            if (((X->p[i] >> j) & 1) != 0) {
+            if (((Xp[i] >> j) & 1) != 0) {
                 return count;
             }
         }
@@ -372,18 +376,19 @@ static size_t mbedtls_clz(const mbedtls_mpi_uint x)
 size_t mbedtls_mpi_bitlen(const mbedtls_mpi *X)
 {
     size_t i, j;
+    const mbedtls_mpi_uint *Xp = X->p;
 
     if (X->n == 0) {
         return 0;
     }
 
     for (i = X->n - 1; i > 0; i--) {
-        if (X->p[i] != 0) {
+        if (Xp[i] != 0) {
             break;
         }
     }
 
-    j = biL - mbedtls_clz(X->p[i]);
+    j = biL - mbedtls_clz(Xp[i]);
 
     return (i * biL) + j;
 }
@@ -573,6 +578,7 @@ int mbedtls_mpi_write_string(const mbedtls_mpi *X, int radix,
         *p++ = '-';
         buflen--;
     }
+    const mbedtls_mpi_uint *Xp = X->p;
 
     if (radix == 16) {
         int c;
@@ -580,7 +586,7 @@ int mbedtls_mpi_write_string(const mbedtls_mpi *X, int radix,
 
         for (i = X->n, k = 0; i > 0; i--) {
             for (j = ciL; j > 0; j--) {
-                c = (X->p[i - 1] >> ((j - 1) << 3)) & 0xFF;
+                c = (Xp[i - 1] >> ((j - 1) << 3)) & 0xFF;
 
                 if (c == 0 && k == 0 && (i + j) != 2) {
                     continue;
@@ -867,6 +873,7 @@ int mbedtls_mpi_write_binary_le(const mbedtls_mpi *X,
     size_t bytes_to_copy;
     size_t i;
 
+    const mbedtls_mpi_uint *Xp = X->p;
     if (stored_bytes < buflen) {
         bytes_to_copy = stored_bytes;
     } else {
@@ -875,14 +882,14 @@ int mbedtls_mpi_write_binary_le(const mbedtls_mpi *X,
         /* The output buffer is smaller than the allocated size of X.
          * However X may fit if its leading bytes are zero. */
         for (i = bytes_to_copy; i < stored_bytes; i++) {
-            if (GET_BYTE(X, i) != 0) {
+            if (GET_BYTE(Xp, i) != 0) {
                 return MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL;
             }
         }
     }
 
     for (i = 0; i < bytes_to_copy; i++) {
-        buf[i] = GET_BYTE(X, i);
+        buf[i] = GET_BYTE(Xp, i);
     }
 
     if (stored_bytes < buflen) {
@@ -908,6 +915,7 @@ int mbedtls_mpi_write_binary(const mbedtls_mpi *X,
     MPI_VALIDATE_RET(buflen == 0 || buf != NULL);
 
     stored_bytes = X->n * ciL;
+    const mbedtls_mpi_uint *Xp = X->p;
 
     if (stored_bytes < buflen) {
         /* There is enough space in the output buffer. Write initial
@@ -924,14 +932,14 @@ int mbedtls_mpi_write_binary(const mbedtls_mpi *X,
         bytes_to_copy = buflen;
         p = buf;
         for (i = bytes_to_copy; i < stored_bytes; i++) {
-            if (GET_BYTE(X, i) != 0) {
+            if (GET_BYTE(Xp, i) != 0) {
                 return MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL;
             }
         }
     }
 
     for (i = 0; i < bytes_to_copy; i++) {
-        p[bytes_to_copy - i - 1] = GET_BYTE(X, i);
+        p[bytes_to_copy - i - 1] = GET_BYTE(Xp, i);
     }
 
     return 0;
@@ -1041,14 +1049,16 @@ int mbedtls_mpi_cmp_abs(const mbedtls_mpi *X, const mbedtls_mpi *Y)
     MPI_VALIDATE_RET(X != NULL);
     MPI_VALIDATE_RET(Y != NULL);
 
+    const mbedtls_mpi_uint *Xp = X->p;
+    const mbedtls_mpi_uint *Yp = Y->p;
     for (i = X->n; i > 0; i--) {
-        if (X->p[i - 1] != 0) {
+        if (Xp[i - 1] != 0) {
             break;
         }
     }
 
     for (j = Y->n; j > 0; j--) {
-        if (Y->p[j - 1] != 0) {
+        if (Yp[j - 1] != 0) {
             break;
         }
     }
@@ -1065,10 +1075,10 @@ int mbedtls_mpi_cmp_abs(const mbedtls_mpi *X, const mbedtls_mpi *Y)
     }
 
     for (; i > 0; i--) {
-        if (X->p[i - 1] > Y->p[i - 1]) {
+        if (Xp[i - 1] > Yp[i - 1]) {
             return 1;
         }
-        if (X->p[i - 1] < Y->p[i - 1]) {
+        if (Xp[i - 1] < Yp[i - 1]) {
             return -1;
         }
     }
@@ -1084,15 +1094,17 @@ int mbedtls_mpi_cmp_mpi(const mbedtls_mpi *X, const mbedtls_mpi *Y)
     size_t i, j;
     MPI_VALIDATE_RET(X != NULL);
     MPI_VALIDATE_RET(Y != NULL);
+    const mbedtls_mpi_uint *Xp = X->p;
+    const mbedtls_mpi_uint *Yp = Y->p;
 
     for (i = X->n; i > 0; i--) {
-        if (X->p[i - 1] != 0) {
+        if (Xp[i - 1] != 0) {
             break;
         }
     }
 
     for (j = Y->n; j > 0; j--) {
-        if (Y->p[j - 1] != 0) {
+        if (Yp[j - 1] != 0) {
             break;
         }
     }
@@ -1116,10 +1128,10 @@ int mbedtls_mpi_cmp_mpi(const mbedtls_mpi *X, const mbedtls_mpi *Y)
     }
 
     for (; i > 0; i--) {
-        if (X->p[i - 1] > Y->p[i - 1]) {
+        if (Xp[i - 1] > Yp[i - 1]) {
             return X->s;
         }
-        if (X->p[i - 1] < Y->p[i - 1]) {
+        if (Xp[i - 1] < Yp[i - 1]) {
             return -X->s;
         }
     }
@@ -1253,8 +1265,9 @@ int mbedtls_mpi_sub_abs(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi 
     MPI_VALIDATE_RET(A != NULL);
     MPI_VALIDATE_RET(B != NULL);
 
+    const mbedtls_mpi_uint *Bp = B->p;
     for (n = B->n; n > 0; n--) {
-        if (B->p[n - 1] != 0) {
+        if (Bp[n - 1] != 0) {
             break;
         }
     }
@@ -1489,8 +1502,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi 
         MBEDTLS_MPI_CHK(mbedtls_mpi_copy(&TB, B)); B = &TB;
     }
 
+    mbedtls_mpi_uint *Ap = A->p;
     for (i = A->n; i > 0; i--) {
-        if (A->p[i - 1] != 0) {
+        if (Ap[i - 1] != 0) {
             break;
         }
     }
@@ -1498,8 +1512,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi 
         result_is_zero = 1;
     }
 
+    mbedtls_mpi_uint *Bp = B->p;
     for (j = B->n; j > 0; j--) {
-        if (B->p[j - 1] != 0) {
+        if (Bp[j - 1] != 0) {
             break;
         }
     }
@@ -1510,8 +1525,9 @@ int mbedtls_mpi_mul_mpi(mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi 
     MBEDTLS_MPI_CHK(mbedtls_mpi_grow(X, i + j));
     MBEDTLS_MPI_CHK(mbedtls_mpi_lset(X, 0));
 
+    mbedtls_mpi_uint *Xp = X->p;
     for (; j > 0; j--) {
-        mpi_mul_hlp(i, A->p, X->p + j - 1, B->p[j - 1]);
+        mpi_mul_hlp(i, Ap, Xp + j - 1, Bp[j - 1]);
     }
 
     /* If the result is 0, we don't shortcut the operation, which reduces
@@ -1541,7 +1557,8 @@ int mbedtls_mpi_mul_int(mbedtls_mpi *X, const mbedtls_mpi *A, mbedtls_mpi_uint b
 
     /* mpi_mul_hlp can't deal with a leading 0. */
     size_t n = A->n;
-    while (n > 0 && A->p[n - 1] == 0) {
+    mbedtls_mpi_uint *Ap = A->p;
+    while (n > 0 && Ap[n - 1] == 0) {
         --n;
     }
 
@@ -1880,8 +1897,10 @@ int mbedtls_mpi_mod_int(mbedtls_mpi_uint *r, const mbedtls_mpi *A, mbedtls_mpi_s
     /*
      * general case
      */
+
+    const mbedtls_mpi_uint *Ap = A->p;
     for (i = A->n, y = 0; i > 0; i--) {
-        x  = A->p[i - 1];
+        x  = Ap[i - 1];
         y  = (y << biH) | (x >> biH);
         z  = y / b;
         y -= z * b;
@@ -1936,15 +1955,22 @@ void mbedtls_mpi_montmul(mbedtls_mpi *A,
     n = N->n;
     m = (B->n < n) ? B->n : n;
 
+    // Load these pointers before the loop, to avoid LVI mitigations slowing
+    // down inside. Note that this does not affect effectiveness of LVI
+    // mitigations.
+    mbedtls_mpi_uint *Ap = A->p;
+    const mbedtls_mpi_uint *Bp = B->p;
+    const mbedtls_mpi_uint *Np = N->p;
+
     for (i = 0; i < n; i++) {
         /*
          * T = (T + u0*B + u1*N) / 2^biL
          */
-        u0 = A->p[i];
-        u1 = (d[0] + u0 * B->p[0]) * mm;
+        u0 = Ap[i];
+        u1 = (d[0] + u0 * Bp[0]) * mm;
 
-        mpi_mul_hlp(m, B->p, d, u0);
-        mpi_mul_hlp(n, N->p, d, u1);
+        mpi_mul_hlp(m, Bp, d, u0);
+        mpi_mul_hlp(n, Np, d, u1);
 
         *d++ = u0; d[n + 1] = 0;
     }
@@ -1960,14 +1986,14 @@ void mbedtls_mpi_montmul(mbedtls_mpi *A,
      * do the calculation without using conditional tests. */
     /* Set d to d0 + (2^biL)^n - N where d0 is the current value of d. */
     d[n] += 1;
-    d[n] -= mpi_sub_hlp(n, d, d, N->p);
+    d[n] -= mpi_sub_hlp(n, d, d, Np);
     /* If d0 < N then d < (2^biL)^n
      * so d[n] == 0 and we want to keep A as it is.
      * If d0 >= N then d >= (2^biL)^n, and d <= (2^biL)^n + N < 2 * (2^biL)^n
      * so d[n] == 1 and we want to set A to the result of the subtraction
      * which is d - (2^biL)^n, i.e. the n least significant limbs of d.
      * This exactly corresponds to a conditional assignment. */
-    mbedtls_ct_mpi_uint_cond_assign(n, A->p, d, (unsigned char) d[n]);
+    mbedtls_ct_mpi_uint_cond_assign(n, Ap, d, (unsigned char) d[n]);
 }
 
 /*
@@ -2214,6 +2240,8 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
     nbits   = 0;
     state   = 0;
 
+    mbedtls_mpi_uint *Ep = E->p;
+
     while (1) {
         if (bufsize == 0) {
             if (nblimbs == 0) {
@@ -2227,7 +2255,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
 
         bufsize--;
 
-        ei = (E->p[nblimbs] >> bufsize) & 1;
+        ei = (Ep[nblimbs] >> bufsize) & 1;
 
         /*
          * skip leading 0s
@@ -2296,7 +2324,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
      */
     mpi_montred(&W[x_index], N, mm, &T);
 
-    if (neg && E->n != 0 && (E->p[0] & 1) != 0) {
+    if (neg && E->n != 0 && (Ep[0] & 1) != 0) {
         W[x_index].s = -1;
         MBEDTLS_MPI_CHK(mbedtls_mpi_add_mpi(&W[x_index], N, &W[x_index]));
     }


### PR DESCRIPTION
LVI mitigations apply LFENCE instructions whenever a pointer is loaded. In the context of Montgomery multiplication for RSA, this degrades performance of private operations. This patch prepares loaded pointers before hot loops in order to reduce the degradation.