### PR TITLE
Update for recent Rust/Cargo toolchain changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "async-stream",
  "bit-vec",

--- a/mbedtls/Cargo.toml
+++ b/mbedtls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mbedtls"
 # We jumped from v0.9 to v0.12 because v0.10 and v0.11 were based on mbedtls 3.X, which
 # we decided not to support.
-version = "0.13.5"
+version = "0.13.6"
 authors = ["Jethro Beekman <jethro@fortanix.com>"]
 build = "build.rs"
 edition = "2018"

--- a/mbedtls/build.rs
+++ b/mbedtls/build.rs
@@ -13,25 +13,17 @@ use std::hash::{Hash, Hasher};
 use rustc_version::Channel;
 use std::env;
 
+#[path = "src/cargo_layout.rs"]
+mod cargo_layout;
+
 /// Retrieves or generates a metadata value used for symbol name mangling to ensure unique C symbols.
 /// When building with Cargo, the metadata value is extracted from the OUT_DIR environment variable.
 /// For Bazel builds, this method generate the suffix by hashing part of the crate OUT_DIR,
 /// which are sufficient for ensuring symbol uniqueness.
 fn get_compilation_symbol_suffix() -> String {
     let out_dir: std::path::PathBuf = std::env::var_os("OUT_DIR").unwrap().into();
-    let mut out_dir_it_rev = out_dir.iter().rev();
-    if out_dir_it_rev.next().map_or(false, |p| p == "out") {
-        // If Cargo is used as build system.
-        let crate_ = out_dir_it_rev
-            .next()
-            .expect("Expected OUT_DIR to have at least 2 components")
-            .to_str()
-            .expect("Expected second to last component of OUT_DIR to be a valid UTF-8 string");
-        assert!(
-            crate_.starts_with("mbedtls-"),
-            "Expected second to last component of OUT_DIR to start with 'mbedtls-'"
-        );
-        return crate_[8..].to_owned(); // Return the part after "mbedtls-"
+    if let Some(suffix) = out_dir.to_str().and_then(cargo_layout::compilation_symbol_suffix) {
+        return suffix.to_owned();
     } else if out_dir.iter().rfind(|p| *p == "bazel-out").is_some() {
         // If Bazel is used as build system.
         let mut hasher = DefaultHasher::new();

--- a/mbedtls/src/cargo_layout.rs
+++ b/mbedtls/src/cargo_layout.rs
@@ -1,6 +1,3 @@
-// Cargo's build directory layout is an implementation detail. Keep this parser separate from
-// build.rs so it can be exercised by the crate's ordinary unit tests.
-
 /// Returns the Cargo build-unit identifier from either supported build directory layout.
 ///
 /// Cargo controls this layout independently of rustc's version, so inspect the path instead of
@@ -18,10 +15,10 @@ pub(crate) fn compilation_symbol_suffix(out_dir: &str) -> Option<&str> {
 
     let build_unit = components.next()?;
     if let Some(suffix) = build_unit.strip_prefix("mbedtls-") {
-        return Some(suffix);
+        return (!suffix.is_empty()).then_some(suffix);
     }
 
-    if components.next()? == "mbedtls" {
+    if !build_unit.is_empty() && components.next()? == "mbedtls" {
         return Some(build_unit);
     }
 
@@ -33,26 +30,36 @@ mod tests {
     use super::compilation_symbol_suffix;
 
     #[test]
-    fn extracts_suffix_from_legacy_cargo_layout() {
-        let out_dir = "target/debug/build/mbedtls-3202cb041a903437/out";
-        assert_eq!(compilation_symbol_suffix(out_dir), Some("3202cb041a903437"));
+    fn extracts_suffix_from_supported_cargo_layouts() {
+        let test_cases = [
+            // Legacy Cargo layout on Unix.
+            ("target/debug/build/mbedtls-3202cb041a903437/out", "3202cb041a903437"),
+            // Cargo build directory layout v2 on Unix.
+            ("target/debug/build/mbedtls/f8d961f56b5f3f44/out", "f8d961f56b5f3f44"),
+            // Legacy Cargo layout on Windows.
+            (r"target\debug\build\mbedtls-3202cb041a903437\out", "3202cb041a903437"),
+            // Cargo build directory layout v2 on Windows.
+            (r"target\debug\build\mbedtls\f8d961f56b5f3f44\out", "f8d961f56b5f3f44"),
+        ];
+
+        for (out_dir, suffix) in test_cases {
+            assert_eq!(compilation_symbol_suffix(out_dir), Some(suffix));
+        }
     }
 
     #[test]
-    fn extracts_suffix_from_new_cargo_layout() {
-        let out_dir = "target/debug/build/mbedtls/f8d961f56b5f3f44/out";
-        assert_eq!(compilation_symbol_suffix(out_dir), Some("f8d961f56b5f3f44"));
-    }
+    fn rejects_unsupported_or_malformed_cargo_layouts() {
+        let test_cases = [
+            "target/debug/build/mbedtls/hash/not-out",
+            "target/debug/build/other-crate-3202cb041a903437/out",
+            "target/debug/build/other-crate/f8d961f56b5f3f44/out",
+            "target/debug/build/mbedtls/out",
+            "target/debug/build/mbedtls-/out",
+            "target/debug/build/mbedtls//out",
+        ];
 
-    #[test]
-    fn extracts_suffix_from_legacy_windows_cargo_layout() {
-        let out_dir = r"target\debug\build\mbedtls-3202cb041a903437\out";
-        assert_eq!(compilation_symbol_suffix(out_dir), Some("3202cb041a903437"));
-    }
-
-    #[test]
-    fn extracts_suffix_from_new_windows_cargo_layout() {
-        let out_dir = r"target\debug\build\mbedtls\f8d961f56b5f3f44\out";
-        assert_eq!(compilation_symbol_suffix(out_dir), Some("f8d961f56b5f3f44"));
+        for out_dir in test_cases {
+            assert_eq!(compilation_symbol_suffix(out_dir), None);
+        }
     }
 }

--- a/mbedtls/src/cargo_layout.rs
+++ b/mbedtls/src/cargo_layout.rs
@@ -1,0 +1,58 @@
+// Cargo's build directory layout is an implementation detail. Keep this parser separate from
+// build.rs so it can be exercised by the crate's ordinary unit tests.
+
+/// Returns the Cargo build-unit identifier from either supported build directory layout.
+///
+/// Cargo controls this layout independently of rustc's version, so inspect the path instead of
+/// relying on the active toolchain version. The legacy layout is
+/// `build/mbedtls-<hash>/out`; the new layout is `build/mbedtls/<hash>/out`.
+///
+/// Ref:
+/// - https://github.com/rust-lang/cargo/issues/15010
+/// - https://github.com/rust-lang/cargo/issues/17182
+pub(crate) fn compilation_symbol_suffix(out_dir: &str) -> Option<&str> {
+    let mut components = out_dir.rsplit(|c| c == '/' || c == '\\');
+    if components.next()? != "out" {
+        return None;
+    }
+
+    let build_unit = components.next()?;
+    if let Some(suffix) = build_unit.strip_prefix("mbedtls-") {
+        return Some(suffix);
+    }
+
+    if components.next()? == "mbedtls" {
+        return Some(build_unit);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compilation_symbol_suffix;
+
+    #[test]
+    fn extracts_suffix_from_legacy_cargo_layout() {
+        let out_dir = "target/debug/build/mbedtls-3202cb041a903437/out";
+        assert_eq!(compilation_symbol_suffix(out_dir), Some("3202cb041a903437"));
+    }
+
+    #[test]
+    fn extracts_suffix_from_new_cargo_layout() {
+        let out_dir = "target/debug/build/mbedtls/f8d961f56b5f3f44/out";
+        assert_eq!(compilation_symbol_suffix(out_dir), Some("f8d961f56b5f3f44"));
+    }
+
+    #[test]
+    fn extracts_suffix_from_legacy_windows_cargo_layout() {
+        let out_dir = r"target\debug\build\mbedtls-3202cb041a903437\out";
+        assert_eq!(compilation_symbol_suffix(out_dir), Some("3202cb041a903437"));
+    }
+
+    #[test]
+    fn extracts_suffix_from_new_windows_cargo_layout() {
+        let out_dir = r"target\debug\build\mbedtls\f8d961f56b5f3f44\out";
+        assert_eq!(compilation_symbol_suffix(out_dir), Some("f8d961f56b5f3f44"));
+    }
+}

--- a/mbedtls/src/lib.rs
+++ b/mbedtls/src/lib.rs
@@ -23,6 +23,9 @@ extern crate rs_libc;
 #[macro_use]
 mod wrapper_macros;
 
+#[cfg(test)]
+mod cargo_layout;
+
 // ==============
 //      API
 // ==============

--- a/mbedtls/src/ssl/io.rs
+++ b/mbedtls/src/ssl/io.rs
@@ -56,8 +56,8 @@ pub trait IoCallback<T> {
 
 impl<IO: IoCallback<T>, T> IoCallbackUnsafe<T> for IO {
     unsafe extern "C" fn call_recv(user_data: *mut c_void, data: *mut c_uchar, len: size_t) -> c_int {
-        let len = if len > (c_int::max_value() as size_t) {
-            c_int::max_value() as size_t
+        let len = if len > (c_int::MAX as size_t) {
+            c_int::MAX as size_t
         } else {
             len
         };
@@ -68,8 +68,8 @@ impl<IO: IoCallback<T>, T> IoCallbackUnsafe<T> for IO {
     }
 
     unsafe extern "C" fn call_send(user_data: *mut c_void, data: *const c_uchar, len: size_t) -> c_int {
-        let len = if len > (c_int::max_value() as size_t) {
-            c_int::max_value() as size_t
+        let len = if len > (c_int::MAX as size_t) {
+            c_int::MAX as size_t
         } else {
             len
         };


### PR DESCRIPTION
## Summary

Update the crate for recent Rust/Cargo toolchains changes:
- Support Cargo’s build directory layout v2, which changes `OUT_DIR` layout from `build/mbedtls-<hash>/out` to `build/mbedtls/<hash>/out`.
- Replace deprecated `c_int::max_value()` calls with `c_int::MAX`.

## Changes

- Update `mbedtls/build.rs` to use a dedicated `OUT_DIR` parser for getting `<hash>` part.
- Add unit tests.
- Bump `mbedtls` crate version to `0.13.6`.
- Update deprecated `max_value()` by `MAX` constant.

## References

- https://github.com/rust-lang/cargo/issues/15010
- https://github.com/rust-lang/cargo/pull/16807
- https://github.com/rust-lang/cargo/issues/17182
- https://github.com/rust-lang/rust/issues/148519